### PR TITLE
fix(lidatube): import completed downloads into Lidarr + fix lidarr_api_key ref

### DIFF
--- a/helm-charts/lidarr/templates/cronjob-lidatube-import.yaml
+++ b/helm-charts/lidarr/templates/cronjob-lidatube-import.yaml
@@ -1,0 +1,51 @@
+---
+{{- if and .Values.lidatube.enabled .Values.lidatube.import.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "lidarr.fullname" . }}-lidatube-import
+  labels:
+    {{- include "lidarr.labels" . | nindent 4 }}
+    app.kubernetes.io/component: lidatube-import
+spec:
+  schedule: {{ .Values.lidatube.import.schedule | quote }}
+  # Never overlap runs; a scan can outlast the interval on a large batch.
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            {{- include "lidarr.labels" . | nindent 12 }}
+            app.kubernetes.io/component: lidatube-import
+        spec:
+          restartPolicy: OnFailure
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+          - name: trigger-import
+            image: "{{ .Values.lidatube.import.image.repository }}:{{ .Values.lidatube.import.image.tag }}"
+            env:
+            - name: LIDARR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalSecrets.secretName | default (printf "%s-secrets" (include "lidarr.fullname" .)) }}
+                  key: LIDARR_API_KEY
+            command:
+            - sh
+            - -c
+            - |
+              set -eu
+              # Ask Lidarr to scan LidaTube's download folder and import (match,
+              # rename, and move) any completed albums into the library.
+              curl -fsS -X POST \
+                -H "X-Api-Key: ${LIDARR_API_KEY}" \
+                -H "Content-Type: application/json" \
+                -d '{"name":"DownloadedAlbumsScan","path":"{{ .Values.lidatube.import.path }}","importMode":"{{ .Values.lidatube.import.importMode }}"}' \
+                {{ .Values.lidatube.env.lidarr_address }}/api/v1/command
+{{- end }}

--- a/helm-charts/lidarr/templates/deployment-lidatube.yaml
+++ b/helm-charts/lidarr/templates/deployment-lidatube.yaml
@@ -34,6 +34,10 @@ spec:
           containerPort: {{ .Values.lidatube.service.port }}
           protocol: TCP
         env:
+        - name: PUID
+          value: {{ .Values.lidatube.env.PUID | default "1000" | quote }}
+        - name: PGID
+          value: {{ .Values.lidatube.env.PGID | default "1000" | quote }}
         - name: lidarr_address
           value: {{ .Values.lidatube.env.lidarr_address | quote }}
         - name: preferred_codec

--- a/helm-charts/lidarr/templates/deployment.yaml
+++ b/helm-charts/lidarr/templates/deployment.yaml
@@ -65,6 +65,10 @@ spec:
           mountPath: {{ .Values.persistence.media.downloadsMusic.mountPath }}
         - name: downloads-music-videos
           mountPath: {{ .Values.persistence.media.downloadsMusicVideos.mountPath }}
+        {{- if .Values.persistence.media.downloadsLidatube }}
+        - name: downloads-lidatube
+          mountPath: {{ .Values.persistence.media.downloadsLidatube.mountPath }}
+        {{- end }}
         {{- end }}
         livenessProbe:
           httpGet:
@@ -105,4 +109,10 @@ spec:
         hostPath:
           path: {{ .Values.persistence.media.downloadsMusicVideos.hostPath }}
           type: Directory
+      {{- if .Values.persistence.media.downloadsLidatube }}
+      - name: downloads-lidatube
+        hostPath:
+          path: {{ .Values.persistence.media.downloadsLidatube.hostPath }}
+          type: DirectoryOrCreate
+      {{- end }}
       {{- end }}

--- a/helm-charts/lidarr/values.yaml
+++ b/helm-charts/lidarr/values.yaml
@@ -42,6 +42,12 @@ persistence:
     downloadsMusicVideos:
       hostPath: /blacktalon/media/downloads/music-videos
       mountPath: /media/downloads/music-videos
+    # LidaTube's completed YouTube downloads. Lidarr imports from here via the
+    # lidatube-import CronJob (DownloadedAlbumsScan). Separate from the ~2yr
+    # backlog in /blacktalon/media/downloads/lidatube, which is left untouched.
+    downloadsLidatube:
+      hostPath: /blacktalon/media/downloads/lidatube-import
+      mountPath: /media/downloads/lidatube-import
 
 # Environment variables
 env:
@@ -65,13 +71,33 @@ lidatube:
     lidarr_address: "http://lidarr:8686"
     preferred_codec: "flac"
     thread_limit: "6"
+    # Run as the media user so downloaded files are owned by 8675309 and Lidarr
+    # (same uid) can move them into the library during import.
+    PUID: "8675309"
+    PGID: "8675309"
   persistence:
     config:
       hostPath: /blacktalon/apps/lidatube
       mountPath: /lidatube/config
     downloads:
