### PR TITLE
fix(matrix): MAS secret_file, LiveKit key perms, Draupnir off by default

### DIFF
--- a/helm-charts/matrix/templates/livekit.yaml
+++ b/helm-charts/matrix/templates/livekit.yaml
@@ -130,6 +130,8 @@ spec:
         - name: secrets
           secret:
             secretName: {{ .Values.rtc.secretName }}
+            # LiveKit refuses a key_file readable by "others"; restrict perms.
+            defaultMode: 0400
 ---
 apiVersion: v1
 kind: Service

--- a/helm-charts/matrix/templates/mas-configmap.yaml
+++ b/helm-charts/matrix/templates/mas-configmap.yaml
@@ -39,7 +39,7 @@ data:
     matrix:
       homeserver: "{{ .Values.serverName }}"
       endpoint: "{{ .Values.synapseEndpoint }}"
-      secret_path: /secrets/synapse-shared-secret
+      secret_file: /secrets/synapse-shared-secret
     secrets:
       encryption_file: /secrets/encryption
       keys:

--- a/helm-charts/matrix/values.yaml
+++ b/helm-charts/matrix/values.yaml
@@ -447,7 +447,10 @@ mediaCleanup:
 # and an access token in Bitwarden (draupnir_access_token), plus a management
 # room the bot is invited to (set managementRoom to its room ID/alias).
 draupnir:
-  enabled: true
+  # Enable after creating the @draupnir bot account via MAS, issuing its access
+  # token into Bitwarden (draupnir_access_token), and creating the management
+  # room. Until then it crash-loops, so it ships disabled.
+  enabled: false
   image: gnuxie/draupnir:v2.4.0
   managementRoom: "#moderation:coreyalan.com"
   secretName: matrix-draupnir


### PR DESCRIPTION
Fixes for the Matrix stack issues found after the initial deploy:

- MAS was crash-looping with "Missing secret or secret_file for key default.matrix" — the matrix integration uses secret_file, not secret_path (which is the Synapse-side key). Corrected.
- LiveKit was crash-looping with "key file others permissions must be set to 0" — the mounted key_file was world-readable. Now mounted with defaultMode 0400.
- Draupnir now ships disabled; it cannot start until the bot account/token and management room exist, so it no longer crash-loops on a fresh deploy.

Still gated separately: the Synapse pods are in ImagePullBackOff because ghcr.io/nx211/synapse-s3:1.155.0 is not built/pushed yet (see helm-charts/matrix/docker/synapse-s3/Dockerfile).
