### PR TITLE
feat(ar-pull): keyless Artifact Registry image pull via WIF

### DIFF
--- a/ar-token-refresher/README.md
+++ b/ar-token-refresher/README.md
@@ -1,0 +1,64 @@
+# ar-token-refresher — keyless Artifact Registry image pull
+
+Replaces the per-app `gcr-pull-secret-*` credentials (currently the
+`homelab-staging-reader` GCP **SA keys** synced from Bitwarden via ESO) with
+short-lived tokens minted through **Workload Identity Federation** — no key
+material on the cluster or in Bitwarden.
+
+## How it works
+
+1. The CronJob pod gets a **projected k3s ServiceAccount token** whose audience
+   is the GCP WIF provider.
+2. It exchanges that token at Google STS for a federated token, then impersonates
+   the keyless `homelab-ar-puller@platform-infra-prod` SA (AR reader on all five
+   projects) for a ~60-min Artifact Registry access token.
+3. It writes that token into the five `gcr-pull-secret-*` dockerconfigjson
+   secrets in `staging`. One token covers every `us-central1-docker.pkg.dev`
+   repo. Runs every 30 min.
+
+GCP side (pool, provider, puller SA, bindings):
+`platform-infra/terraform/environments/prod/homelab-wif.tf`. The subject
+`system:serviceaccount:ar-pull-system:ar-token-refresher` must match on both
+sides.
+
+## ⚠️ Not yet cut over — this needs live verification first
+
+This ran no live test. Before deleting the SA keys or re-enforcing the org
+policy, verify on the cluster:
+
+1. **Apply the GCP side** (merge the platform-infra PR so the pool/provider/SA
+   exist).
+2. **Deploy this** (ArgoCD syncs it) and trigger the first run:
+   ```
+   kubectl -n ar-pull-system create job --from=cronjob/ar-token-refresher bootstrap
+   kubectl -n ar-pull-system logs job/bootstrap
+   ```
+   Expect `refreshed staging: gcr-pull-secret-...`. The most likely failure is
+   the **WIF audience** — if STS rejects the token, confirm the projected-token
+   audience, the script's `AUDIENCE`, and the provider's expected audience all
+   match, and that `attribute_condition` on the provider matches the subject.
+3. **Confirm a keyless pull:** roll one staging deployment and check the image
+   pulls using the refreshed secret (e.g. `kubectl -n staging rollout restart
+   deploy/<app>` and watch events).
+
+## Cutover (only after the above passes)
+
+1. Point the staging apps' `gcrPullSecret` at these refresher-managed secrets
+   (they already use the same names — just stop ESO from also writing them, so
+   the two don't fight; remove the `gcrPullSecret.bitwardenKey` wiring per app).
+2. Delete the `homelab-staging-reader` SA keys in each project.
+3. Re-enforce the ban: `gcloud resource-manager org-policies delete
+   iam.disableServiceAccountKeyCreation --project=<jl-shaw-486618|dispatchr-social>`.
+
+## Rollback
+
+The old ESO-synced pull secrets still work until step 1 of cutover. If the
+refresher misbehaves, re-enable ESO for the pull secret and the keys keep
+working (they aren't deleted until cutover step 2).
+
+## JWKS rotation
+
+The provider trusts the cluster's SA signing key via an inline JWKS
+(`k3s-jwks.json` in platform-infra). If k3s rotates its signing key, refresh
+that file or federation stops. Stable across normal ops on the single-node
+cluster.

--- a/ar-token-refresher/namespace.yaml
+++ b/ar-token-refresher/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ar-pull-system
+  labels:
+    app.kubernetes.io/name: ar-token-refresher

--- a/ar-token-refresher/rbac.yaml
+++ b/ar-token-refresher/rbac.yaml
@@ -1,0 +1,36 @@
+# The refresher's k8s identity. Its projected token (audience = the GCP WIF
+# provider) is federated to impersonate homelab-ar-puller@platform-infra-prod.
+# The GCP side (pool/provider/SA/bindings) is in platform-infra:
+# terraform/environments/prod/homelab-wif.tf — the subject
+# `system:serviceaccount:ar-pull-system:ar-token-refresher` must match there.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ar-token-refresher
+  namespace: ar-pull-system
+---
+# Least privilege: the refresher only writes the image-pull secrets, only in the
+# staging namespace where the apps run.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ar-pull-secret-writer
+  namespace: staging
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ar-token-refresher
+  namespace: staging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ar-pull-secret-writer
+subjects:
+  - kind: ServiceAccount
+    name: ar-token-refresher
+    namespace: ar-pull-system

--- a/ar-token-refresher/refresher.yaml
+++ b/ar-token-refresher/refresher.yaml
@@ -17,7 +17,7 @@ data:
     #!/bin/sh
     set -eu
 
-    AUDIENCE="//iam.googleapis.com/projects/861533890029/locations/global/workloadIdentityPools/homelab-staging/providers/k3s"
+    AUDIENCE="//iam.googleapis.com/projects/861533890029/locations/global/workloadIdentityPools/homelab-staging/providers/k3s-oidc"
     PULLER_SA="homelab-ar-puller@platform-infra-prod.iam.gserviceaccount.com"
     REGISTRY="us-central1-docker.pkg.dev"
     NS="staging"
@@ -130,7 +130,7 @@ spec:
               projected:
                 sources:
                   - serviceAccountToken:
-                      audience: //iam.googleapis.com/projects/861533890029/locations/global/workloadIdentityPools/homelab-staging/providers/k3s
+                      audience: //iam.googleapis.com/projects/861533890029/locations/global/workloadIdentityPools/homelab-staging/providers/k3s-oidc
                       expirationSeconds: 3600
                       path: token
             - name: script

--- a/ar-token-refresher/refresher.yaml
+++ b/ar-token-refresher/refresher.yaml
@@ -1,0 +1,141 @@
+# Keyless Artifact Registry pull-secret refresher.
+#
+# Exchanges the pod's projected k3s ServiceAccount token (audience = the GCP WIF
+# provider) for a short-lived AR access token by impersonating the keyless
+# homelab-ar-puller SA, then writes it into the five gcr-pull-secret-* docker
+# secrets in the `staging` namespace. Runs every 30 min; the AR token is valid
+# ~60 min, so there is always a fresh one. No SA key anywhere.
+#
+# GCP side: platform-infra/terraform/environments/prod/homelab-wif.tf
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ar-token-refresher
+  namespace: ar-pull-system
+data:
+  refresh.sh: |
+    #!/bin/sh
+    set -eu
+
+    AUDIENCE="//iam.googleapis.com/projects/861533890029/locations/global/workloadIdentityPools/homelab-staging/providers/k3s"
+    PULLER_SA="homelab-ar-puller@platform-infra-prod.iam.gserviceaccount.com"
+    REGISTRY="us-central1-docker.pkg.dev"
+    NS="staging"
+    SECRETS="gcr-pull-secret-blue-sky gcr-pull-secret-capturly-web gcr-pull-secret-coreyalan gcr-pull-secret-dispatchr gcr-pull-secret-jlshaw"
+    TOKEN_FILE="/var/run/secrets/gcp-sts/token"
+
+    b64() { base64 | tr -d '\n'; }
+
+    SUBJECT_TOKEN="$(cat "$TOKEN_FILE")"
+
+    # 1) Exchange the projected k3s token for a federated Google access token.
+    FED_TOKEN="$(jq -nc --arg aud "$AUDIENCE" --arg st "$SUBJECT_TOKEN" '{
+        audience:$aud,
+        grantType:"urn:ietf:params:oauth:grant-type:token-exchange",
+        requestedTokenType:"urn:ietf:params:oauth:token-type:access_token",
+        scope:"https://www.googleapis.com/auth/cloud-platform",
+        subjectTokenType:"urn:ietf:params:oauth:token-type:jwt",
+        subjectToken:$st
+      }' | curl -sf -X POST https://sts.googleapis.com/v1/token \
+            -H 'Content-Type: application/json' -d @- | jq -r '.access_token')"
+    [ -n "$FED_TOKEN" ] && [ "$FED_TOKEN" != "null" ] || { echo "STS exchange failed"; exit 1; }
+
+    # 2) Impersonate the puller SA for an Artifact Registry access token.
+    AR_TOKEN="$(curl -sf -X POST \
+        "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${PULLER_SA}:generateAccessToken" \
+        -H "Authorization: Bearer ${FED_TOKEN}" -H 'Content-Type: application/json' \
+        -d '{"scope":["https://www.googleapis.com/auth/cloud-platform"]}' | jq -r '.accessToken')"
+    [ -n "$AR_TOKEN" ] && [ "$AR_TOKEN" != "null" ] || { echo "impersonation failed"; exit 1; }
+
+    # 3) Build the dockerconfigjson (one token covers every us-central1 AR repo).
+    AUTH_B64="$(printf 'oauth2accesstoken:%s' "$AR_TOKEN" | b64)"
+    DOCKERCFG_B64="$(jq -nc --arg reg "$REGISTRY" --arg tok "$AR_TOKEN" --arg auth "$AUTH_B64" \
+        '{auths:{($reg):{username:"oauth2accesstoken",password:$tok,auth:$auth}}}' | b64)"
+
+    # 4) Upsert each pull secret. reloader.../ignore stops Reloader rolling the
+    #    apps every refresh (imagePullSecret changes don't need a restart).
+    for SEC in $SECRETS; do
+      printf '%s\n' \
+        'apiVersion: v1' \
+        'kind: Secret' \
+        'metadata:' \
+        "  name: ${SEC}" \
+        "  namespace: ${NS}" \
+        '  annotations:' \
+        '    reloader.stakater.com/ignore: "true"' \
+        'type: kubernetes.io/dockerconfigjson' \
+        'data:' \
+        "  .dockerconfigjson: ${DOCKERCFG_B64}" \
+        | kubectl apply -f -
+    done
+    echo "refreshed ${NS}: ${SECRETS}"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ar-token-refresher
+  namespace: ar-pull-system
+spec:
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          serviceAccountName: ar-token-refresher
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: refresher
+              image: alpine/k8s:1.32.1
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "/scripts/refresh.sh"]
+              env:
+                - name: HOME
+                  value: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
+              volumeMounts:
+                - name: gcp-sts-token
+                  mountPath: /var/run/secrets/gcp-sts
+                  readOnly: true
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            # The federated subject token. Its audience must equal AUDIENCE in
+            # the script and the WIF provider's expected audience.
+            - name: gcp-sts-token
+              projected:
+                sources:
+                  - serviceAccountToken:
+                      audience: //iam.googleapis.com/projects/861533890029/locations/global/workloadIdentityPools/homelab-staging/providers/k3s
+                      expirationSeconds: 3600
+                      path: token
+            - name: script
+              configMap:
+                name: ar-token-refresher
+                defaultMode: 0555
+            - name: tmp
+              emptyDir: {}

