### PR TITLE
fix: resolve slskd & promtail Argo apps stuck in Progressing

### DIFF
--- a/argocd/applications/promtail.yaml
+++ b/argocd/applications/promtail.yaml
@@ -110,6 +110,15 @@ spec:
                     - __meta_kubernetes_pod_container_name
                     target_label: __path__
 
+        # Loosen the readiness probe. The default 1s timeout flaps to NotReady
+        # on high-churn nodes (many short-lived pods rotating log files), where
+        # /ready occasionally answers slower than 1s. A perpetually NotReady pod
+        # keeps the DaemonSet from reaching full availability, which pins the
+        # Argo app in Progressing even though promtail is shipping logs fine.
+        readinessProbe:
+          timeoutSeconds: 5
+          failureThreshold: 10
+
         # ServiceMonitor for Prometheus metrics
         serviceMonitor:
           enabled: true

--- a/helm-charts/slskd/templates/deployment.yaml
+++ b/helm-charts/slskd/templates/deployment.yaml
@@ -90,6 +90,17 @@ spec:
         - name: music
           mountPath: {{ .Values.persistence.music.mountPath }}
           readOnly: {{ .Values.persistence.music.readOnly }}
+        startupProbe:
+          # The initial cold share scan blocks slskd's HTTP listener and can
+          # take 20-30 min. Without this, liveness kills the container mid-scan
+          # before the share cache is ever persisted, forcing a rescan on every
+          # boot (a self-perpetuating crash loop). Suppress liveness until the
+          # first scan completes; subsequent restarts are fast from cache.
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds: 30
+          failureThreshold: 60
         livenessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
## Summary

Both `slskd` and `promtail` show `Synced / Progressing` indefinitely in ArgoCD. Neither is a sync problem — each has one pod that never reaches **Ready**, so Argo sees the underlying workload as not fully available. Two unrelated root causes:

### slskd — crash loop (14,603 restarts), Deployment 0/1
On boot slskd runs a forced full share scan (7,107 dirs / 200k+ files, ~20–30 min) and doesn't serve `/health` until it finishes. The `livenessProbe` grace window (~210s) expires long before that, so the kubelet kills the container (`exitCode 137`, `reason: Error` — not OOM). Because the scan never completes, the share cache is never persisted to the `/app` PVC, so every boot logs *"Shared file cache missing or invalid"* and rescans from scratch — a self-perpetuating deadlock.

**Fix:** add a `startupProbe` on `/health` (`periodSeconds: 30`, `failureThreshold: 60` ≈ 30 min) so liveness is suppressed until the initial scan completes once and persists the cache. Subsequent restarts are fast.

### promtail — DaemonSet 3/4 ready
The pod on the busiest node flaps `NotReady` with `Readiness probe failed: ... /ready: context deadline exceeded`. The chart's default `readinessProbe.timeoutSeconds: 1` is too tight for high-churn nodes (many short-lived pods rotating log files) where `/ready` occasionally answers slower than 1s. The pod is healthy and shipping logs; only the probe flaps. One perpetually NotReady pod keeps the DaemonSet from full availability, pinning the app in Progressing.

**Fix:** raise the readiness probe to `timeoutSeconds: 5`, `failureThreshold: 10`.

## Changes
- `helm-charts/slskd/templates/deployment.yaml` — add `startupProbe`
- `argocd/applications/promtail.yaml` — loosen readiness probe in Helm `valuesObject`

## Verification
Investigated live on the cluster: slskd dying at ~3m55s to a liveness kill mid-scan with cache never persisted; only the `yellowtalon` promtail pod NotReady due to `/ready` exceeding the 1s timeout (pod not resource-starved, Loki healthy). Both are health/readiness only — sync status is already `Synced`.