### PR TITLE
feat(authelia): add login.authoritah.tv portal route + cert

### DIFF
--- a/authelia-manifests/certificate.yaml
+++ b/authelia-manifests/certificate.yaml
@@ -11,3 +11,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - login.authoritah.com
+    - login.authoritah.tv

--- a/authelia-manifests/ingressroute.yaml
+++ b/authelia-manifests/ingressroute.yaml
@@ -15,5 +15,12 @@ spec:
     services:
     - name: authelia
       port: 9091
+  # Second portal host for multi-domain SSO — services on authoritah.tv redirect
+  # here so their .tv session cookie is issued by a same-domain portal.
+  - match: Host(`login.authoritah.tv`)
+    kind: Rule
+    services:
+    - name: authelia
+      port: 9091
   tls:
     secretName: authelia-manifests-tls


### PR DESCRIPTION
## Summary
Adds the Authelia portal on **login.authoritah.tv** (second IngressRoute host + cert dnsName) so services migrating to authoritah.tv can redirect to a same-domain portal for cookie issuance.

Additive and non-breaking — the existing login.authoritah.com portal is untouched.

## This is only the routing half
It makes the .tv portal reachable + TLS. The part that makes cross-domain SSO actually *work* — the second session cookie (domain: authoritah.tv) and the *.authoritah.tv access rule — lives in the `authelia-config` secret, which is currently out-of-band (not ESO/git-managed). That change is handled separately (bringing authelia-config under ESO).

## Prereq before merge
- **DNS:** login.authoritah.tv A record must exist (its in the media-migration DNS script list) or cert-manager cannot issue the added dnsName.