### PR TITLE
feat(plex): mount sports media directory

### DIFF
--- a/helm-charts/plex/templates/deployment.yaml
+++ b/helm-charts/plex/templates/deployment.yaml
@@ -73,6 +73,9 @@ spec:
         - name: tv-uhd
           mountPath: /tv-uhd
           readOnly: true
+        - name: sports
+          mountPath: /sports
+          readOnly: true
         - name: kids
           mountPath: /kids
           readOnly: true
@@ -121,6 +124,10 @@ spec:
       - name: tv-uhd
         hostPath:
           path: {{ .Values.persistence.media.tvUhd.hostPath }}
+          type: Directory
+      - name: sports
+        hostPath:
+          path: {{ .Values.persistence.media.sports.hostPath }}
           type: Directory
       - name: kids
         hostPath:

--- a/helm-charts/plex/values.yaml
+++ b/helm-charts/plex/values.yaml
@@ -39,6 +39,8 @@ persistence:
       hostPath: /blacktalon/media/tv
     tvUhd:
       hostPath: /blacktalon/media/tv-uhd
+    sports:
+      hostPath: /blacktalon/media/sports
     kids:
       hostPath: /blacktalon/media/kids
     anime:


### PR DESCRIPTION
## Summary
Adds the `/blacktalon/media/sports` hostPath to Plex as a read-only `/sports` mount, so a dedicated **Sports** library can be created in the Plex UI. This is the same directory Jellyfin already serves.

## Changes
- `helm-charts/plex/values.yaml` — add `persistence.media.sports` (`/blacktalon/media/sports`)
- `helm-charts/plex/templates/deployment.yaml` — add the `sports` volumeMount (`/sports`, read-only) and corresponding hostPath volume

## Context
The sports media flow already mirrors tv/movies and is fully isolated:
- **sportarr** imports from `/media/downloads/sports` into `/media/sports` (only sees its own category)
- **download clients** (sabnzbd, transmission) route the `sports` category into `/blacktalon/media/downloads/sports`
- **jellyfin** already serves it via its whole-`/media` mount

Plex was the only consumer missing the mount — this closes that gap.

## Follow-up (manual)
After sync, add a new library in the Plex UI pointing at `/sports`.