### PR TITLE
fix(staging): ignore reconciler-managed middleware sourceRange in Argo

### DIFF
--- a/argocd/applications/staging-blue-skysolutions-com.yaml
+++ b/argocd/applications/staging-blue-skysolutions-com.yaml
@@ -19,6 +19,16 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: staging
+  # The allowlist-reconciler owns this Middleware's sourceRange (base ∪ reviewer
+  # IPs). Tell Argo to ignore that field so selfHeal won't revert runtime writes;
+  # base ranges still live in git via the chart values.
+  ignoreDifferences:
+    - group: traefik.io
+      kind: Middleware
+      name: blue-skysolutions-com-staging-ipallowlist
+      namespace: staging
+      jsonPointers:
+        - /spec/ipAllowList/sourceRange
   syncPolicy:
     automated:
       prune: true

--- a/argocd/applications/staging-capturly-web.yaml
+++ b/argocd/applications/staging-capturly-web.yaml
@@ -15,6 +15,16 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: staging
+  # The allowlist-reconciler owns this Middleware's sourceRange (base ∪ reviewer
+  # IPs). Tell Argo to ignore that field so selfHeal won't revert runtime writes;
+  # base ranges still live in git via the chart values.
+  ignoreDifferences:
+    - group: traefik.io
+      kind: Middleware
+      name: capturly-web-staging-ipallowlist
+      namespace: staging
+      jsonPointers:
+        - /spec/ipAllowList/sourceRange
   syncPolicy:
     automated:
       prune: true

--- a/argocd/applications/staging-dispatchr-social.yaml
+++ b/argocd/applications/staging-dispatchr-social.yaml
@@ -27,6 +27,16 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: staging
+  # The allowlist-reconciler owns this Middleware's sourceRange (base ∪ reviewer
+  # IPs). Tell Argo to ignore that field so selfHeal won't revert runtime writes;
+  # base ranges still live in git via the chart values.
+  ignoreDifferences:
+    - group: traefik.io
+      kind: Middleware
+      name: dispatchr-social-staging-ipallowlist
+      namespace: staging
+      jsonPointers:
+        - /spec/ipAllowList/sourceRange
   syncPolicy:
     automated:
       prune: true

--- a/argocd/applications/staging-jlshaw-link.yaml
+++ b/argocd/applications/staging-jlshaw-link.yaml
@@ -19,6 +19,16 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: staging
+  # The allowlist-reconciler owns this Middleware's sourceRange (base ∪ reviewer
+  # IPs). Tell Argo to ignore that field so selfHeal won't revert runtime writes;
+  # base ranges still live in git via the chart values.
+  ignoreDifferences:
+    - group: traefik.io
+      kind: Middleware
+      name: jlshaw-link-staging-ipallowlist
+      namespace: staging
+      jsonPointers:
+        - /spec/ipAllowList/sourceRange
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
The allowlist-reconciler writes base + reviewer IPs into each app's ipAllowList Middleware at runtime, but these four apps lacked the ignoreDifferences rule coreyalan-com has, so Argo selfHeal kept reverting the reviewer IP (~20s flap = intermittent 403s for reviewers). Tell Argo to ignore /spec/ipAllowList/sourceRange on each app's Middleware; base ranges still live in git via the chart values.