### PR TITLE
fix(authelia): scope ACL bypass to media hosts, remove wildcard + mesh rules

### DIFF
--- a/authelia-manifests/configmap-config.yaml
+++ b/authelia-manifests/configmap-config.yaml
@@ -32,23 +32,40 @@ data:
         networks:
         - 10.0.0.0/8
       rules:
-      - domain: "*.authoritah.tv"
-        policy: bypass
-        resources:
-          - "^/api/.*$"
-          - "^/identity/.*$"
-          - "^/triggers/.*$"
-      - domain: "*.authoritah.com"
+      # Media/app APIs only. Mobile + integration clients (Prowlarr sync,
+      # Jellyseerr, nzb360/LunaSea, etc.) authenticate with the app's own API
+      # key, so Authelia is bypassed on API paths. Scoped to specific hosts —
+      # NOT a wildcard — so infra hosts (grafana/metrics/alerts/cd/pve/…) keep
+      # full two_factor on their /api surface.
+      - domain:
+        - sonarr.authoritah.com
+        - sonarr2.authoritah.com
+        - sonarr3.authoritah.com
+        - radarr.authoritah.com
+        - radarr2.authoritah.com
+        - lidarr.authoritah.com
+        - listenarr.authoritah.com
+        - lidatube.authoritah.com
+        - prowlarr.authoritah.com
+        - sabnzbd.authoritah.com
+        - transmission.authoritah.com
+        - bazarr.authoritah.com
+        - tdarr.authoritah.com
+        - watchstate.authoritah.com
+        - suggestarr.authoritah.com
+        - autobrr.authoritah.com
+        - sportarr.authoritah.com
+        - slskd.authoritah.com
+        - jellyfin.authoritah.com
+        - request.authoritah.com
+        - request.authoritah.tv
+        - join.authoritah.tv
+        - stats.authoritah.tv
         policy: bypass
         resources:
         - "^/api/.*$"
         - "^/identity/.*$"
         - "^/triggers/.*$"
-        - "^/meshagents.*$"
-        - "^/meshsettings.*$"
-        - "^/agent.*$"
-        - "^/control.*$"
-        - "^/meshrelay.*$"
       - domain: api.authoritah.com
         policy: two_factor
         subject:


### PR DESCRIPTION
The Authelia access-control rules used wildcard `bypass` policies on `*.authoritah.tv` and `*.authoritah.com` for `^/api/`, `^/identity/` and `^/triggers/`. Because those wildcards match every subdomain, they exposed the unauthenticated APIs of infra hosts that rely on Authelia as their only gate:

- `metrics.authoritah.com/api/v1/*` (Prometheus — no native auth)
- `alerts.authoritah.com/api/v2/*` (Alertmanager — no native auth)
- `grafana.authoritah.com/api/*` (Grafana data/admin API)
- also `cd` (ArgoCD) and `pve` (Proxmox)

## Change
- Replace the two wildcard bypass rules with a single rule scoped to an explicit allowlist of the media/app hosts whose API-key clients (Prowlarr sync, Jellyseerr, mobile apps) legitimately need an unauthenticated `/api`.
- Infra hosts now fall through to `default_policy: two_factor`.
- Remove the vestigial MeshCentral agent-path bypasses (`/meshagents`, `/agent`, `/control`, `/meshrelay`, `/meshsettings`) — no MeshCentral is deployed; the paths were carried over from the pre-GitOps config migration.

## Verification
- Embedded Authelia config parses; no wildcards remain in any bypass rule; asserted `grafana`/`metrics`/`alerts`/`cd`/`pve` are not present in any bypass.
- Behaviour-preserving for the media hosts (they already had `/api` bypassed).

## Post-merge checks
- `metrics.authoritah.com/api/v1/query` and `grafana.authoritah.com/api/health` should now redirect to Authelia login.
- Confirm media integrations (Prowlarr→*arr, Jellyseerr, mobile apps) still work.
- Authelia may need a config reload / pod restart to pick up the ConfigMap.