### PR TITLE
feat(reconciler): source base allowlist CIDR from Bitwarden + auto-reload

### DIFF
--- a/allowlist-reconciler/deployment.yaml
+++ b/allowlist-reconciler/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
   labels:
     app.kubernetes.io/name: allowlist-reconciler
     app.kubernetes.io/part-of: staging
+  annotations:
+    # Restart when its ESO secret changes so new/rotated values (incl. the
+    # STAGING_BASE_ALLOWLIST_CIDR base) are picked up — envFrom is read only at
+    # container start.
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   # Single writer — avoid two replicas racing to patch the same Middleware.

--- a/allowlist-reconciler/externalsecret.yaml
+++ b/allowlist-reconciler/externalsecret.yaml
@@ -38,3 +38,8 @@ spec:
     - secretKey: RECONCILER_WEBHOOK_TOKEN
       remoteRef:
         key: ef6e7090-8690-46a4-a34f-b4740105ebd6
+    # Base CIDR (homelab WAN /32) unioned into every managed app's allowlist,
+    # kept in Bitwarden so it stays out of the public repo.
+    - secretKey: STAGING_BASE_ALLOWLIST_CIDR
+      remoteRef:
+        key: 74c08382-6135-46a1-a3e1-b47f016a705b


### PR DESCRIPTION
Step 3 of externalizing the homelab WAN IP. Builds on #500 (merged; the new reconciler image is already CI-pinned on main).

## Change
- Add `STAGING_BASE_ALLOWLIST_CIDR` to `allowlist-reconciler/externalsecret.yaml` — a Bitwarden item (created in the staging project) holding the homelab WAN `/32`. Exposed to the reconciler via its existing `envFrom` secret.
- Annotate the deployment with `reloader.stakater.com/auto: "true"` so it restarts when the ESO secret changes (`envFrom` is only read at container start; reloader is already running in the cluster).

## Effect after sync (zero change to effective allowlist)
ESO adds the key → reloader restarts the reconciler → it injects the WAN IP from the secret, **unioned** with the still-committed per-app base (`206.225.142.166/32`). Set union ⇒ identical result. This is deliberately a no-op safety step before the IP is removed from values.

## Verify after merge (staging ns — I do not have kubectl reach to it)
- `kubectl -n staging get secret allowlist-reconciler-secrets -o jsonpath='{.data.STAGING_BASE_ALLOWLIST_CIDR}' | base64 -d` → `206.225.142.166/32`
- Reconciler pod restarted (reloader) and logs show it applying allowlists.
- The app Middlewares still list `206.225.142.166/32`.

## Next (final step, separate PR — only after the above verifies)
Remove `206.225.142.166/32` + the self-identifying comments from the 5 `staging-apps/*/values.yaml`. The WAN IP then lives solely in Bitwarden.