### PR TITLE
fix(slskd): widen startupProbe budget to 75 min for cold share scan

### DIFF
--- a/helm-charts/slskd/templates/deployment.yaml
+++ b/helm-charts/slskd/templates/deployment.yaml
@@ -91,16 +91,17 @@ spec:
           mountPath: {{ .Values.persistence.music.mountPath }}
           readOnly: {{ .Values.persistence.music.readOnly }}
         startupProbe:
-          # The initial cold share scan blocks slskd's HTTP listener and can
-          # take 20-30 min. Without this, liveness kills the container mid-scan
-          # before the share cache is ever persisted, forcing a rescan on every
-          # boot (a self-perpetuating crash loop). Suppress liveness until the
-          # first scan completes; subsequent restarts are fast from cache.
+          # The initial cold share scan blocks slskd's HTTP listener. Measured
+          # on this cluster at ~50-55 min for 200k+ files on local-path disk.
+          # Without this, liveness kills the container mid-scan before the share
+          # cache is ever persisted, forcing a rescan on every boot (a self-
+          # perpetuating crash loop). Budget = 150 x 30s = 75 min, comfortably
+          # above the measured scan time. Subsequent restarts are fast from cache.
           httpGet:
             path: /health
             port: http
           periodSeconds: 30
-          failureThreshold: 60
+          failureThreshold: 150
         livenessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
## Summary

Follow-up to #468. After that PR merged, slskd stopped crash-looping (0 restarts) and the share scan finally progressed **past the ~19% ceiling** it always died at before — confirming the `startupProbe` approach works. But it went Degraded because the first budget was too small.

Live measurement on the cluster: the cold scan of 200k+ files runs at ~1.5%/min (decelerating), reaching only **37% after 13.5 min** → full scan ≈ **50–55 min**. The original `failureThreshold: 60` (× `periodSeconds: 30` = **30 min**) would still kill the container mid-scan around ~90%, before the cache is persisted — the same deadlock, just slower.

## Change
Raise `startupProbe.failureThreshold` 60 → 150 (**75 min** budget), comfortably above the measured scan time. Once the first scan completes and writes the cache to the `/app` PVC, subsequent restarts are fast and liveness/readiness take over normally.

## Note
This is a one-time cold-scan cost. The `Recreate` rollout restarts the scan from scratch, but with the larger budget it will now run to completion and cache, after which the pod goes Ready and Argo returns to Healthy.