### PR TITLE
feat(cert-manager): bump to v1.18.6 for k8s 1.31/1.32

### DIFF
--- a/argocd/applications/cert-manager.yaml
+++ b/argocd/applications/cert-manager.yaml
@@ -13,7 +13,9 @@ spec:
   source:
     repoURL: https://charts.jetstack.io
     chart: cert-manager
-    targetRevision: v1.15.0
+    # v1.15 only supports k8s <=1.30; bumped to 1.18 (supports 1.30-1.33) ahead
+    # of the k3s upgrade to 1.31/1.32. CRDs are clean (no selectableFields).
+    targetRevision: v1.18.6
     helm:
       valuesObject:
         crds:


### PR DESCRIPTION
Prereq for the k3s upgrade to 1.31/1.32. cert-manager v1.15 only supports k8s <=1.30.

- v1.15.0 -> v1.18.6 (supports k8s 1.30-1.33, covers the whole upgrade path)
- v1.19 not usable yet (requires k8s >=1.31; cluster is currently at 1.30)
- v1.18.6 CRDs have no `selectableFields`, so no ArgoCD v3.4.4 comparison error
- crds.enabled + ServerSideApply already set

**Sequencing:** merge + let ArgoCD sync this (cluster at 1.30 now), confirm cert-manager healthy, then continue k3s hops 1.31 -> 1.32.

Cluster status: hops 1.29.15 and 1.30.14 done; all 4 nodes currently on v1.30.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
