### PR TITLE
fix(vpn): tighten caps on transmission/slskd route-init containers

### DIFF
--- a/helm-charts/slskd/templates/deployment.yaml
+++ b/helm-charts/slskd/templates/deployment.yaml
@@ -27,7 +27,9 @@ spec:
       - name: vpn-cluster-routes
         image: nicolaka/netshoot:v0.13
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
+            drop: ["ALL"]
             add: ["NET_ADMIN"]
         command:
         - sh

--- a/helm-charts/transmission/templates/deployment.yaml
+++ b/helm-charts/transmission/templates/deployment.yaml
@@ -31,7 +31,9 @@ spec:
       - name: vpn-cluster-routes
         image: nicolaka/netshoot:v0.13
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
+            drop: ["ALL"]
             add: ["NET_ADMIN"]
         command:
         - sh


### PR DESCRIPTION
Follow-up hardening on the VPN-routed clients. The audit flagged `NET_ADMIN` + hostPort on transmission/slskd; on inspection **`NET_ADMIN` is already correctly confined to the `vpn-cluster-routes` init container** in both charts (needed to re-add cluster CIDR routes after Multus swaps the default route to the AirVPN VLAN). The main `transmission`/`slskd` containers never had it, and the transmission peer `hostPort` is required for inbound BitTorrent connectivity — both left as-is.

The one available least-privilege tightening:

## Change
On both `vpn-cluster-routes` init containers:
- `capabilities.drop: ["ALL"]` before `add: ["NET_ADMIN"]` (was adding NET_ADMIN on top of the default set).
- `allowPrivilegeEscalation: false`.

`ip route add` only needs `NET_ADMIN`, so this is behaviour-preserving.

## Verification
- `helm template` renders both init containers with `drop: [ALL]` / `add: [NET_ADMIN]` and no privilege escalation.