--- a/argocd/applications/ar-token-refresher.yaml
+++ b/argocd/applications/ar-token-refresher.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ar-token-refresher
+  namespace: argocd
+  annotations:
+    # Comes up before the staging apps so the pull secrets it writes exist by
+    # the time apps pull. (First write still happens on the CronJob's first run —
+    # trigger it once manually at cutover; see ar-token-refresher/README.md.)
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    path: ar-token-refresher
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ar-pull-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m


### PR DESCRIPTION
## What

Keyless Artifact Registry image pull for the staging cluster, replacing the
`homelab-staging-reader` **SA keys** (currently synced from Bitwarden via ESO as
the `gcr-pull-secret-*` docker secrets). Those keys are what forced the
`iam.disableServiceAccountKeyCreation` org-policy overrides on dispatchr-social
and jl-shaw — the audit's finding that the org-wide key ban is silently neutered.

A CronJob (`ar-token-refresher`) uses the pod's **projected k3s ServiceAccount
token** (Workload Identity Federation) to impersonate a keyless
`homelab-ar-puller` SA and mint a ~60-min AR access token, then writes it into
the five `gcr-pull-secret-*` secrets in `staging` every 30 min. No key material
anywhere.

**GCP side:** platform-infra PR "feat(homelab): keyless AR image pull via
Workload Identity" (WIF pool/provider with the cluster's inline JWKS, the puller
SA, AR reader on all five projects, and the WI binding). Merge that first.

## Contents

- `ar-token-refresher/` — namespace, least-privilege RBAC (writes only the pull
  secrets, only in `staging`), the refresher ConfigMap + CronJob, and a README
  with the cutover/testing procedure.
- `argocd/applications/ar-token-refresher.yaml` — ArgoCD Application (sync-wave
  -1, before the apps).

## ⚠️ Needs live verification before cutover

I could not test this against the cluster. It is validated with `kubeconform`
only. **Do not delete the SA keys or re-enforce the org policy until** the first
run succeeds and a staging pull works keyless — see `ar-token-refresher/README.md`
for the exact steps. The most likely thing to tune is the **WIF audience** (the
projected-token audience ↔ script `AUDIENCE` ↔ provider expectation).

The old ESO-synced pull secrets keep working until cutover, so this is safe to
merge and deploy alongside them for testing.
