### PR TITLE
ci(matrix): build/push synapse-s3 image to GHCR

### DIFF
--- a/.github/workflows/build-synapse-s3.yml
+++ b/.github/workflows/build-synapse-s3.yml
@@ -1,0 +1,38 @@
+name: Build Synapse S3 Image
+
+# Builds the custom Synapse image (element-hq/synapse + synapse-s3-storage-provider)
+# and pushes it to GHCR. Runs on changes to the Dockerfile, or on demand.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "helm-charts/matrix/docker/synapse-s3/**"
+      - ".github/workflows/build-synapse-s3.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/nx211/synapse-s3
+      SYNAPSE_VERSION: "1.155.0"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: helm-charts/matrix/docker/synapse-s3
+          build-args: SYNAPSE_VERSION=${{ env.SYNAPSE_VERSION }}
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ env.SYNAPSE_VERSION }}
+            ${{ env.IMAGE }}:latest


### PR DESCRIPTION
Adds a GitHub Actions workflow to build the custom Synapse image (element-hq/synapse + synapse-s3-storage-provider) and push it to ghcr.io/nx211/synapse-s3. Runs on Dockerfile changes or via workflow_dispatch, using the automatic GITHUB_TOKEN. After the first run, set the GHCR package visibility to public (or we add an imagePullSecret) so the cluster can pull it.