### PR TITLE
fix(dispatchr): enable staging DB migrations

### DIFF
--- a/staging-apps/dispatchr-social/values.yaml
+++ b/staging-apps/dispatchr-social/values.yaml
@@ -25,7 +25,7 @@ staging-app:
     nameKey: aa6e43f9-115a-402e-b527-b423016103b2 # DISPATCHR_STAGING_DB_NAME
   # Migration image (built by CI alongside the app image)
   migration:
-    enabled: false
+    enabled: true # was false — staging DB had no schema (P2021); runs prisma migrate deploy
     repository: us-central1-docker.pkg.dev/dispatchr-social/dispatchr-social/dispatchr-web-migrate
     digest: "sha256:fb290cc0a7b9ff70dade020b98e5e058cb055edfa312b615b7ebd584d998a523" # Updated by CI/CD
   image:


### PR DESCRIPTION
The async-tier crons surfaced that staging dispatchr has **no DB schema** (Prisma `P2021: table public.Job does not exist`) — `migration.enabled` was `false`, so migrations never ran.

Now that the staging `DATABASE_URL` + `dispatchr_staging` role password are aligned (DB auth confirmed working), enable migrations so the `job-migrate` PreSync hook runs `prisma migrate deploy` and creates the schema. The migrate image + digest were already configured.

After merge: ArgoCD PreSync runs the migrate job -> schema created -> the worker/crons can write to the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)