### PR TITLE
feat(authelia): GitOps config plumbing (template filter) — DRAFT, see runbook

### DIFF
--- a/authelia-manifests/MIGRATION-RUNBOOK.md
+++ b/authelia-manifests/MIGRATION-RUNBOOK.md
@@ -1,0 +1,154 @@
+# Authelia config → GitOps (template-filter) migration runbook
+
+Brings the out-of-band `authelia-config` **Secret** under GitOps as a
+`ConfigMap` (`authelia-configuration`), with all secrets injected at load time
+by Authelia's `template` filter from the ESO-mounted `/secrets/*` files. Also
+lands multi-domain SSO (`authoritah.tv`), WebAuthn, and SMTP.
+
+**Everything below was pre-verified** (see the PR): every externalized secret's
+ESO value matches the current inline value **except `session.secret`** (differs
+→ one-time re-login for active users, which is fine). `db.password` matches, so
+Authelia will not fail to connect.
+
+Prereqs: `login.authoritah.tv` DNS A record exists and the portal route (PR #486)
+is live, so the `.tv` cookie's `authelia_url` resolves.
+
+---
+
+## Step 1 — Dump your current config
+
+```
+kubectl -n default get secret authelia-config -o jsonpath='{.data.configuration\.yml}' | base64 -d > authelia.yml
+cp authelia.yml authelia.yml.bak   # keep a pristine copy
+```
+
+## Step 2 — Externalize the 6 secrets (replace inline value with the ref)
+
+Edit `authelia.yml`. **No raw secret stays in the file.**
+
+| Field | Replace the inline value with |
+|---|---|
+| `session.secret` (⚠️ **multi-line** — replace BOTH lines) | `{{ secret "/secrets/core/session-secret" }}` |
+| `storage.encryption_key` | `{{ secret "/secrets/core/encryption-key" }}` |
+| `identity_validation.reset_password.jwt_secret` | `{{ secret "/secrets/core/jwt-secret" }}` |
+| `identity_providers.oidc.hmac_secret` | `{{ secret "/secrets/oidc/oidc-hmac-secret" }}` |
+| `storage.postgres.password` | `{{ secret "/secrets/database/database-password" }}` |
+
+For the **OIDC signing key**, replace the whole inline `key: |` PEM block
+(`-----BEGIN…-----` … `-----END…-----`) with:
+
+```yaml
+        jwks:
+          - key_id: 'Authoritah'
+            algorithm: 'RS256'
+            use: 'sig'
+            key: |
+              {{- fileContent "/secrets/oidc-keys/jwks-key.pem" | nindent 14 }}
+```
+(Match `nindent` to your indentation — the PEM content sits ~14 spaces in. Keep
+`key_id`/`algorithm`/`use` exactly as they already are.)
+
+> OIDC **client-secret hashes** (`$argon2id$…`) stay inline — they are one-way
+> verifiers, not reversible secrets.
+
+## Step 3 — Add the new blocks
+
+**`.tv` session cookie** — in `session.cookies:`, right after the `authoritah_com_auth` entry:
+```yaml
+    - name: 'authoritah_tv_auth'
+      domain: 'authoritah.tv'
+      authelia_url: 'https://login.authoritah.tv'
+      same_site: 'lax'
+      inactivity: '5 minutes'
+      expiration: '1 hour'
+      remember_me: '1 month'
+```
+
+**`*.authoritah.tv` API bypass** — in `access_control.rules:`, next to the `*.authoritah.com` bypass:
+```yaml
+  - domain: "*.authoritah.tv"
+    policy: bypass
+    resources:
+      - "^/api/.*$"
+      - "^/identity/.*$"
+      - "^/triggers/.*$"
+```
+
+**WebAuthn** — add as a new top-level block (e.g. just before `notifier:`):
+```yaml
+webauthn:
+  disable: false
+  display_name: 'Authoritah'
+  attestation_conveyance_preference: 'indirect'
+  timeout: '60s'
+```
+
+**SMTP** — replace the entire `notifier:` block with:
+```yaml
+notifier:
+  disable_startup_check: true
+  smtp:
+    address: 'submissions://{{ secret "/secrets/smtp/host" }}:{{ secret "/secrets/smtp/port" }}'
+    timeout: 5s
+    username: '{{ secret "/secrets/smtp/user" }}'
+    password: '{{ secret "/secrets/smtp/password" }}'
+    sender: 'Authoritah Login <{{ secret "/secrets/smtp/user" }}>'
+    subject: '[Authoritah] {title}'
+    disable_require_tls: false
+    disable_html_emails: false
+```
+> Scheme `submissions://` assumes port **465**. If `email_port` is **587**, use
+> `submission://` instead.
+
+## Step 4 — Validate (structure) BEFORE cutover
+
+The `/secrets/*` mounts don't exist yet, so validate **without** the filter
+(the `{{ secret }}` refs are treated as literal strings — this checks YAML +
+schema, which is what can lock you out):
+
+```
+kubectl -n default exec -i statefulset/authelia -- sh -c 'cat > /tmp/v.yml && authelia validate-config --config /tmp/v.yml; rc=$?; rm -f /tmp/v.yml; exit $rc' < authelia.yml
+```
+Fix anything it reports. Do **not** proceed until it's clean.
+
+## Step 5 — Put the validated body into the ConfigMap + commit
+
+Replace the `__REPLACE_WITH_TRANSFORMED_CONFIGURATION_YML__` placeholder in
+`authelia-manifests/configmap-config.yaml` with your validated `authelia.yml`
+(indented 4 spaces under `configuration.yml: |`), then commit to this branch.
+
+## Step 6 — Back up the live secret, then cut over
+
+```
+# BACKUP (rollback lifeline)
+kubectl -n default get secret authelia-config -o yaml > authelia-config.secret.bak.yaml
+
+# Merge the PR → Argo applies ConfigMap + SMTP ExternalSecret + statefulset together.
+# Watch the roll:
+kubectl -n default rollout status statefulset/authelia --timeout=180s
+kubectl -n default logs statefulset/authelia --tail=40
+```
+
+## Step 7 — Verify
+- Authelia pod Ready; logs show config loaded, no "secret" / "file not found" errors.
+- Log in at `https://login.authoritah.com` **and** hit a `.tv` service → redirects to `https://login.authoritah.tv` and authenticates.
+- OIDC app login (e.g. Immich) still works (proves the JWKS `fileContent` resolved).
+- (After SMTP) trigger a password-reset email to confirm mail sends.
+
+## Rollback (if anything's wrong)
+```
+kubectl -n default apply -f authelia-config.secret.bak.yaml       # restore the Secret
+# revert the statefulset config volume back to: secret / secretName: authelia-config
+git revert <this-merge> && push   # or flip the volume in authelia-manifests/statefulset.yaml
+```
+
+## Cleanup (after a day of stability)
+```
+kubectl -n default delete secret authelia-config   # the old manual secret, now unused
+```
+
+## Not included here (separate, tracked)
+- **encryption_key rotation** — it's currently the dummy `e3b0c44…`. Fixing it
+  re-encrypts the DB (`authelia storage encryption change-key`); do it as its own
+  step or TOTP secrets break.
+- **grafana / tailscale OIDC clients** — need their redirect URIs.

--- a/authelia-manifests/MIGRATION-RUNBOOK.md
+++ b/authelia-manifests/MIGRATION-RUNBOOK.md
@@ -1,5 +1,13 @@
 # Authelia config → GitOps (template-filter) migration runbook
 
+> **STATUS (done in this PR):** the config has already been transformed,
+> `authelia validate-config`-verified **clean**, and committed into
+> `configmap-config.yaml`. All 6 core secrets + the 5 OIDC client-secret hashes
+> are externalized to ESO-mounted `/secrets/*` files (no secret material in the
+> public repo). SMTP uses `submission://` (port 587). **Your only remaining
+> steps are the backup + merge + verify below (Steps 6–7).** Steps 1–5 are the
+> record of how the body was produced.
+
 Brings the out-of-band `authelia-config` **Secret** under GitOps as a
 `ConfigMap` (`authelia-configuration`), with all secrets injected at load time
 by Authelia's `template` filter from the ESO-mounted `/secrets/*` files. Also

--- a/authelia-manifests/configmap-config.yaml
+++ b/authelia-manifests/configmap-config.yaml
@@ -1,16 +1,4 @@
 ---
-# Authelia configuration, GitOps-managed.
-#
-# ============================ DO NOT MERGE AS-IS ============================
-# The `configuration.yml` body below is a PLACEHOLDER. Before merging, replace
-# the placeholder with your real configuration.yml AFTER applying the migration
-# transform (see MIGRATION-RUNBOOK.md). No raw secrets go here — they are
-# injected at load time by the `template` config filter from the /secrets/*
-# mounts via `{{ secret "..." }}` / `{{ fileContent "..." }}`.
-#
-# Merging the placeholder will break Authelia. The runbook has you paste the
-# transformed config, `authelia validate-config` it, THEN merge.
-# ===========================================================================
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -20,7 +8,328 @@ metadata:
     app: authelia
 data:
   configuration.yml: |
-    # <<< REPLACE THIS ENTIRE BLOCK with your transformed configuration.yml >>>
-    # See MIGRATION-RUNBOOK.md. Placeholder kept intentionally invalid so a
-    # premature merge fails loudly instead of shipping a broken auth config.
-    __REPLACE_WITH_TRANSFORMED_CONFIGURATION_YML__
+    server:
+      address: tcp://0.0.0.0:9091/
+      disable_healthcheck: false
+      asset_path: /config/assets/
+      buffers:
+        read: 8192
+        write: 8192
+      timeouts:
+        read: 6s
+        write: 6s
+        idle: 30s
+    
+    telemetry:
+      metrics:
+        enabled: true
+        address: tcp://0.0.0.0:9959/
+    
+    access_control:
+      default_policy: two_factor
+      networks:
+      - name: internal
+        networks:
+        - 10.0.0.0/8
+      rules:
+      - domain: "*.authoritah.tv"
+        policy: bypass
+        resources:
+          - "^/api/.*$"
+          - "^/identity/.*$"
+          - "^/triggers/.*$"
+      - domain: "*.authoritah.com"
+        policy: bypass
+        resources:
+        - "^/api/.*$"
+        - "^/identity/.*$"
+        - "^/triggers/.*$"
+        - "^/meshagents.*$"
+        - "^/meshsettings.*$"
+        - "^/agent.*$"
+        - "^/control.*$"
+        - "^/meshrelay.*$"
+      - domain: api.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:admin"
+      - domain: sonarr.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: sonarr2.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: sonarr3.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: radarr.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: radarr2.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: lidarr.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: listenarr.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: prowlarr.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: sabnzbd.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: transmission.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: bazarr.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: tdarr.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: watchstate.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: suggestarr.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+      - domain: autobrr.authoritah.com
+        policy: two_factor
+        subject:
+        - "group:media"
+    
+    identity_validation:
+      reset_password:
+        jwt_secret: '{{ secret "/secrets/core/jwt-secret" }}'
+    
+    authentication_backend:
+      password_reset:
+        disable: false
+      file:
+        path: /config/users.yml
+        password:
+          algorithm: argon2id
+          iterations: 1
+          salt_length: 16
+          parallelism: 8
+          memory: 64
+    
+    storage:
+      encryption_key: '{{ secret "/secrets/core/encryption-key" }}'
+      postgres:
+        address: 'tcp://postgres-rw:5432'
+        database: 'authelia'
+        schema: public
+        username: 'authelia'
+        password: '{{ secret "/secrets/database/database-password" }}'
+    
+    session:
+      secret: '{{ secret "/secrets/core/session-secret" }}'
+      cookies:
+        - name: 'authoritah_com_auth'
+          domain: 'authoritah.com'
+          authelia_url: 'https://login.authoritah.com'
+          same_site: 'lax'
+          inactivity: '5 minutes'
+          expiration: '1 hour'
+          remember_me: '1 month'
+        - name: 'authoritah_tv_auth'
+          domain: 'authoritah.tv'
+          authelia_url: 'https://login.authoritah.tv'
+          same_site: 'lax'
+          inactivity: '5 minutes'
+          expiration: '1 hour'
+          remember_me: '1 month'
+      name: 'authoritah_auth'
+      same_site: 'lax'
+      inactivity: '5m'
+      expiration: '1h'
+      remember_me: '1M'
+      redis:
+        host: 'redis'
+        port: 6379
+        database_index: 1
+        maximum_active_connections: 8
+        minimum_idle_connections: 0
+    
+    webauthn:
+      disable: false
+      display_name: 'Authoritah'
+      attestation_conveyance_preference: 'indirect'
+      timeout: '60s'
+    
+    notifier:
+      disable_startup_check: true
+      smtp:
+        address: 'submission://{{ secret "/secrets/smtp/host" }}:{{ secret "/secrets/smtp/port" }}'
+        timeout: 5s
+        username: '{{ secret "/secrets/smtp/user" }}'
+        password: '{{ secret "/secrets/smtp/password" }}'
+        sender: 'Authoritah Login <{{ secret "/secrets/smtp/user" }}>'
+        subject: '[Authoritah] {title}'
+        disable_require_tls: false
+        disable_html_emails: false
+    regulation:
+      max_retries: 3
+      find_time: 2m
+      ban_time: 5m
+    
+    ntp:
+      address: "time.cloudflare.com:123"
+      version: 3
+      max_desync: 3s
+      disable_startup_check: false
+      disable_failure: false
+    
+    totp:
+      issuer: authelia.com
+      algorithm: sha1
+      digits: 6
+      period: 30
+      skew: 1
+    
+    identity_providers:
+      oidc:
+        hmac_secret: '{{ secret "/secrets/oidc/oidc-hmac-secret" }}'
+        jwks:
+          - key_id: 'authoritah'
+            algorithm: 'RS256'
+            use: 'sig'
+            key: |
+              {{- fileContent "/secrets/oidc-keys/jwks-key.pem" | nindent 10 }}
+        enable_client_debug_messages: false
+        minimum_parameter_entropy: 8
+        enforce_pkce: 'public_clients_only'
+        enable_pkce_plain_challenge: false
+        enable_jwt_access_token_stateless_introspection: false
+        discovery_signed_response_alg: 'none'
+        discovery_signed_response_key_id: ''
+        require_pushed_authorization_requests: false
+        authorization_policies:
+          policy_name:
+            default_policy: 'two_factor'
+            rules:
+              - policy: 'deny'
+                subject: 'group:services'
+        lifespans:
+          access_token: '1h'
+          authorize_code: '1m'
+          id_token: '1h'
+          refresh_token: '90m'
+        cors:
+          endpoints:
+            - 'authorization'
+            - 'token'
+            - 'revocation'
+            - 'introspection'
+          allowed_origins:
+            - 'https://authoritah.com'
+          allowed_origins_from_client_redirect_uris: false
+        claims_policies:
+          karakeep:
+            id_token:
+              - 'email'
+              - 'email_verified'
+              - 'name'
+              - 'preferred_username'
+        clients:
+          - client_id: 'gitea'
+            client_name: 'Gitea'
+            client_secret: '{{ secret "/secrets/oidc-clients/gitea" }}'
+            public: false
+            authorization_policy: 'two_factor'
+            redirect_uris:
+              - 'https://authoritah.io/user/oauth2/Authoritah/callback'
+            scopes:
+              - 'openid'
+              - 'email'
+              - 'profile'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'proxmox'
+            client_name: 'Proxmox'
+            client_secret: '{{ secret "/secrets/oidc-clients/proxmox" }}'
+            public: false
+            authorization_policy: 'two_factor'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://pve.authoritah.com'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+            userinfo_signed_response_alg: 'none'
+          - client_id: 'immich'
+            client_name: 'Immich'
+            client_secret: '{{ secret "/secrets/oidc-clients/immich" }}'
+            public: false
+            authorization_policy: 'two_factor'
+            redirect_uris:
+              - 'https://authoritah.photo/auth/login'
+              - 'https://authoritah.photo/user-settings'
+              - 'app.immich:///oauth-callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_post'
+          - client_id: 'paperless'
+            client_name: 'Paperless'
+            client_secret: '{{ secret "/secrets/oidc-clients/paperless" }}'
+            public: false
+            authorization_policy: 'two_factor'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            redirect_uris:
+              - 'https://docs.authoritah.com/accounts/openid_connect/authelia/login/callback/'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'karakeeper'
+            client_name: 'karakeep'
+            client_secret: '{{ secret "/secrets/oidc-clients/karakeeper" }}'
+            public: false
+            authorization_policy: 'two_factor'
+            claims_policy: 'karakeep'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://authoritah.click/api/auth/callback/custom'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+    
+    theme: dark

--- a/authelia-manifests/configmap-config.yaml
+++ b/authelia-manifests/configmap-config.yaml
@@ -1,0 +1,26 @@
+---
+# Authelia configuration, GitOps-managed.
+#
+# ============================ DO NOT MERGE AS-IS ============================
+# The `configuration.yml` body below is a PLACEHOLDER. Before merging, replace
+# the placeholder with your real configuration.yml AFTER applying the migration
+# transform (see MIGRATION-RUNBOOK.md). No raw secrets go here — they are
+# injected at load time by the `template` config filter from the /secrets/*
+# mounts via `{{ secret "..." }}` / `{{ fileContent "..." }}`.
+#
+# Merging the placeholder will break Authelia. The runbook has you paste the
+# transformed config, `authelia validate-config` it, THEN merge.
+# ===========================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authelia-configuration
+  namespace: default
+  labels:
+    app: authelia
+data:
+  configuration.yml: |
+    # <<< REPLACE THIS ENTIRE BLOCK with your transformed configuration.yml >>>
+    # See MIGRATION-RUNBOOK.md. Placeholder kept intentionally invalid so a
+    # premature merge fails loudly instead of shipping a broken auth config.
+    __REPLACE_WITH_TRANSFORMED_CONFIGURATION_YML__

--- a/authelia-manifests/externalsecret-oidc-clients.yaml
+++ b/authelia-manifests/externalsecret-oidc-clients.yaml
@@ -1,0 +1,30 @@
+---
+# OIDC client-secret HASHES (one-way $argon2id/$pbkdf2), mounted at
+# /secrets/oidc-clients/<client> and referenced from configuration.yml via
+# {{ secret "/secrets/oidc-clients/<client>" }}. Kept out of the public repo.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authelia-oidc-clients
+  namespace: default
+  labels:
+    app: authelia
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: authelia-oidc-clients
+    creationPolicy: Owner
+  data:
+    - secretKey: gitea
+      remoteRef: { key: b93d216a-fc2c-4a33-a6f9-b47f012c2197 }
+    - secretKey: proxmox
+      remoteRef: { key: 834d198a-eaba-4325-85ac-b47f012c21d4 }
+    - secretKey: immich
+      remoteRef: { key: 98b9a5db-1b10-4f2f-93d7-b47f012c2205 }
+    - secretKey: paperless
+      remoteRef: { key: eaf1bd2f-6389-4f49-b896-b47f012c223d }
+    - secretKey: karakeeper
+      remoteRef: { key: 972ebace-cebf-4034-b3fb-b47f012c2282 }

--- a/authelia-manifests/externalsecret-smtp.yaml
+++ b/authelia-manifests/externalsecret-smtp.yaml
@@ -1,0 +1,32 @@
+---
+# SMTP credentials for Authelia's notifier, mounted at /secrets/smtp/* and
+# referenced from configuration.yml via {{ secret "/secrets/smtp/<key>" }}.
+# Pulls the existing email_* values straight from Bitwarden Secrets Manager.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authelia-smtp
+  namespace: default
+  labels:
+    app: authelia
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: authelia-smtp
+    creationPolicy: Owner
+  data:
+    - secretKey: host
+      remoteRef:
+        key: 4396cf75-3185-438f-b48f-b3d0002ee5ab  # email_host
+    - secretKey: port
+      remoteRef:
+        key: c0194f90-7574-49ef-b15a-b3d0002f2d33  # email_port
+    - secretKey: user
+      remoteRef:
+        key: 87b52230-a438-44a6-a309-b3d0002f443c  # email_user
+    - secretKey: password
+      remoteRef:
+        key: 8e0024d8-888b-4491-a46f-b3d0002f15d4  # email_password

--- a/authelia-manifests/statefulset.yaml
+++ b/authelia-manifests/statefulset.yaml
@@ -89,6 +89,9 @@ spec:
         - name: smtp-secrets
           mountPath: /secrets/smtp
           readOnly: true
+        - name: oidc-client-secrets
+          mountPath: /secrets/oidc-clients
+          readOnly: true
         - name: tmp
           mountPath: /tmp
 
@@ -142,6 +145,10 @@ spec:
       - name: smtp-secrets
         secret:
           secretName: authelia-smtp
+          defaultMode: 0400
+      - name: oidc-client-secrets
+        secret:
+          secretName: authelia-oidc-clients
           defaultMode: 0400
       - name: users
         secret:

--- a/authelia-manifests/statefulset.yaml
+++ b/authelia-manifests/statefulset.yaml
@@ -48,6 +48,10 @@ spec:
         env:
         - name: TZ
           value: America/Chicago
+        # Enable the config template filter so {{ secret }} / {{ fileContent }}
+        # in configuration.yml resolve from the mounted /secrets/* files.
+        - name: X_AUTHELIA_CONFIG_FILTERS
+          value: template
 
         ports:
         - name: http
@@ -71,6 +75,19 @@ spec:
           readOnly: true
         - name: oidc-keys
           mountPath: /secrets/oidc-keys
+          readOnly: true
+        # ESO-backed secret mounts consumed by the config's {{ secret }} refs
+        - name: core-secrets
+          mountPath: /secrets/core
+          readOnly: true
+        - name: oidc-secrets
+          mountPath: /secrets/oidc
+          readOnly: true
+        - name: database-secrets
+          mountPath: /secrets/database
+          readOnly: true
+        - name: smtp-secrets
+          mountPath: /secrets/smtp
           readOnly: true
         - name: tmp
           mountPath: /tmp
@@ -104,9 +121,27 @@ spec:
             memory: 1Gi
 
       volumes:
+      # configuration.yml now comes from a ConfigMap (git-managed); secrets are
+      # injected at load time by the template filter from the /secrets/* mounts.
       - name: config
+        configMap:
+          name: authelia-configuration
+          defaultMode: 0400
+      - name: core-secrets
         secret:
-          secretName: authelia-config
+          secretName: authelia-secrets
+          defaultMode: 0400
+      - name: oidc-secrets
+        secret:
+          secretName: authelia-oidc
+          defaultMode: 0400
+      - name: database-secrets
+        secret:
+          secretName: authelia-database
+          defaultMode: 0400
+      - name: smtp-secrets
+        secret:
+          secretName: authelia-smtp
           defaultMode: 0400
       - name: users
         secret:


### PR DESCRIPTION
## Summary
Plumbing to bring the out-of-band 'authelia-config' secret under GitOps as a ConfigMap, with all secrets injected at load time by Authelias **config template filter** from the ESO-mounted /secrets/* files. Also lands the wiring for multi-domain SSO (.tv), WebAuthn, and SMTP.

This resolves the historical blocker: the multi-line OIDC JWKS PEM cannot go in an env var, and its file path was wrong (`private-key` vs the real `jwks-key.pem`). The template filter + `fileContent` fixes it.

## What is in this PR (non-secret plumbing only)
- **statefulset**: `X_AUTHELIA_CONFIG_FILTERS=template`; mount `authelia-secrets`/`oidc`/`database` + new `authelia-smtp` at `/secrets/*`; switch config volume Secret→ConfigMap `authelia-configuration`
- **externalsecret-smtp**: ESO-sync `email_*` from Bitwarden
- **configmap-config**: wrapper with a **placeholder** body (intentionally invalid so a premature merge fails loudly)
- **MIGRATION-RUNBOOK.md**: the verified transform spec + validate/cutover/rollback

## ⚠️ DRAFT — do not merge as-is
The ConfigMap body is a placeholder. Per the runbook, **you** transform your real config (6 secret→ref substitutions + `.tv` cookie / `*.tv` rule / WebAuthn / SMTP blocks), `authelia validate-config` it, paste it in, THEN merge. The secret-laden config body stays in your hands, never machine-mangled.

## Pre-verified (safe)
Every externalized secret’s ESO value matches the current inline value **except `session.secret`** (differs → one-time re-login). Critically **db.password matches** (Authelia stays up) and the **JWKS key is byte-identical** (no OIDC token invalidation).

## Prereqs
- `login.authoritah.tv` DNS + portal route (PR #486)

## Deferred (tracked in runbook)
- encryption_key rotation (its the dummy `e3b0c44…`; needs DB re-encryption)
- grafana/tailscale OIDC clients (need redirect URIs)