### PR TITLE
fix(staging): remove homelab WAN IP from committed allowlists

### DIFF
--- a/staging-apps/blue-skysolutions-com/values.yaml
+++ b/staging-apps/blue-skysolutions-com/values.yaml
@@ -38,14 +38,12 @@ staging-app:
     enabled: true
     host: staging.blue-skysolutions.com
     clusterIssuer: letsencrypt-prod
-    # Restrict access to the homelab WAN + on-LAN sources. CoreDNS resolves
-    # this host to the internal LB for cluster/LAN clients, so the RFC1918
-    # ranges cover internal traffic; the /32 covers external traffic that
-    # egresses through the static ISP IP.
+    # Restrict access to on-LAN/in-cluster sources (RFC1918). The external base
+    # CIDR is injected at runtime by the allowlist-reconciler from Bitwarden
+    # (STAGING_BASE_ALLOWLIST_CIDR), so it stays out of this public repo.
     ipAllowList:
       enabled: true
       sourceRange:
-        - 206.225.142.166/32
         - 10.0.0.0/8
         - 172.16.0.0/12
         - 192.168.0.0/16

--- a/staging-apps/capturly-web/values.yaml
+++ b/staging-apps/capturly-web/values.yaml
@@ -45,14 +45,12 @@ staging-app:
     enabled: true
     host: staging.capturly.app
     clusterIssuer: letsencrypt-prod
-    # Restrict access to the homelab WAN + on-LAN sources. CoreDNS resolves
-    # this host to the internal LB for cluster/LAN clients, so the RFC1918
-    # ranges cover internal traffic; the /32 covers external traffic that
-    # egresses through the static ISP IP.
+    # Restrict access to on-LAN/in-cluster sources (RFC1918). The external base
+    # CIDR is injected at runtime by the allowlist-reconciler from Bitwarden
+    # (STAGING_BASE_ALLOWLIST_CIDR), so it stays out of this public repo.
     ipAllowList:
       enabled: true
       sourceRange:
-        - 206.225.142.166/32
         - 10.0.0.0/8
         - 172.16.0.0/12
         - 192.168.0.0/16

--- a/staging-apps/coreyalan-com/values.yaml
+++ b/staging-apps/coreyalan-com/values.yaml
@@ -47,17 +47,17 @@ staging-app:
     enabled: true
     host: staging.coreyalan.com
     clusterIssuer: letsencrypt-prod
-    # Restrict to the homelab WAN + on-LAN/in-cluster sources (matches jlshaw &
-    # blue-sky staging). In-cluster callers (capturly/dispatchr/jlshaw → this
-    # host via split-horizon DNS) and the worker land in 10.42.x (RFC1918); the
-    # /32 is the static ISP egress IP. Webhooks here are outbound, so this
+    # Restrict to on-LAN/in-cluster sources (RFC1918). In-cluster callers
+    # (capturly/dispatchr/jlshaw → this host via split-horizon DNS) and the
+    # worker land in 10.42.x. Webhooks here are outbound, so the allowlist
     # doesn't break integrations. Closes the public-exposure gap (prod uses
     # authRateLimit; staging standardizes on the allowlist).
     ipAllowList:
       enabled: true
-      # Static BASE; the allowlist-reconciler layers reviewer IPs on top.
+      # Base = RFC1918 here + the external CIDR injected by the
+      # allowlist-reconciler from Bitwarden (STAGING_BASE_ALLOWLIST_CIDR), kept
+      # out of this public repo; reviewer IPs are layered on top too.
       sourceRange:
-        - 206.225.142.166/32
         - 10.0.0.0/8
         - 172.16.0.0/12
         - 192.168.0.0/16

--- a/staging-apps/dispatchr-social/values.yaml
+++ b/staging-apps/dispatchr-social/values.yaml
@@ -45,14 +45,12 @@ staging-app:
     enabled: true
     host: staging.dispatchr.social
     clusterIssuer: letsencrypt-prod
-    # Restrict access to the homelab WAN + on-LAN sources. CoreDNS resolves
-    # this host to the internal LB for cluster/LAN clients, so the RFC1918
-    # ranges cover internal traffic; the /32 covers external traffic that
-    # egresses through the static ISP IP.
+    # Restrict access to on-LAN/in-cluster sources (RFC1918). The external base
+    # CIDR is injected at runtime by the allowlist-reconciler from Bitwarden
+    # (STAGING_BASE_ALLOWLIST_CIDR), so it stays out of this public repo.
     ipAllowList:
       enabled: true
       sourceRange:
-        - 206.225.142.166/32
         - 10.0.0.0/8
         - 172.16.0.0/12
         - 192.168.0.0/16

--- a/staging-apps/jlshaw-link/values.yaml
+++ b/staging-apps/jlshaw-link/values.yaml
@@ -45,14 +45,12 @@ staging-app:
     enabled: true
     host: staging.jlshawconsulting.com
     clusterIssuer: letsencrypt-prod
-    # Restrict access to the homelab WAN + on-LAN sources. CoreDNS resolves
-    # this host to the internal LB for cluster/LAN clients, so the RFC1918
-    # ranges cover internal traffic; the /32 covers external traffic that
-    # egresses through the static ISP IP.
+    # Restrict access to on-LAN/in-cluster sources (RFC1918). The external base
+    # CIDR is injected at runtime by the allowlist-reconciler from Bitwarden
+    # (STAGING_BASE_ALLOWLIST_CIDR), so it stays out of this public repo.
     ipAllowList:
       enabled: true
       sourceRange:
-        - 206.225.142.166/32
         - 10.0.0.0/8
         - 172.16.0.0/12
         - 192.168.0.0/16


### PR DESCRIPTION
Final step of externalizing the homelab WAN IP (`206.225.142.166`). Follows #500 (reconciler code) and #501 (Bitwarden item + ExternalSecret + reloader), both merged and **verified live in staging**.

## Change
- Remove `206.225.142.166/32` from `ingress.ipAllowList.sourceRange` in all 5 `staging-apps/*/values.yaml`. Committed base is now RFC1918-only.
- Rewrite the comments that identified it as "homelab WAN" / "static ISP egress IP".

The reconciler now injects the external CIDR from Bitwarden (`STAGING_BASE_ALLOWLIST_CIDR`) and unions it with the RFC1918 base + reviewer IPs, so the effective allowlist is unchanged.

## Why this is safe (verified in staging via blacktalon)
- ESO synced `STAGING_BASE_ALLOWLIST_CIDR = 206.225.142.166/32` into the secret.
- The reconciler pod was restarted **after** the secret synced, so it has the env loaded, and it is reconciling without errors.
- ArgoCD already ignores the Middleware `sourceRange` (reconciler-owned), so removing the IP from values does not touch the live Middlewares directly — the reconciler re-applies `injected-WAN ∪ RFC1918 ∪ reviewers` each cycle.

## Post-merge check (I will run via `ssh blacktalon` on merge)
Confirm all 5 app Middlewares **still** list `206.225.142.166/32` after ArgoCD syncs the reduced base — proving the WAN IP now comes solely from the injected secret. Revert if not.

## History note
This removes the IP from future state only; it remains in prior commits. A `git filter-repo` purge would be needed to remove it from history (separate, heavier task).