### PR TITLE
fix(lidatube): prevent OOM kills mid-download

### DIFF
--- a/helm-charts/lidarr/values.yaml
+++ b/helm-charts/lidarr/values.yaml
@@ -70,7 +70,11 @@ lidatube:
   env:
     lidarr_address: "http://lidarr:8686"
     preferred_codec: "flac"
-    thread_limit: "6"
+    # Concurrent download/convert threads. Each yt-dlp+ffmpeg FLAC conversion
+    # spikes RAM; 6 blew past the 1Gi limit and got OOMKilled mid-download
+    # (which resets LidaTube since it has no resumable queue). 3 keeps peak
+    # memory in check.
+    thread_limit: "3"
     # Run as the media user so downloaded files are owned by 8675309 and Lidarr
     # (same uid) can move them into the library during import.
     PUID: "8675309"
@@ -104,7 +108,9 @@ lidatube:
       memory: 256Mi
     limits:
       cpu: 2000m
-      memory: 1Gi
+      # Raised 1Gi -> 3Gi: FLAC conversion spikes past 1Gi and the OOM kill
+      # restarts the pod, wiping in-progress downloads.
+      memory: 3Gi
 
 # External Secrets (optional - if using ESO)
 externalSecrets:


### PR DESCRIPTION
## Summary

LidaTube was **OOMKilled** (exit 137, `reason: OOMKilled`) mid-download after exceeding its **1Gi** memory limit. FLAC conversion running `thread_limit: 6` concurrent yt-dlp+ffmpeg jobs spikes RAM past 1Gi.

Because LidaTube has **no resumable download queue**, each OOM restart wipes in-progress downloads and forces a full re-scan of Lidarr's wanted list — which presents as the app “resetting” mid-download.

## Changes
- Raise LidaTube memory limit **1Gi → 3Gi** (requests unchanged at 256Mi)
- Lower **`thread_limit` 6 → 3** to cap peak RAM (slower, but stable)

## Notes
- Pre-existing limit — not introduced by the recent PUID/download-folder changes.
- This stops the OOM-triggered restarts; it does **not** make LidaTube resume across restarts (a LidaTube limitation with no fix on our side).
- `helm template` renders clean; change is scoped to the lidatube container.