### PR TITLE
fix(jellyfin): catch SPA client-side route to login for SSO redirect

### DIFF
--- a/helm-charts/jellyfin/templates/configmap-sso-autoredirect.yaml
+++ b/helm-charts/jellyfin/templates/configmap-sso-autoredirect.yaml
@@ -24,8 +24,21 @@ data:
         window.__ssoRedirecting = true;
         window.location.replace(START);
       }
+      // The SPA routes to the login page client-side. pushState fires no
+      // event, and replaceState fires none either, so wrap both to catch it.
+      ['pushState', 'replaceState'].forEach(function (m) {
+        var orig = history[m];
+        history[m] = function () { var r = orig.apply(this, arguments); go(); return r; };
+      });
       window.addEventListener('hashchange', go);
+      window.addEventListener('popstate', go);
       document.addEventListener('DOMContentLoaded', go);
+      // Fallback: poll briefly after boot to catch the initial async route to
+      // /login before the history hooks are guaranteed to be in place.
+      var n = 0, t = setInterval(function () {
+        go();
+        if (++n > 40 || window.__ssoRedirecting) clearInterval(t);
+      }, 250);
       go();
     })();
     </script>


### PR DESCRIPTION
## Problem
After #553, the auto-redirect only fired on a **hard refresh** of the login page — on normal navigation it landed on the standard login form and stayed there.

## Cause
The Jellyfin web client routes to the login page **client-side via the History API**. `replaceState` fires no event, and `pushState` fires none for the code that calls it, so the original `hashchange` / `DOMContentLoaded` listeners never saw the route change. A hard refresh worked only because the URL already contained `login` at load time, so the inline `go()` caught it.

## Fix
In the injected script:
- Wrap `history.pushState` / `history.replaceState` to call `go()` after each route change.
- Also listen for `popstate`.
- Add a short boot-time fallback poll (250 ms, ~10 s) to catch the initial async route before the hooks are guaranteed to be attached.

`go()` remains idempotent (`__ssoRedirecting` guard) and still honors the `local` bypass.

## Verified
- `helm template` renders valid YAML.
- Re-ran the injection against the live `index.html`: output starts with `<!doctype html>`, contains exactly one injected `<script>` block, and it sits immediately before the single `</body></html>`.
