### PR TITLE
fix(staging): unbreak the staging → prod pipeline

### DIFF
--- a/.github/workflows/gitops-staging-update.yml
+++ b/.github/workflows/gitops-staging-update.yml
@@ -27,6 +27,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Validate payload
+        id: validate
         env:
           APP_NAME: ${{ github.event.client_payload.app_name }}
           DIGEST: ${{ github.event.client_payload.digest }}
@@ -40,6 +41,15 @@ jobs:
             exit 1
           fi
 
+          # Reject app_name and image values containing path traversal
+          # or shell metacharacters. Everything that flows through this
+          # workflow originates from a trusted Cloud Run dispatch, but
+          # defense in depth is cheap.
+          if ! printf '%s' "$APP_NAME" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+            echo "ERROR: Invalid app_name: $APP_NAME"
+            exit 1
+          fi
+
           VALUES_FILE="staging-apps/${APP_NAME}/values.yaml"
           if [ ! -f "$VALUES_FILE" ]; then
             echo "ERROR: Staging chart not found at ${VALUES_FILE}"
@@ -48,7 +58,20 @@ jobs:
             exit 1
           fi
 
-          echo "Updating staging ${APP_NAME} to digest ${DIGEST}"
+          # Extract the short image name (last path segment, e.g.
+          # "dispatchr-web" or "dispatchr-worker") from the full AR
+          # reference. Used as a per-image PR branch suffix so concurrent
+          # web/worker pushes don't overwrite each other's changes on a
+          # shared branch — the previous fixed `staging/<app>` branch
+          # was silently force-pushed by each subsequent dispatch.
+          IMAGE_SHORT="${IMAGE##*/}"
+          if ! printf '%s' "$IMAGE_SHORT" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+            echo "ERROR: Failed to extract valid short image name from IMAGE=$IMAGE"
+            exit 1
+          fi
+
+          echo "image_short=${IMAGE_SHORT}" >> "$GITHUB_OUTPUT"
+          echo "Updating staging ${APP_NAME} (${IMAGE_SHORT}) to digest ${DIGEST}"
 
       - name: Install yq
         uses: mikefarah/yq@v4
@@ -97,18 +120,38 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
-          branch: staging/${{ github.event.client_payload.app_name }}
-          title: "staging: update ${{ github.event.client_payload.app_name }} image"
+          # Per-image branch (staging/<app>/<image-short>) so concurrent
+          # dispatches for different images in the same app don't race
+          # on a shared branch and force-push each other's changes away.
+          branch: staging/${{ github.event.client_payload.app_name }}/${{ steps.validate.outputs.image_short }}
+          title: "staging: update ${{ github.event.client_payload.app_name }} (${{ steps.validate.outputs.image_short }}) image"
           body: |
             Automated staging image update
 
-            Once merged and ArgoCD confirms healthy, this will auto-promote to production.
+            - **App:** `${{ github.event.client_payload.app_name }}`
+            - **Image:** `${{ steps.validate.outputs.image_short }}`
+            - **Digest:** `${{ github.event.client_payload.digest }}`
+            - **Tag:** `${{ github.event.client_payload.tag || 'N/A' }}`
+
+            Once merged and ArgoCD confirms healthy, this will auto-promote
+            to production via `staging-promote.yml`.
           labels: staging,auto-merge
           delete-branch: true
 
-      - name: Enable auto-merge
+      - name: Merge PR
         if: steps.create-pr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
-        run: gh pr merge "$PR_NUMBER" --auto --squash
+        run: |
+          # Try auto-merge first so the PR merges after required checks
+          # pass. Fall back to a direct merge when GitHub rejects --auto
+          # because the PR is already in CLEAN status — which is the
+          # default on homelab-infra since no required checks are
+          # configured on main. Without the fallback, every staging
+          # update PR gets stuck in MERGEABLE+CLEAN indefinitely and
+          # the staging→prod gate never fires.
+          if ! gh pr merge "$PR_NUMBER" --auto --squash 2>&1; then
+            echo "Auto-merge rejected (likely CLEAN status) — merging directly"
+            gh pr merge "$PR_NUMBER" --squash
+          fi

