### PR TITLE
fix(coredns): add login.authoritah.tv so its cert can issue

### DIFF
--- a/coredns/configmap.yaml
+++ b/coredns/configmap.yaml
@@ -41,6 +41,7 @@ data:
     10.43.5.100 authoritah.com
     10.43.5.100 www.authoritah.com
     10.43.5.100 login.authoritah.com
+    10.43.5.100 login.authoritah.tv
     10.43.5.100 dashboard.authoritah.com
     10.43.5.100 api.authoritah.com
     10.43.5.100 cd.authoritah.com


### PR DESCRIPTION
cert-manager HTTP-01 self-check for `login.authoritah.tv` was timing out because it wasn't in coredns split-DNS (fell through to the external IP). Adding it -> the Traefik ingress IP lets the challenge validate internally, same as `login.authoritah.com`. Fixes the `authelia-manifests-tls` cert stuck `Ready=False` (and the resulting Argo `Progressing`). No DNS-01 infra needed.