### PR TITLE
feat(matrix): migrate admin UI to ketesa and enable MAS OIDC login + admin API

### DIFF
--- a/helm-charts/matrix/templates/mas-configmap.yaml
+++ b/helm-charts/matrix/templates/mas-configmap.yaml
@@ -23,6 +23,12 @@ data:
             - name: compat
             - name: graphql
             - name: assets
+            # MAS admin API — required by the ketesa admin UI (sessions,
+            # registration tokens, email management) which calls it from the
+            # browser. Guarded by the urn:mas:admin scope, granted only to
+            # policy.data.admin_users below, so exposure on the public listener
+            # is authenticated rather than open.
+            - name: adminapi
           binds:
             - address: "[::]:8080"
         - name: internal
@@ -71,6 +77,16 @@ data:
     # suffix. Applies to Google signups too (email is required above).
     policy:
       data:
+        {{- with .Values.mas.adminUsers }}
+        # Usernames (MAS localparts) allowed to request admin scopes. MAS grants
+        # these accounts both urn:mas:admin (MAS admin API) and urn:synapse:admin:*
+        # (Synapse admin API), so this is the single authorization gate for the
+        # ketesa admin UI. Empty list = no admin access.
+        admin_users:
+          {{- range . }}
+          - {{ . | quote }}
+          {{- end }}
+        {{- end }}
         emails:
           allowed_addresses:
             suffixes:

--- a/helm-charts/matrix/templates/synapse-admin.yaml
+++ b/helm-charts/matrix/templates/synapse-admin.yaml
@@ -43,11 +43,12 @@ spec:
           image: {{ .Values.synapseAdmin.image }}
           ports:
             - name: http
-              # etke.cc image runs static-web-server on 8080 (SERVER_PORT=8080)
+              # ketesa image runs static-web-server on 8080 (SERVER_PORT=8080)
               containerPort: 8080
           readinessProbe:
             httpGet:
-              path: /config.json
+              # static-web-server health endpoint (SERVER_HEALTH=true)
+              path: /health
               port: http
             initialDelaySeconds: 3
             periodSeconds: 10
@@ -59,7 +60,8 @@ spec:
               drop: ["ALL"]
           volumeMounts:
             - name: config
-              # static-web-server web root (SERVER_FALLBACK_PAGE=/var/public/index.html)
+              # static-web-server web root: /var/public is symlinked to the
+              # image web root (/home/sws/public), so config.json is served here.
               mountPath: /var/public/config.json
               subPath: config.json
               readOnly: true

--- a/helm-charts/matrix/values.yaml
+++ b/helm-charts/matrix/values.yaml
@@ -151,13 +151,16 @@ elementWeb:
       memory: 128Mi
 
 # --------------------------------------------------------------------------
-# synapse-admin (etke.cc fork) — admin web UI at admin.coreyalan.com.
+# ketesa (etke.cc) — admin web UI at admin.coreyalan.com. Formerly the etke.cc
+# synapse-admin fork (ghcr.io/etkecc/synapse-admin), renamed to ketesa and
+# renumbered to v1.x; a drop-in replacement (same static-web-server image,
+# port, config layout, and restrictBaseUrl key).
 # Static SPA; pinned to our homeserver via restrictBaseUrl. Log in with an
 # admin access token (password login is disabled under MAS).
 # --------------------------------------------------------------------------
 synapseAdmin:
   enabled: true
-  image: ghcr.io/etkecc/synapse-admin:v0.11.4-etke54
+  image: ghcr.io/etkecc/ketesa:v1.3.0
   host: admin.coreyalan.com
   resources:
     requests:

--- a/helm-charts/matrix/values.yaml
+++ b/helm-charts/matrix/values.yaml
@@ -121,6 +121,12 @@ mas:
   # signups to the org domain; without this ANY Google account could sign up.
   allowedEmailSuffixes:
     - "@coreyalan.com"
+  # MAS usernames (localparts, NOT full MXIDs) granted admin scopes. MAS gives
+  # these accounts both the MAS admin API (urn:mas:admin) and the Synapse admin
+  # API (urn:synapse:admin:*), which is what authorizes the ketesa admin UI.
+  # Empty = no one has admin access. Set to your admin account's MAS username.
+  adminUsers:
+    - nx211
   secretName: matrix-mas
   resources:
     requests:


### PR DESCRIPTION
## What

Migrates the Matrix admin UI from etke.cc's synapse-admin fork to **ketesa** (its successor), and enables OIDC/MAS login plus the MAS-native admin panels.

etke.cc renamed `ghcr.io/etkecc/synapse-admin` to `ghcr.io/etkecc/ketesa` and renumbered `v0.11.x → v1.x`. It's a drop-in replacement — same `static-web-server` base, port `8080`, `/var/public` config layout, and `restrictBaseUrl` key.

## Changes

**Admin UI image (`values.yaml`, `templates/synapse-admin.yaml`)**
- `ghcr.io/etkecc/synapse-admin:v0.11.4-etke54` → `ghcr.io/etkecc/ketesa:v1.3.0`
- Readiness probe `/config.json` → `/health` (ketesa's purpose-built endpoint, `SERVER_HEALTH=true`)
- Refreshed comments to reflect the ketesa naming

**MAS admin API + authorization (`templates/mas-configmap.yaml`, `values.yaml`)**
- Added the `adminapi` resource to the MAS `web` listener so the ketesa UI can reach the MAS admin API from the browser (enables session revocation, registration tokens, email management)
- Added `mas.adminUsers`, rendered into `policy.data.admin_users`. Under MAS delegated auth this is the single authorization gate — listed accounts receive both `urn:mas:admin` (MAS admin API) and `urn:synapse:admin:*` (Synapse admin API). Granted to `nx211`.

## Behavior after deploy

- **Login:** OIDC/SSO via MAS → Google (no more pasting admin access tokens). Works even with `/_matrix/client/v3/login` disabled, since ketesa keys the button off `/_matrix/client/v1/auth_metadata`.
- **Synapse admin** (users/rooms/media/federation) and **MAS-native panels** both authorized via `adminUsers`.
- MAS deployment has `reloader.stakater.com/auto: "true"`, so it restarts automatically on the ConfigMap change.

## Notes

- **Security tradeoff (by design):** `adminapi` rides the public `web` listener at `auth.coreyalan.com` because the ketesa SPA at `admin.coreyalan.com` must reach it cross-origin. It's authenticated (admin-scope bearer token required) and matches etke.cc's documented approach.
- The Helm values key `synapseAdmin` and the K8s resource names (`matrix-synapse-admin`) are intentionally left unchanged — renaming would force object recreation for no functional gain.

## Verification

- `helm template` renders the new image, `/health` probe, `adminapi` resource, and `admin_users: [nx211]` correctly
- `helm lint` passes (pre-existing unrelated `matrix-synapse.redis.image` warning only)
- Post-deploy: log into ketesa via SSO and open Sessions / Registration Tokens to confirm the admin API + scope are wired end-to-end
