### PR TITLE
feat(soularr): add Soularr chart and ArgoCD application

### DIFF
--- a/argocd/applications/soularr.yaml
+++ b/argocd/applications/soularr.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: soularr
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: HEAD
+    path: helm-charts/soularr
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/helm-charts/slskd/values.yaml
+++ b/helm-charts/slskd/values.yaml
@@ -39,8 +39,10 @@ persistence:
 # Environment variables (slskd reads SLSKD_* env to override slskd.yml at runtime)
 env:
   TZ: America/New_York
-  # Where slskd writes finished files (subdir of mounted /downloads)
-  SLSKD_DOWNLOADS_DIR: "/downloads/soulseek"
+  # Where slskd writes finished files. Kept UNDER Lidarr's importable music
+  # downloads tree (/blacktalon/media/downloads/music) so Soularr can hand
+  # Lidarr a path it can import from. = /blacktalon/media/downloads/music/soulseek
+  SLSKD_DOWNLOADS_DIR: "/downloads/music/soulseek"
   # In-progress downloads (subdir of mounted /downloads)
   SLSKD_INCOMPLETE_DIR: "/downloads/incomplete/soulseek"
   # Comma-separated list of dirs to share with peers
@@ -68,6 +70,12 @@ externalSecrets:
       key: d3bcd21e-e9be-42c8-9fb0-b43d00f5b49a  # slskd_web_username
     - name: SLSKD_PASSWORD
       key: 391a7ea7-9e98-4a24-918e-b43d00f5b4cf  # slskd_web_password
+    # Primary API key so Soularr can authenticate to slskd's REST API. A bare
+    # key defaults to Administrator role + any CIDR (slskd behaviour), which is
+    # what Soularr needs to initiate downloads. Same secret is consumed by the
+    # soularr chart, so both sides present the identical key.
+    - name: SLSKD_API_KEY
+      key: 7dde21f3-7fd8-4153-b6a3-b47e00f78c43  # slskd_api_key
 
 resources:
   requests:

--- a/helm-charts/soularr/Chart.yaml
+++ b/helm-charts/soularr/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: soularr
+description: Soularr - bridges Lidarr's wanted list to slskd (Soulseek) as an extra music source
+type: application
+version: 1.0.0
+# Upstream publishes a rolling :latest image rather than semver tags.
+appVersion: "latest"
+
+keywords:
+  - soularr
+  - lidarr
+  - slskd
+  - soulseek
+  - music
+
+maintainers:
+  - name: Homelab Admin

--- a/helm-charts/soularr/templates/_helpers.tpl
+++ b/helm-charts/soularr/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "soularr.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "soularr.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "soularr.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "soularr.labels" -}}
+helm.sh/chart: {{ include "soularr.chart" . }}
+{{ include "soularr.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "soularr.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "soularr.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm-charts/soularr/templates/configmap.yaml
+++ b/helm-charts/soularr/templates/configmap.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "soularr.fullname" . }}-config
+  labels:
+    {{- include "soularr.labels" . | nindent 4 }}
+data:
+  # Template only — the two api_key placeholders are substituted with values
+  # from the ExternalSecret by the render-config init container at pod start,
+  # so real secrets never live in git. Rendered to /data/config.ini.
+  config.ini.tmpl: |
+    [Lidarr]
+    api_key = __LIDARR_API_KEY__
+    download_dir = {{ .Values.config.lidarr.downloadDir }}
+    host_url = {{ .Values.config.lidarr.hostUrl }}
+
+    [Slskd]
+    api_key = __SLSKD_API_KEY__
+    download_dir = {{ .Values.config.slskd.downloadDir }}
+    host_url = {{ .Values.config.slskd.hostUrl }}
+    url_base = {{ .Values.config.slskd.urlBase }}
+    delete_searches = {{ ternary "True" "False" .Values.config.slskd.deleteSearches }}
+    stalled_timeout = {{ .Values.config.slskd.stalledTimeout }}
+
+    [Release Settings]
+    use_most_common_tracknum = {{ ternary "True" "False" .Values.config.release.useMostCommonTracknum }}
+    allow_multi_disc = {{ ternary "True" "False" .Values.config.release.allowMultiDisc }}
+    accepted_countries = {{ .Values.config.release.acceptedCountries }}
+    accepted_formats = {{ .Values.config.release.acceptedFormats }}
+
+    [Search Settings]
+    search_timeout = {{ .Values.config.search.searchTimeout }}
+    maximum_peer_queue = {{ .Values.config.search.maximumPeerQueue }}
+    minimum_peer_upload_speed = {{ .Values.config.search.minimumPeerUploadSpeed }}
+    minimum_filename_match_ratio = {{ .Values.config.search.minimumFilenameMatchRatio }}
+    allowed_filetypes = {{ .Values.config.search.allowedFiletypes }}
+    search_for_tracks = {{ ternary "True" "False" .Values.config.search.searchForTracks }}
+    album_prepend_artist = {{ ternary "True" "False" .Values.config.search.albumPrependArtist }}
+    number_of_albums_to_grab = {{ .Values.config.search.numberOfAlbumsToGrab }}
+    remove_wanted_on_failure = {{ ternary "True" "False" .Values.config.search.removeWantedOnFailure }}
+    search_type = {{ .Values.config.search.searchType }}
+
+    [Logging]
+    level = {{ .Values.config.logging.level }}
+    format = [%(levelname)s|%(module)s|L%(lineno)d] %(asctime)s: %(message)s
+    datefmt = %Y-%m-%dT%H:%M:%S%z