--- a/.github/workflows/staging-promote.yml
+++ b/.github/workflows/staging-promote.yml
@@ -24,12 +24,28 @@ jobs:
         env:
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          # Extract app name from PR branch (staging/<app-name>)
-          APP_NAME="${PR_BRANCH#staging/}"
+          # PR branch format is `staging/<app-name>/<image-short>`, e.g.
+          # `staging/dispatchr-social/dispatchr-web`. Split on the first
+          # `/` after the `staging/` prefix so app-names containing dashes
+          # (dispatchr-social, jlshaw-link) parse unambiguously.
+          BRANCH_PATH="${PR_BRANCH#staging/}"
+          APP_NAME="${BRANCH_PATH%%/*}"
+          IMAGE_SHORT="${BRANCH_PATH#*/}"
 
-          # Validate app name is safe (alphanumeric, hyphens, underscores only)
-          if ! echo "$APP_NAME" | grep -qE '^[a-zA-Z0-9_-]+$'; then
-            echo "ERROR: Invalid app name extracted from branch: ${APP_NAME}"
+          # Validate both components are safe before using in file paths
+          # or shell expansions. PR_BRANCH is attacker-controllable in
+          # theory (anyone who can open a PR) so we do not trust it —
+          # only exact-match whitelists pass.
+          if ! printf '%s' "$APP_NAME" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+            echo "ERROR: Invalid app name extracted from branch: $APP_NAME"
+            exit 1
+          fi
+          if [ -z "$IMAGE_SHORT" ] || [ "$IMAGE_SHORT" = "$BRANCH_PATH" ]; then
+            echo "ERROR: Branch is missing the image-short segment (expected staging/<app>/<image>)"
+            exit 1
+          fi
+          if ! printf '%s' "$IMAGE_SHORT" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+            echo "ERROR: Invalid image-short extracted from branch: $IMAGE_SHORT"
             exit 1
           fi
 
@@ -41,18 +57,23 @@ jobs:
             exit 1
           fi
 
+          # The staging chart currently only exposes the web image under
+          # .staging-app.image.*. When worker staging support is added,
+          # this step will need to select the correct values path based
+          # on IMAGE_SHORT (e.g. worker → .worker.image.*).
           DIGEST=$(yq eval '.["staging-app"].image.digest' "${VALUES_FILE}")
           IMAGE=$(yq eval '.["staging-app"].image.repository' "${VALUES_FILE}")
           TAG=$(yq eval '.appVersion' "${CHART_FILE}" 2>/dev/null || echo "")
           MIGRATE_DIGEST=$(yq eval '.["staging-app"].migration.digest // ""' "${VALUES_FILE}")
 
           echo "app_name=${APP_NAME}" >> "$GITHUB_OUTPUT"
+          echo "image_short=${IMAGE_SHORT}" >> "$GITHUB_OUTPUT"
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "migrate_digest=${MIGRATE_DIGEST}" >> "$GITHUB_OUTPUT"
 
-          echo "App: ${APP_NAME}, Digest: ${DIGEST}, Tag: ${TAG}, Migrate: ${MIGRATE_DIGEST}"
+          echo "App: ${APP_NAME}, Image: ${IMAGE_SHORT}, Digest: ${DIGEST}, Tag: ${TAG}, Migrate: ${MIGRATE_DIGEST}"
 
       - name: Wait for ArgoCD sync and health
         env:
@@ -63,14 +84,38 @@ jobs:
           ARGO_APP="staging-${APP_NAME}"
           MAX_ATTEMPTS=30
           ATTEMPT=0
+          HEALTH=""
+          SYNC=""
 
           echo "Waiting for ArgoCD app ${ARGO_APP} to be Healthy and Synced..."
