### PR TITLE
feat(reconciler): inject global base allowlist CIDR from secret

### DIFF
--- a/apps/allowlist-reconciler/README.md
+++ b/apps/allowlist-reconciler/README.md
@@ -48,6 +48,7 @@ static policy declarative and auditable.
 | `LABEL_SELECTOR` | default `allowlist.coreyalan.com/managed=true` |
 | `POLL_INTERVAL_MS` | default `20000` |
 | `PORT` | default `8080` |
+| `STAGING_BASE_ALLOWLIST_CIDR` | optional base CIDR(s) unioned into **every** managed app's allowlist (JSON array or comma-separated). Sourced from Bitwarden so the homelab WAN IP stays out of the repo. Unset ⇒ per-app `baseSourceRange` only. |
 
 Secrets come from Bitwarden via External Secrets (see
 `../../allowlist-reconciler/externalsecret.yaml`). RBAC is least-privilege:

--- a/apps/allowlist-reconciler/src/index.mjs
+++ b/apps/allowlist-reconciler/src/index.mjs
@@ -27,6 +27,12 @@ const CONFIG = {
   labelSelector: process.env.LABEL_SELECTOR || 'allowlist.coreyalan.com/managed=true',
   pollIntervalMs: Number(process.env.POLL_INTERVAL_MS) || 20000,
   port: Number(process.env.PORT) || 8080,
+  // Base CIDR(s) unioned into every managed app's allowlist, sourced from the
+  // ESO secret (Bitwarden) instead of committed values so the homelab WAN IP
+  // stays out of the public repo. Accepts a JSON array or comma-separated list.
+  // Unset ⇒ empty ⇒ behaviour unchanged (the per-app baseSourceRange still
+  // applies), so this is safe to ship before the secret exists.
+  globalBaseSourceRange: parseCidrList(process.env.STAGING_BASE_ALLOWLIST_CIDR),
 };
 
 const SA_DIR = '/var/run/secrets/kubernetes.io/serviceaccount';
@@ -41,6 +47,22 @@ function requireEnv(name) {
     process.exit(1);
   }
   return value;
+}
+
+// Parse a CIDR list from either a JSON array (`["a/32","b/32"]`) or a
+// comma-separated string (`a/32, b/32`). Empty/unset ⇒ [].
+function parseCidrList(raw) {
+  if (!raw) return [];
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('[')) {
+    try {
+      const arr = JSON.parse(trimmed);
+      if (Array.isArray(arr)) return arr.map(String).map(s => s.trim()).filter(Boolean);
+    } catch {
+      // fall through to comma-split
+    }
+  }
+  return trimmed.split(',').map(s => s.trim()).filter(Boolean);
 }
 
 function log(level, msg, extra = {}) {
@@ -210,7 +232,7 @@ async function reconcileConfigMap(cm) {
     return ok;
   });
 
-  const merged = Array.from(new Set([...base, ...reviewers])).sort();
+  const merged = Array.from(new Set([...CONFIG.globalBaseSourceRange, ...base, ...reviewers])).sort();
   const appliedHash = crypto.createHash('sha256').update(merged.join(',')).digest('hex');
 
   try {


### PR DESCRIPTION
Step 1 of externalizing the homelab WAN IP (`206.225.142.166`) out of the committed staging values.

The reconciler currently unions each app's per-app `baseSourceRange` (from committed Helm values) with reviewer IPs. This adds an optional **global** base CIDR sourced from the reconciler's ESO/Bitwarden secret (`STAGING_BASE_ALLOWLIST_CIDR`), unioned into every managed app's allowlist — so the WAN IP can be supplied at runtime instead of hardcoded in the repo.

## Change (code only, no behaviour change yet)
- `parseCidrList()` accepts a JSON array or comma-separated CIDRs.
- `CONFIG.globalBaseSourceRange` reads `STAGING_BASE_ALLOWLIST_CIDR` (from the existing `envFrom` ESO secret).
- The per-app union now includes the global base.

**Backward compatible:** unset ⇒ `[]` ⇒ the per-app `baseSourceRange` still applies. Safe to merge and build before the Bitwarden item exists.

## Verification
- `node --check` passes; unit-tested `parseCidrList` (unset/empty/single/CSV/JSON) and the union (with and without a global base).

## Follow-up (tracked, in order — see PR discussion)
1. Create Bitwarden item `STAGING_BASE_ALLOWLIST_CIDR = 206.225.142.166/32` in the staging project.
2. Rebuild + repush + re-pin the reconciler image to include this code.
3. Add the key to `allowlist-reconciler/externalsecret.yaml` (needs the BWS UUID); deploy; verify middlewares still carry the WAN IP.
4. Remove `206.225.142.166/32` from the 5 `staging-apps/*/values.yaml` (and the self-identifying comments) — the WAN IP then comes solely from the secret.