### PR TITLE
fix(matrix): v-prefixed synapse base image tag

### DIFF
--- a/helm-charts/matrix/docker/synapse-s3/Dockerfile
+++ b/helm-charts/matrix/docker/synapse-s3/Dockerfile
@@ -11,8 +11,10 @@
 #
 # Keep the tag in sync with matrix-synapse.image.tag in values.yaml and bump
 # both together when upgrading Synapse.
+# NB: element-hq/synapse image tags are v-prefixed (e.g. v1.155.0), while the
+# output image + chart values.yaml use the bare version (1.155.0).
 ARG SYNAPSE_VERSION=1.155.0
-FROM ghcr.io/element-hq/synapse:${SYNAPSE_VERSION}
+FROM ghcr.io/element-hq/synapse:v${SYNAPSE_VERSION}
 
 # pip install needs root; the image entrypoint drops privileges at runtime.
 USER root


### PR DESCRIPTION
The synapse-s3 image build failed with 'ghcr.io/element-hq/synapse:1.155.0: not found'. The element-hq/synapse image tags are v-prefixed (v1.155.0 exists; 1.155.0 does not). Fix the Dockerfile FROM to use v${SYNAPSE_VERSION}. The output image and chart values keep the bare tag (1.155.0). Merging this re-triggers the build workflow.