+
+          # Pre-flight: verify the Application actually exists before
+          # burning the full polling budget. A mismatched app name (e.g.
+          # renamed in homelab-infra but not reflected in the workflow
+          # convention) previously caused the old loop to tick through
+          # 30 "Unknown/Unknown" attempts and fail after 10 minutes, with
+          # no signal that the real cause was a 404. Fail loud, fail fast.
+          PREFLIGHT_STATUS=$(curl -sS -o /tmp/argo-preflight.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${ARGOCD_TOKEN}" \
+            "${ARGOCD_SERVER}/api/v1/applications/${ARGO_APP}" || echo "000")
+          if [ "$PREFLIGHT_STATUS" = "404" ]; then
+            echo "ERROR: ArgoCD Application '${ARGO_APP}' not found (404)."
+            echo "Expected naming convention: staging-<app-name> matching staging-apps/<app-name>/."
+            echo "Check that argocd/applications/${ARGO_APP}.yaml exists with metadata.name: ${ARGO_APP}"
+            exit 1
+          fi
+          if [ "$PREFLIGHT_STATUS" != "200" ]; then
+            echo "ERROR: ArgoCD preflight failed with HTTP ${PREFLIGHT_STATUS}"
+            echo "Response body:"
+            cat /tmp/argo-preflight.json || true
+            exit 1
+          fi
 
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             ATTEMPT=$((ATTEMPT + 1))
 
-            RESPONSE=$(curl -s -H "Authorization: Bearer ${ARGOCD_TOKEN}" \
-              "${ARGOCD_SERVER}/api/v1/applications/${ARGO_APP}" 2>/dev/null || echo "{}")
+            RESPONSE=$(curl -sS -H "Authorization: Bearer ${ARGOCD_TOKEN}" \
+              "${ARGOCD_SERVER}/api/v1/applications/${ARGO_APP}" || echo "{}")
 
             HEALTH=$(echo "$RESPONSE" | jq -r '.status.health.status // "Unknown"')
             SYNC=$(echo "$RESPONSE" | jq -r '.status.sync.status // "Unknown"')
@@ -91,7 +136,7 @@ jobs:
           done
 
           if [ "$HEALTH" != "Healthy" ] || [ "$SYNC" != "Synced" ]; then
-            echo "ERROR: Timed out waiting for staging app to be Healthy and Synced"
+            echo "ERROR: Timed out waiting for staging app to be Healthy and Synced (last: health=${HEALTH}, sync=${SYNC})"
             exit 1
           fi
 

--- a/argocd/applications/staging-dispatchr-social.yaml
+++ b/argocd/applications/staging-dispatchr-social.yaml
@@ -2,7 +2,12 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: staging-dispatchr
+  # Name follows the `staging-<prod-app-name>` convention so the
+  # staging-promote.yml workflow (`ARGO_APP="staging-${APP_NAME}"`),
+  # the gitops-trigger STAGING_APP_MAP, and the PR branch naming all
+  # line up without per-app special cases. Mismatched naming previously
+  # caused staging-promote.yml to poll a non-existent Application forever.
+  name: staging-dispatchr-social
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/argocd/applications/staging-jlshaw-link.yaml
+++ b/argocd/applications/staging-jlshaw-link.yaml
@@ -2,7 +2,11 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: staging-jlshaw
+  # Name follows the `staging-<prod-app-name>` convention so the
+  # staging-promote.yml workflow (`ARGO_APP="staging-${APP_NAME}"`),
+  # the gitops-trigger STAGING_APP_MAP, and the PR branch naming all
+  # line up without per-app special cases.
+  name: staging-jlshaw-link
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io


### PR DESCRIPTION
Four independent bugs in the staging automation prevented v0.1.19 from reaching prod today and would have broken the next release too. All four are fixed here in one pass.

1. ArgoCD app name mismatch (primary bug) -----------------------------------------
The Application CRs were named `staging-dispatchr` and `staging-jlshaw` but staging-promote.yml builds the name from the PR branch as `staging-${APP_NAME}` where APP_NAME is the full `dispatchr-social` / `jlshaw-link`. The ArgoCD API returned 404 every poll, jq silently coerced the response to "Unknown/Unknown", and the workflow burned its full 30-attempt budget before timing out — never dispatching to prod.

Rename both Application files and metadata.name to the `staging-<full-app-name>` convention so everything lines up:
- argocd/applications/staging-dispatchr.yaml → staging-dispatchr-social.yaml
- argocd/applications/staging-jlshaw.yaml → staging-jlshaw-link.yaml

IMPORTANT one-time migration step (see PR description for details): strip the ArgoCD finalizer off the old Application objects before merging so their deletion doesn't cascade into the managed resources. The new Application CRs will adopt the existing resources on first sync.

2. Auto-merge step always fails on CLEAN PRs --------------------------------------------
gitops-staging-update.yml called `gh pr merge --auto --squash`. GitHub's GraphQL API rejects enablePullRequestAutoMerge when the PR is already in CLEAN status (which is the default on homelab-infra since no required checks are configured on main). Every staging update PR sat MERGEABLE+CLEAN forever and had to be merged by hand. That's why today's PR #23 was stuck.

Wrap the auto-merge in an `|| gh pr merge --squash` fallback so CLEAN PRs merge directly.

3. Concurrent dispatches silently overwrite each other ------------------------------------------------------ Every gitops-staging-update run used the fixed branch `staging/<app-name>`. When release-please ships web+worker in lockstep, both image-push dispatches hit the same branch sequentially (concurrency group serializes them) and the second run force-pushes its own digest update on top of a main-base checkout, throwing away the first run's changes. This is how the platform-infra prod dispatch today only picked up the worker update and dropped the web update for v0.1.18, leaving a stranded commit on the gitops branch.

Switch to per-image nested branches
`staging/<app-name>/<image-short>`:
- dispatchr-social/dispatchr-web gets its own branch
- dispatchr-social/dispatchr-worker (when added) gets its own
- No cross-image races

staging-promote.yml is updated to parse the new nested format: split BRANCH_PATH on the first `/` since app names can contain dashes (dispatchr-social, jlshaw-link) and the previous `%-*` split would have been ambiguous.

4. Pre-flight check on the ArgoCD polling loop ----------------------------------------------
Today's 404-polling-loop disaster (bug #1) would have been obvious in the first 2 seconds if the workflow had distinguished "app not found" from "app not yet healthy". Add a pre-flight GET before the poll that fails loud on any non-200, including a pointer to the expected Application name so future naming drift surfaces with a clear error instead of a 10-minute "Unknown/Unknown" timeout.

Also switch `curl -s` to `curl -sS` inside the poll so network errors surface in the log instead of being silently swallowed into an "Unknown" reading, and include the last observed health/sync values in the timeout error for post-mortem context.

Additional hardening
--------------------
Both workflows now validate APP_NAME and IMAGE_SHORT against a strict alphanumeric+hyphen+underscore allowlist before using them in file paths or shell expansions. Everything flowing through these workflows originates from a trusted Cloud Run dispatch (or a staging-team-authored PR), but defense in depth is cheap and consistent with the existing validation pattern.

Out of scope (separate follow-ups)
----------------------------------
- Worker has no staging path at all — it bypasses the gate via the platform-infra APP_MAP and ships direct-to-prod. That's how today's ffprobe/ESM bug (dispatchr.social#27) reached prod without any validation. Fixing requires adding a worker deployment to the staging-app chart + worker SA + a staging pub/sub path, which is a bigger architectural change.
- The parallel ArgoCD notifications → gitops-trigger /promote path is still subscribed on the staging Application but the PR-closed workflow here is what actually runs. Having two promotion paths is confusing and fragile; pick one in a follow-up.
- platform-infra gitops-update.yml has the same fixed-branch overwrite pattern as bug #3 but a separate PR will fix that there since it's a different repo.