### PR TITLE
feat(eso): drop v1beta1 serving - migration complete

### DIFF
--- a/argocd/applications/external-secrets-operator.yaml
+++ b/argocd/applications/external-secrets-operator.yaml
@@ -12,17 +12,14 @@ spec:
     # Use official External Secrets Helm chart
     repoURL: https://charts.external-secrets.io
     chart: external-secrets
-    # PR1 of the v1beta1->v1 API migration: jump to latest 2.6.0 (matches the
-    # target for prod) while keeping the deprecated v1beta1 API served, so the
-    # existing v1beta1 manifests keep working untouched. PR2 migrates the
-    # manifests to v1 and flips unsafeServeV1Beta1 to false.
+    # On 2.6.0 (matches the prod target). The v1beta1->v1 API migration is
+    # complete: all manifests are external-secrets.io/v1, so v1beta1 serving is
+    # disabled (crds.unsafeServeV1Beta1 defaults to false).
     targetRevision: 2.6.0
     helm:
       valuesObject:
         crds:
           enabled: true
-          # Serve BOTH v1 and v1beta1 during the migration (PR2 -> false).
-          unsafeServeV1Beta1: true
 
         resources:
           requests:


### PR DESCRIPTION
Final step of the ESO `v1beta1 -> v1` migration.

All ExternalSecrets / SecretStores / ClusterSecretStores are now `external-secrets.io/v1` (merged in #350 and confirmed on-cluster: 34/34 ExternalSecrets `SecretSynced`, 7 ClusterSecretStores ready). This removes `crds.unsafeServeV1Beta1` (defaults to `false`) so the deprecated `v1beta1` API stops being served.

**Validated:** `helm template` against 2.6.0 renders the `externalsecrets` CRD with `v1` (served+storage) and `v1beta1` served=`false`.

After merge, ArgoCD applies the CRD update; v1beta1 stops serving. Safe — everything is already v1 (manifests + stored objects). Completes the migration: staging ESO is on 2.6.0, v1-only, matching prod's API generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
