### PR TITLE
feat(authelia): grafana + tailscale OIDC clients

### DIFF
--- a/authelia-manifests/configmap-config.yaml
+++ b/authelia-manifests/configmap-config.yaml
@@ -332,4 +332,31 @@ data:
             userinfo_signed_response_alg: 'none'
             token_endpoint_auth_method: 'client_secret_basic'
     
+          - client_id: 'grafana'
+            client_name: 'Grafana'
+            client_secret: '{{ secret "/secrets/oidc-clients/grafana" }}'
+            public: false
+            authorization_policy: 'two_factor'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://grafana.authoritah.com/login/generic_oauth'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            userinfo_signed_response_alg: 'none'
+          - client_id: 'kbrfZnEnfC11CNTRL'
+            client_name: 'Tailscale'
+            client_secret: '{{ secret "/secrets/oidc-clients/tailscale" }}'
+            public: false
+            authorization_policy: 'two_factor'
+            redirect_uris:
+              - 'https://login.tailscale.com/a/oauth_response'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+            userinfo_signed_response_alg: 'none'
     theme: dark

--- a/authelia-manifests/externalsecret-oidc-clients.yaml
+++ b/authelia-manifests/externalsecret-oidc-clients.yaml
@@ -28,3 +28,7 @@ spec:
       remoteRef: { key: eaf1bd2f-6389-4f49-b896-b47f012c223d }
     - secretKey: karakeeper
       remoteRef: { key: 972ebace-cebf-4034-b3fb-b47f012c2282 }
+    - secretKey: grafana
+      remoteRef: { key: 552c3029-2631-4a78-bfdd-b47f0144b2cf }
+    - secretKey: tailscale
+      remoteRef: { key: 3e87f390-481b-4aef-b006-b47f0144b4a5 }


### PR DESCRIPTION
Adds two OIDC clients to the (now git-managed) Authelia config.

| Client | client_id | redirect_uri |
|---|---|---|
| Grafana | \`grafana\` | \`https://grafana.authoritah.com/login/generic_oauth\` (derived from grafana.ini root_url + generic_oauth) |
| Tailscale | \`kbrfZnEnfC11CNTRL\` | \`https://login.tailscale.com/a/oauth_response\` |

- Grafana: PKCE (S256) + \`groups\` scope (grafana.ini uses role_attribute_path on groups). Its auth_url/token_url already point at login.authoritah.com.
- Client-secret **hashes** externalized to Bitwarden and synced via the existing \`authelia-oidc-clients\` ExternalSecret -> \`/secrets/oidc-clients/{grafana,tailscale}\` (no secret material in this public repo).
- \`authelia validate-config\`: clean (plaintext warnings are validation-dummy artifacts only).

## After merge
- **Manual restart required** (no reloader on the authelia statefulset): \`kubectl -n default rollout restart statefulset/authelia\` so it loads the new clients.

## ⚠️ Confirm
- **Tailscale redirect URI** is the standard custom-OIDC callback \`https://login.tailscale.com/a/oauth_response\` — verify it matches what your Tailscale admin console expects (that side is not in this repo). Grafana is fully derived from the codebase.