### PR TITLE
feat(authelia): add Jellyfin OIDC client for SSO-Auth plugin

### DIFF
--- a/authelia-manifests/configmap-config.yaml
+++ b/authelia-manifests/configmap-config.yaml
@@ -375,4 +375,21 @@ data:
               - 'profile'
               - 'email'
             userinfo_signed_response_alg: 'none'
+          - client_id: 'jellyfin'
+            client_name: 'Jellyfin'
+            client_secret: '{{ secret "/secrets/oidc-clients/jellyfin" }}'
+            public: false
+            authorization_policy: 'two_factor'
+            redirect_uris:
+              - 'https://jellyfin.authoritah.tv/sso/OID/redirect/authelia'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_post'
     theme: dark

--- a/authelia-manifests/externalsecret-oidc-clients.yaml
+++ b/authelia-manifests/externalsecret-oidc-clients.yaml
@@ -32,3 +32,5 @@ spec:
       remoteRef: { key: 552c3029-2631-4a78-bfdd-b47f0144b2cf }
     - secretKey: tailscale
       remoteRef: { key: 3e87f390-481b-4aef-b006-b47f0144b4a5 }
+    - secretKey: jellyfin
+      remoteRef: { key: 71631c0d-663e-4d47-9042-b48901135262 }


### PR DESCRIPTION
## Summary
Registers a `jellyfin` OpenID Connect client in Authelia so the [jellyfin-plugin-sso](https://github.com/9p4/jellyfin-plugin-sso) can use Authelia as an SSO provider. Values follow Authelia's official Jellyfin integration guide, adapted to this cluster's conventions (groups-based authorization, `.tv` media domain).

## Changes
- `authelia-manifests/configmap-config.yaml` — add the `jellyfin` OIDC client:
  - `authorization_policy: two_factor` (matches every other client here)
  - redirect URI `https://jellyfin.authoritah.tv/sso/OID/redirect/authelia`
  - scopes `openid`, `profile`, `groups`; `token_endpoint_auth_method: client_secret_post`
- `authelia-manifests/externalsecret-oidc-clients.yaml` — add the `jellyfin` client-secret hash, sourced from Bitwarden Secrets Manager (`authelia_oidc_jellyfin_secret_hash`)

## Secrets
Created in Bitwarden Secrets Manager (Platform Infrastructure project):
- `authelia_oidc_jellyfin_secret_hash` — PBKDF2-SHA512 digest, read by ESO into `/secrets/oidc-clients/jellyfin`
- `authelia_oidc_jellyfin_client_secret` — plaintext, entered into the Jellyfin plugin UI

## Post-merge (Jellyfin plugin UI → SSO-Auth → Add Provider)
| Field | Value |
|---|---|
| Name of OID Provider | `authelia` |
| OID Endpoint | `https://login.authoritah.tv` |
| OpenID Client ID | `jellyfin` |
| OID Secret | value of `authelia_oidc_jellyfin_client_secret` |
| Enable Authorization by Plugin | ✓ |
| Enable All Folders | ✓ |
| Roles | `media` |
| Admin Roles | `admin` |
| Role Claim | `groups` |
| Request Additional Scopes | `groups` |
| Scheme Override | `https` |