### PR TITLE
fix(coreyalan): add staging IP allowlist

### DIFF
--- a/staging-apps/coreyalan-com/values.yaml
+++ b/staging-apps/coreyalan-com/values.yaml
@@ -47,6 +47,19 @@ staging-app:
     enabled: true
     host: staging.coreyalan.com
     clusterIssuer: letsencrypt-prod
+    # Restrict to the homelab WAN + on-LAN/in-cluster sources (matches jlshaw &
+    # blue-sky staging). In-cluster callers (capturly/dispatchr/jlshaw → this
+    # host via split-horizon DNS) and the worker land in 10.42.x (RFC1918); the
+    # /32 is the static ISP egress IP. Webhooks here are outbound, so this
+    # doesn't break integrations. Closes the public-exposure gap (prod uses
+    # authRateLimit; staging standardizes on the allowlist).
+    ipAllowList:
+      enabled: true
+      sourceRange:
+        - 206.225.142.166/32
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
   env:
     - name: NODE_ENV
       value: production


### PR DESCRIPTION
Closes the last drift item — coreyalan was the only public staging app with **no auth-endpoint protection** (no prod-style authRateLimit, no IP allowlist like jlshaw/blue-sky).

Adds the same Traefik IP allowlist jlshaw & blue-sky staging use:
- `206.225.142.166/32` (static ISP egress) + RFC1918 ranges
- In-cluster callers (capturly/dispatchr/jlshaw → `staging.coreyalan.com` via split-horizon DNS) and the worker are in `10.42.x` → allowed
- coreyalan's webhooks are **outbound** (→ capturly), so no integration breaks

Validated: renders the `coreyalan-com-staging-ipallowlist` Middleware (identical sourceRange to jlshaw) attached to the IngressRoute.