### PR TITLE
fix(eso): scope kubernetes-provider secret access to secrets-vault

### DIFF
--- a/external-secrets-operator/manifests/eso-rbac.yaml
+++ b/external-secrets-operator/manifests/eso-rbac.yaml
@@ -1,18 +1,44 @@
 ---
-# ClusterRole for ESO to read secrets from secrets-vault
+# ESO's Kubernetes provider reads secrets ONLY from the secrets-vault namespace
+# (the kubernetes-backend ClusterSecretStore's remoteNamespace), so secret
+# access is scoped there with a namespaced Role instead of a cluster-wide
+# ClusterRole. This removes the operator SA's read access to secrets in every
+# other namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: external-secrets-kubernetes-provider
+  namespace: secrets-vault
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: external-secrets-kubernetes-provider
+  namespace: secrets-vault
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: external-secrets-kubernetes-provider
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets-operator
+    namespace: external-secrets-system
+---
+# Namespaces are cluster-scoped, so the provider's namespace-metadata read must
+# stay in a ClusterRole. This grants no access to secrets.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: external-secrets-kubernetes-provider
 rules:
   - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]
 ---
-# ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
The `external-secrets-kubernetes-provider` ClusterRole granted the `external-secrets-operator` ServiceAccount `get`/`list`/`watch` on **secrets in every namespace**, but the `kubernetes-backend` ClusterSecretStore it serves only reads from `remoteNamespace: secrets-vault`. The cluster-wide grant was far broader than the store needs.

## Change
- Move secret access to a namespaced `Role` + `RoleBinding` in `secrets-vault`.
- Keep only namespace-metadata read (`namespaces`, a cluster-scoped resource) in the `ClusterRole`; it grants no access to secrets.

Net effect: the operator SA can no longer read secrets in any namespace other than `secrets-vault`.

## Verification
- Manifest parses (4 resources: Role, RoleBinding, ClusterRole, ClusterRoleBinding).
- Asserted the ClusterRole no longer grants `secrets`, and the namespaced Role grants `secrets` in `secrets-vault`.

## Post-merge check
- Confirm the ExternalSecrets backed by the `kubernetes-backend` store still reconcile (monitoring, postgresql, argocd-notifications, authelia, gitea, matrix).