### PR TITLE
feat(jellyfin): auto-redirect web login to Authelia SSO

### DIFF
--- a/helm-charts/jellyfin/templates/configmap-sso-autoredirect.yaml
+++ b/helm-charts/jellyfin/templates/configmap-sso-autoredirect.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ssoAutoRedirect.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jellyfin.fullname" . }}-sso-autoredirect
+  labels:
+    {{- include "jellyfin.labels" . | nindent 4 }}
+data:
+  # Injected verbatim into jellyfin-web/index.html (before </body>) by the
+  # inject-sso-autoredirect initContainer. Auto-redirects the web login page
+  # to the SSO provider. Escape hatch: load a login URL containing "local"
+  # (e.g. .../web/index.html#/login.html?local=1) to reach the native form.
+  inject.html: |
+    <script>
+    (function () {
+      'use strict';
+      var START = {{ .Values.ssoAutoRedirect.startPath | quote }};
+      function href() { return (window.location.href || '').toLowerCase(); }
+      function onLoginPage() { return href().indexOf('login') !== -1; }
+      function bypassed() { return href().indexOf('local') !== -1; }
+      function go() {
+        if (window.__ssoRedirecting || bypassed() || !onLoginPage()) return;
+        window.__ssoRedirecting = true;
+        window.location.replace(START);
+      }
+      window.addEventListener('hashchange', go);
+      document.addEventListener('DOMContentLoaded', go);
+      go();
+    })();
+    </script>
+{{- end }}

--- a/helm-charts/jellyfin/templates/deployment.yaml
+++ b/helm-charts/jellyfin/templates/deployment.yaml
@@ -22,6 +22,29 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.ssoAutoRedirect.enabled }}
+      initContainers:
+      - name: inject-sso-autoredirect
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - sh
+        - -c
+        - |
+          set -e
+          cp -a /jellyfin/jellyfin-web/. /web/
+          # index.html is minified onto one line, so insert the snippet at the
+          # </body> position within the line (substr is metacharacter-safe).
+          awk 'BEGIN{while((getline l < "/inject/inject.html")>0)s=s l "\n"}
+          {p=index($0,"</body>"); if(p>0){printf "%s",substr($0,1,p-1); printf "%s",s; print substr($0,p)} else print}' \
+            /jellyfin/jellyfin-web/index.html > /web/index.html
+        volumeMounts:
+        - name: web
+          mountPath: /web
+        - name: sso-inject
+          mountPath: /inject
+          readOnly: true
+      {{- end }}
       containers:
       - name: jellyfin
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -61,6 +84,10 @@ spec:
           mountPath: /media
           readOnly: true
         {{- end }}
+        {{- if .Values.ssoAutoRedirect.enabled }}
+        - name: web
+          mountPath: /jellyfin/jellyfin-web
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       volumes:
@@ -69,6 +96,13 @@ spec:
           claimName: {{ include "jellyfin.fullname" . }}-config
       - name: cache
         emptyDir: {}
+      {{- if .Values.ssoAutoRedirect.enabled }}
+      - name: web
+        emptyDir: {}
+      - name: sso-inject
+        configMap:
+          name: {{ include "jellyfin.fullname" . }}-sso-autoredirect
+      {{- end }}
       {{- if .Values.persistence.media.enabled }}
       - name: media
         hostPath:

--- a/helm-charts/jellyfin/values.yaml
+++ b/helm-charts/jellyfin/values.yaml
@@ -37,6 +37,14 @@ env:
   TZ: America/New_York
   JELLYFIN_PublishedServerUrl: "https://jellyfin.authoritah.tv"
 
+# Auto-redirect the web login page to the SSO provider. An initContainer
+# injects a small script into jellyfin-web/index.html at startup. Load a login
+# URL containing "local" (e.g. .../web/index.html#/login.html?local=1) to reach
+# the native username/password form as an admin fallback.
+ssoAutoRedirect:
+  enabled: true
+  startPath: /sso/OID/start/authelia
+
 # Resource limits
 resources:
   requests:


### PR DESCRIPTION
## Summary
Makes the Jellyfin **web** login page redirect straight to Authelia SSO (`/sso/OID/start/authelia`) instead of requiring a click on the "Sign in with Authelia" button.

Jellyfin has no native custom-JS hook, so this injects a tiny script into `jellyfin-web/index.html` via an initContainer.

## How it works
- An `initContainer` (same Jellyfin image) copies `/jellyfin/jellyfin-web` into an `emptyDir`, then inlines a `<script>` immediately before `</body>` using an `index()`/`substr` awk transform (metacharacter-safe; the file is minified onto one line).
- The main container mounts that `emptyDir` over `/jellyfin/jellyfin-web`.
- Because the copy happens at every startup, it **survives image upgrades** automatically — no pinned/overridden `index.html`.
- The script only fires on the login route and calls `window.location.replace('/sso/OID/start/authelia')`.

## Safety / fallback
- **Gated by `ssoAutoRedirect.enabled`** (default `true`) — flip to `false` to revert instantly.
- **Admin escape hatch:** load a login URL containing `local` (e.g. `https://jellyfin.authoritah.tv/web/index.html#/login.html?local=1`) to reach the native username/password form. Essential if Authelia is ever down.

## Verified
- `helm template` renders valid YAML.
- The awk injection was tested against the live `index.html`: output still begins with `<!doctype html>` (no quirks mode) and the script closes exactly at `</script></body></html>`.

## Note on logout
With forced SSO redirect, logging out of Jellyfin lands back on the login page, which redirects to Authelia; if the Authelia session cookie is still valid you'll be signed straight back in. To fully sign out, also end the Authelia session at `https://login.authoritah.tv/logout`. Use the `local` bypass for local-account login.