--- a/helm-charts/soularr/templates/deployment.yaml
+++ b/helm-charts/soularr/templates/deployment.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "soularr.fullname" . }}
+  labels:
+    {{- include "soularr.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  # Single instance only — Soularr is not safe to run concurrently.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "soularr.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Roll the pod when config.ini content changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "soularr.selectorLabels" . | nindent 8 }}
+    spec:
+      enableServiceLinks: false
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+      # Inject the secret API keys into config.ini (kept out of git) and write
+      # the rendered file to the shared /data volume that Soularr reads.
+      - name: render-config
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          set -e
+          sed -e "s|__LIDARR_API_KEY__|${LIDARR_API_KEY}|g" \
+              -e "s|__SLSKD_API_KEY__|${SLSKD_API_KEY}|g" \
+              /tmpl/config.ini.tmpl > /data/config.ini
+        envFrom:
+        - secretRef:
+            name: {{ .Values.externalSecrets.secretName | default (printf "%s-secrets" (include "soularr.fullname" .)) }}
+        volumeMounts:
+        - name: config-tmpl
+          mountPath: /tmpl
+        - name: data
+          mountPath: /data
+      containers:
+      - name: soularr
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: TZ
+          value: {{ .Values.env.TZ | quote }}
+        - name: SCRIPT_INTERVAL
+          value: {{ .Values.env.SCRIPT_INTERVAL | quote }}
+        volumeMounts:
+        # Soularr reads /data/config.ini and writes run state alongside it.
+        - name: data
+          mountPath: /data
+        # Shared downloads tree so Soularr can see slskd's completed files and
+        # hand Lidarr a path it can import from.
+        - name: downloads
+          mountPath: {{ .Values.persistence.downloads.mountPath }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+      volumes:
+      - name: config-tmpl
+        configMap:
+          name: {{ include "soularr.fullname" . }}-config
+      - name: data
+        emptyDir: {}
+      - name: downloads
+        hostPath:
+          path: {{ .Values.persistence.downloads.hostPath }}
+          type: Directory

--- a/helm-charts/soularr/templates/externalsecret.yaml
+++ b/helm-charts/soularr/templates/externalsecret.yaml
@@ -1,0 +1,31 @@
+---
+{{- if .Values.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.externalSecrets.secretName | default (printf "%s-secrets" (include "soularr.fullname" .)) }}
+  labels:
+    {{- include "soularr.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | default "1h" }}
+
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+
+  target:
+    name: {{ .Values.externalSecrets.secretName | default (printf "%s-secrets" (include "soularr.fullname" .)) }}
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          {{- include "soularr.labels" . | nindent 10 }}
+
+  data:
+  {{- range .Values.externalSecrets.secrets }}
+  - secretKey: {{ .name }}
+    remoteRef:
+      key: {{ .key }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/soularr/values.yaml
+++ b/helm-charts/soularr/values.yaml
@@ -1,0 +1,96 @@
+# Soularr Helm Chart Values
+#
+# Soularr polls Lidarr's Missing / Cutoff-Unmet lists, searches slskd (Soulseek),
+# downloads matches, and triggers Lidarr to import them. It ADDS Soulseek as an
+# extra source alongside your existing usenet/torrent workflow — nothing about
+# Prowlarr / sabnzbd / transmission / autobrr changes. Soularr requires Lidarr;
+# it is not a replacement for it.
+
+image:
+  repository: mrusse08/soularr
+  # No upstream semver tags; :latest is the published image. Pin a digest here
+  # if you want reproducible deploys.
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+# Pin to blacktalon — that's where /blacktalon/media/downloads lives and where
+# lidarr + slskd run.
+nodeSelector:
+  kubernetes.io/hostname: blacktalon
+
+env:
+  TZ: America/New_York
+  # Soularr runs on its own internal loop; seconds to wait between runs.
+  SCRIPT_INTERVAL: "300"
+
+# Shared downloads hostPath. This MUST expose the same physical directory that
+# slskd writes completed files into AND that Lidarr imports from, mounted at the
+# SAME in-container path Lidarr uses (see config.lidarr.downloadDir).
+#
+# NB: Lidarr mounts /blacktalon/media/downloads/music at /media/downloads/music.
+# For the hand-off to work, slskd must write its completed Soulseek downloads
+# somewhere UNDER that tree (see the companion slskd change in the PR notes):
+#   slskd: SLSKD_DOWNLOADS_DIR=/downloads/music/soulseek
+#          (= /blacktalon/media/downloads/music/soulseek)
+persistence:
+  downloads:
+    hostPath: /blacktalon/media/downloads/music
+    mountPath: /media/downloads/music
+
+# config.ini values. Rendered to /data/config.ini at pod start; the two API keys
+# are injected from the ExternalSecret by an init container so they never live in
+# git (see templates/configmap.yaml + templates/deployment.yaml).
+config:
+  lidarr:
+    hostUrl: http://lidarr:8686
+    # Path to the completed-downloads dir AS LIDARR SEES IT.
+    downloadDir: /media/downloads/music
+  slskd:
+    hostUrl: http://slskd:5030
+    urlBase: /
+    # Path to slskd's completed downloads AS SOULARR SEES IT. Kept identical to
+    # lidarr.downloadDir by mounting the same hostPath at the same path above.
+    downloadDir: /media/downloads/music
+    deleteSearches: false
+    stalledTimeout: 3600
+  release:
+    useMostCommonTracknum: true
+    allowMultiDisc: true
+    acceptedCountries: "Europe,Japan,United Kingdom,United States,[Worldwide],Australia,Canada"
+    acceptedFormats: "CD,Digital Media,Vinyl"
+  search:
+    searchTimeout: 5000
+    maximumPeerQueue: 50
+    minimumPeerUploadSpeed: 0
+    minimumFilenameMatchRatio: 0.5
+    allowedFiletypes: "flac,mp3"
+    searchForTracks: true
+    albumPrependArtist: false
+    numberOfAlbumsToGrab: 10
+    # Keep Soulseek as a FALLBACK source: do NOT unmonitor the album in Lidarr
+    # when a Soulseek grab fails, so your usenet/torrent grabbers still get it.
+    removeWantedOnFailure: false
+    searchType: incrementing_page
+  logging:
+    level: INFO
+
+# External Secrets (Bitwarden Secrets Manager).
+# ACTION REQUIRED: create these two secrets in Bitwarden and paste their UUIDs.
+#   lidarr_api_key : Lidarr -> Settings -> General -> API Key
+#   slskd_api_key  : an API key you add to slskd (see companion change in PR)
+externalSecrets:
+  enabled: true
+  refreshInterval: 1h
+  secrets:
+    - name: LIDARR_API_KEY
+      key: REPLACE_WITH_BITWARDEN_UUID_lidarr_api_key
+    - name: SLSKD_API_KEY
+      key: REPLACE_WITH_BITWARDEN_UUID_slskd_api_key
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi

--- a/helm-charts/soularr/values.yaml
+++ b/helm-charts/soularr/values.yaml
@@ -43,14 +43,16 @@ persistence:
 config:
   lidarr:
     hostUrl: http://lidarr:8686
-    # Path to the completed-downloads dir AS LIDARR SEES IT.
-    downloadDir: /media/downloads/music
+    # slskd's completed-downloads dir AS LIDARR SEES IT. Lidarr mounts
+    # /blacktalon/media/downloads/music at /media/downloads/music, and slskd
+    # writes completed albums into the soulseek/ subfolder (SLSKD_DOWNLOADS_DIR).
+    downloadDir: /media/downloads/music/soulseek
   slskd:
     hostUrl: http://slskd:5030
     urlBase: /
-    # Path to slskd's completed downloads AS SOULARR SEES IT. Kept identical to
-    # lidarr.downloadDir by mounting the same hostPath at the same path above.
-    downloadDir: /media/downloads/music
+    # Same physical dir AS SOULARR SEES IT — kept identical to lidarr.downloadDir
+    # by mounting the same hostPath at the same path below.
+    downloadDir: /media/downloads/music/soulseek
     deleteSearches: false
     stalledTimeout: 3600
   release:
@@ -74,18 +76,18 @@ config:
   logging:
     level: INFO
 
-# External Secrets (Bitwarden Secrets Manager).
-# ACTION REQUIRED: create these two secrets in Bitwarden and paste their UUIDs.
-#   lidarr_api_key : Lidarr -> Settings -> General -> API Key
-#   slskd_api_key  : an API key you add to slskd (see companion change in PR)
+# External Secrets (Bitwarden Secrets Manager, Workbench project).
+#   lidarr_api_key : Lidarr's API key (Settings -> General -> API Key)
+#   slskd_api_key  : the API key slskd is configured to accept (same secret is
+#                    consumed by the slskd chart to register the key)
 externalSecrets:
   enabled: true
   refreshInterval: 1h
   secrets:
     - name: LIDARR_API_KEY
-      key: REPLACE_WITH_BITWARDEN_UUID_lidarr_api_key
+      key: b8e9a29f-4dec-4a57-91a7-b47e00f78c13  # lidarr_api_key
     - name: SLSKD_API_KEY
-      key: REPLACE_WITH_BITWARDEN_UUID_slskd_api_key
+      key: 7dde21f3-7fd8-4153-b6a3-b47e00f78c43  # slskd_api_key
 
 resources:
   requests:


### PR DESCRIPTION
## Summary

Adds **Soularr** as an additional music source that bridges Lidarr's wanted list to slskd (Soulseek). It runs *alongside* the existing usenet/torrent workflow — Prowlarr, sabnzbd, transmission, and autobrr are untouched. Soularr requires Lidarr; it is not a replacement for it.

How it works: Soularr polls Lidarr's Missing / Cutoff-Unmet lists, searches slskd, downloads matches, and triggers Lidarr to import them. It's configured as a *fallback* source (`remove_wanted_on_failure = False`) so usenet/torrent stay primary and Soulseek fills the long tail.

## What's included
- `helm-charts/soularr/` — chart modelled on the existing `slskd` chart (same `_helpers.tpl`, ExternalSecret, and label conventions)
  - **Deployment** pinned to `blacktalon`, single replica, `Recreate` (Soularr isn't safe to run concurrently), self-loops via `SCRIPT_INTERVAL`
  - **config.ini** rendered at pod start by a `render-config` init container that injects the two API keys from the ExternalSecret via `sed` — secrets never live in git
  - **ExternalSecret** pulling `LIDARR_API_KEY` / `SLSKD_API_KEY` from Bitwarden (same ClusterSecretStore as slskd)
  - Shared `/blacktalon/media/downloads/music` hostPath so Soularr sees slskd's completed files and hands Lidarr an importable path
- `argocd/applications/soularr.yaml` — Application (auto-discovered by the `root-apps` app-of-apps; no manual apply)
- **slskd companion changes** (same branch, so this merges atomically):
  - registers `SLSKD_API_KEY` from the shared `slskd_api_key` secret (bare key ⇒ Administrator role, which Soularr needs)
  - repoints `SLSKD_DOWNLOADS_DIR` → `/downloads/music/soulseek` so completed grabs land under Lidarr's importable music tree

Both charts `helm template` clean.

## Secrets (already created)
The two Bitwarden Secrets Manager secrets exist in the **Workbench** project and are wired by UUID in `values.yaml`:
- `lidarr_api_key` (`b8e9a29f-…`) — pulled from Lidarr's live config
- `slskd_api_key` (`7dde21f3-…`) — freshly generated 64-hex key, consumed by **both** slskd (to register the key) and Soularr (to authenticate), so the two always match

## Merge notes
- Merging repoints slskd's download dir, which triggers a slskd pod restart (Recreate). slskd's share cache lives on its `/app` PVC and is unaffected, so the restart is fast (no cold re-scan).
- After sync, verify: `kubectl -n default logs -f deploy/soularr` — it should poll Lidarr, search slskd, and begin filling missing albums. Soularr has no web UI; results appear in Lidarr.
- The two `download_dir` values are best-guess for the shared path; if the first run mislocates files, they're the knob to adjust.
