### PR TITLE
fix(images): pin byparr and soularr by digest instead of :latest

### DIFF
--- a/helm-charts/prowlarr/templates/deployment-byparr.yaml
+++ b/helm-charts/prowlarr/templates/deployment-byparr.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: byparr
-        image: "{{ .Values.byparr.image.repository }}:{{ .Values.byparr.image.tag }}"
+        image: "{{ .Values.byparr.image.repository }}{{ if .Values.byparr.image.digest }}@{{ .Values.byparr.image.digest }}{{ else }}:{{ .Values.byparr.image.tag }}{{ end }}"
         imagePullPolicy: {{ .Values.byparr.image.pullPolicy }}
         ports:
         - name: http

--- a/helm-charts/prowlarr/values.yaml
+++ b/helm-charts/prowlarr/values.yaml
@@ -38,7 +38,10 @@ byparr:
   enabled: true
   image:
     repository: ghcr.io/thephaseless/byparr
+    # Upstream publishes only :latest (no semver tags), so pin by digest for
+    # reproducible deploys. digest takes precedence over tag in the template.
     tag: "latest"
+    digest: "sha256:01a46a2865d9a6db5eb8ead04ec0dd33b8fbe233e8565ae70b50d4cc0af4cfb0"
     pullPolicy: IfNotPresent
   service:
     port: 8191

--- a/helm-charts/soularr/templates/deployment.yaml
+++ b/helm-charts/soularr/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           mountPath: /data
       containers:
       - name: soularr
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: TZ

--- a/helm-charts/soularr/values.yaml
+++ b/helm-charts/soularr/values.yaml
@@ -8,9 +8,11 @@
 
 image:
   repository: mrusse08/soularr
-  # No upstream semver tags; :latest is the published image. Pin a digest here
-  # if you want reproducible deploys.
+  # No upstream semver tags; :latest is the only published tag, so the image is
+  # pinned by digest for reproducible deploys. tag is kept for readability but
+  # digest takes precedence in the template. Refresh the digest to update.
   tag: "latest"
+  digest: "sha256:a46d4b0af667e54e816e2058ec574a03337519ee74476e17875d4c5cb3a3c288"
   pullPolicy: IfNotPresent
 
 # Pin to blacktalon — that's where /blacktalon/media/downloads lives and where


### PR DESCRIPTION
Two workloads ran on floating `:latest` tags, so their running code silently changes on every pull and a compromised upstream tag lands automatically:

- `ghcr.io/thephaseless/byparr` — the FlareSolverr-style scraping sidecar in prowlarr (default `enabled: true`)
- `mrusse08/soularr`

Neither image publishes semver tags (byparr only has `latest` + cosign `.sig` tags), so digest is the only way to pin.

## Change
- Add an `image.digest` value to each chart; the template renders `repo@sha256:...` when a digest is set and falls back to `repo:tag` otherwise.
- Pin current digests:
  - byparr `sha256:01a46a28...af4cfb0`
  - soularr `sha256:a46d4b0a...a3c288`

## Verification
- `helm template` renders both as `repo@sha256:<digest>`; confirmed the tag fallback still works when `digest` is empty.

Note: the `busybox:1.38.0` / `netshoot:v0.13` init images elsewhere are tag-pinned (not floating), so they are lower-risk and left as-is; can digest-pin them in a follow-up if desired.