-      hostPath: /blacktalon/media/downloads/lidatube
+      # Fresh folder for the automated import pipeline. The old
+      # /blacktalon/media/downloads/lidatube backlog is intentionally NOT reused
+      # so it stays untouched for manual triage.
+      hostPath: /blacktalon/media/downloads/lidatube-import
       mountPath: /lidatube/downloads
+  # Lidarr import of LidaTube's completed downloads. LidaTube downloads but never
+  # imports (it only calls RescanFolders on the library root, where its files
+  # never land). This CronJob triggers Lidarr's DownloadedAlbumsScan on the
+  # download folder so Lidarr matches, renames, and moves them into the library.
+  import:
+    enabled: true
+    schedule: "*/15 * * * *"
+    # Path AS LIDARR SEES IT — matches persistence.media.downloadsLidatube.mountPath.
+    path: /media/downloads/lidatube-import
+    importMode: Move
+    image:
+      repository: curlimages/curl
+      tag: "8.11.1"
   resources:
     requests:
       cpu: 100m
@@ -82,12 +108,13 @@ lidatube:
 
 # External Secrets (optional - if using ESO)
 externalSecrets:
-  enabled: false
-  # secretName: lidarr-secrets
-  # refreshInterval: 1h
-  # secrets:
-  #   - name: LIDARR_API_KEY
-  #     key: lidarr-api-key
+  enabled: true
+  refreshInterval: 1h
+  secrets:
+    # Lidarr's API key. Consumed by the LidaTube companion (to read the wanted
+    # list) and by the lidatube-import CronJob (to trigger DownloadedAlbumsScan).
+    - name: LIDARR_API_KEY
+      key: 1ee9bd9f-911c-4ef0-be32-b3d000f652e9  # lidarr_api_key
 
 # Resource limits
 resources:

--- a/helm-charts/soularr/values.yaml
+++ b/helm-charts/soularr/values.yaml
@@ -85,7 +85,7 @@ externalSecrets:
   refreshInterval: 1h
   secrets:
     - name: LIDARR_API_KEY
-      key: b8e9a29f-4dec-4a57-91a7-b47e00f78c13  # lidarr_api_key
+      key: 1ee9bd9f-911c-4ef0-be32-b3d000f652e9  # lidarr_api_key
     - name: SLSKD_API_KEY
       key: 7dde21f3-7fd8-4153-b6a3-b47e00f78c43  # slskd_api_key
 


### PR DESCRIPTION
## Summary

Fixes LidaTube's broken import loop and reconciles the Lidarr API-key secret.

**The bug:** LidaTube reads Lidarr's wanted list and downloads from YouTube, but its files then sit orphaned — the download folder (`/blacktalon/media/downloads/lidatube`) isn't in Lidarr's library, and Lidarr's modern releases have no auto-watched drop folder. Reading the source confirmed LidaTube **never moves files** and only calls `RescanFolders` on the library *root* (where its files never land). Result: ~250 artist folders orphaned since Sept 2024.

**The fix** — proper arr-style import (LidaTube as "download client", Lidarr as importer):

- **lidarr**: enable the ExternalSecret for `LIDARR_API_KEY` (canonical `lidarr_api_key`, `1ee9bd9f`); mount a `downloads-lidatube` dir; add a **CronJob** (`*/15`) that POSTs Lidarr's `DownloadedAlbumsScan` (`importMode: Move`) so Lidarr matches/renames/moves completed downloads into the library. Verified live: the command returns HTTP 201.
- **lidatube**: run as the media user (`PUID/PGID 8675309`) so Lidarr (same uid) can move its files; download to a **fresh folder** (`/blacktalon/media/downloads/lidatube-import`).
- **soularr**: repoint `LIDARR_API_KEY` at the canonical `1ee9bd9f` secret (fixes a broken reference — a duplicate `lidarr_api_key` was created earlier and has been deleted from Bitwarden, which would have broken soularr's ExternalSecret on main).

## Backlog left untouched
The ~250-folder backlog in `/blacktalon/media/downloads/lidatube` is **not** reused or scanned — new downloads go to a separate `-import` folder. Note: LidaTube will re-download still-missing albums into the new folder over time. If you'd rather import the existing backlog instead of re-downloading, trigger a one-time scan of the old folder (I can hand you the command) — that marks those albums present so LidaTube skips them.

## Why the secret reference matters (merge this soon-ish)
`main` currently references the deleted `b8e9…` UUID in soularr, so soularr's ExternalSecret is broken until this merges. `helm template` is clean for both charts.

## Verify after sync
- `kubectl -n default get cronjob lidarr-lidatube-import`
- Force a run: `kubectl -n default create job --from=cronjob/lidarr-lidatube-import lidatube-import-test`
- Watch Lidarr Activity → History for imports.
