### PR TITLE
fix(matrix): restrict synapse-admin UI to internal networks

### DIFF
--- a/helm-charts/matrix/templates/synapse-admin.yaml
+++ b/helm-charts/matrix/templates/synapse-admin.yaml
@@ -97,6 +97,12 @@ spec:
   routes:
     - match: Host(`{{ .Values.synapseAdmin.host }}`)
       kind: Rule
+      middlewares:
+        # Restrict the admin UI to trusted internal networks (RFC1918). The
+        # coreyalan.com domain has no Authelia session cookie / login portal, so
+        # an IP allowlist is the right gate here rather than forward-auth.
+        - name: internal-only
+          namespace: default
       services:
         - name: matrix-synapse-admin
           port: 80


### PR DESCRIPTION
The `matrix-synapse-admin` IngressRoute (`admin.coreyalan.com`) had **no middleware** — the Synapse admin panel was reachable from the internet behind only its own admin-token login. A publicly-exposed homeserver admin UI is a high-value target.

## Change
Attach the existing `internal-only` ipAllowList middleware (cross-namespace ref to `default`) to the admin route, restricting it to RFC1918 networks (`10/8`, `172.16/12`, `192.168/16`, loopback). The Matrix server itself and all other Matrix routes are unaffected.

Authelia forward-auth is intentionally **not** used here: `coreyalan.com` has no Authelia session cookie or login portal (Authelia cookies cover `authoritah.com`/`.tv` only), so an IP allowlist is the appropriate gate.

## Verification
- `helm template` renders the IngressRoute with the middleware attached.
- Uses the same `internal-only` middleware already defined in `traefik-manifests/` (previously unused); `allowCrossNamespace: true` is set on Traefik.

## Heads-up before merge
This limits the admin UI to **RFC1918 LAN** (matching how the repo gates all other internal services via split-DNS). If you administer Matrix over Tailscale (`100.64.0.0/10`) or from outside the LAN, that range must be added — say the word and I will switch this to a dedicated middleware that also allows the tailnet.