### PR TITLE
feat(arc): self-hosted Capturly Android release runner

### DIFF
--- a/.github/workflows/build-capturly-android-runner.yml
+++ b/.github/workflows/build-capturly-android-runner.yml
@@ -1,0 +1,51 @@
+name: Build capturly-android-runner
+
+# Builds the Capturly Android release-runner image (ARC self-hosted runner +
+# Android toolchain) and pushes it to GHCR. The arc-runners-android scale set
+# references it by tag; bump the tag there after a version change. Runs on
+# changes to the image or this workflow, or on demand.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "apps/capturly-android-runner/**"
+      - ".github/workflows/build-capturly-android-runner.yml"
+
+concurrency:
+  group: build-capturly-android-runner
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/nx211/capturly-android-runner
+  VERSION: "0.1.0"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v7
+        with:
+          context: apps/capturly-android-runner
+          platforms: linux/amd64
+          push: true
+          # Single-arch, no attestation side manifests — keeps a clean manifest
+          # the kubelet pulls by digest.
+          provenance: false
+          tags: |
+            ${{ env.IMAGE }}:${{ env.VERSION }}
+            ${{ env.IMAGE }}:${{ github.sha }}

--- a/.github/workflows/build-capturly-android-runner.yml
+++ b/.github/workflows/build-capturly-android-runner.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # keyless Cosign signing via Sigstore/OIDC
     steps:
       - uses: actions/checkout@v7
 
@@ -38,6 +39,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: apps/capturly-android-runner
@@ -49,3 +51,14 @@ jobs:
           tags: |
             ${{ env.IMAGE }}:${{ env.VERSION }}
             ${{ env.IMAGE }}:${{ github.sha }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image (keyless)
+        # Sign by digest (immutable). Verified in-cluster by the business-plane
+        # Kyverno policy verify-image-signatures-business (keyless, Sigstore/OIDC).
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+        env:
+          IMAGE: ${{ env.IMAGE }}
+          DIGEST: ${{ steps.build.outputs.digest }}

--- a/apps/capturly-android-runner/Dockerfile
+++ b/apps/capturly-android-runner/Dockerfile
@@ -1,0 +1,52 @@
+# Custom GitHub Actions runner image for Capturly Android release builds.
+#
+# Extends the official ARC runner with exactly the toolchain the release-android
+# workflow needs, so the ephemeral runner pod IS the build environment and no SDK
+# is downloaded per run. Versions are pinned to apps/mobile/android/build.gradle:
+#   compileSdk 36 · buildToolsVersion 36.0.0 · ndkVersion 28.2.13676358 · JDK 17
+# Gradle itself comes from the repo's wrapper (9.0.0) and is cached on the PVC.
+#
+# Verify the base tag against the current runner release before bumping:
+#   https://github.com/actions/runner/releases
+FROM ghcr.io/actions/actions-runner:2.328.0
+
+USER root
+
+# Base tools + JDK 17 (Temurin headless)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      openjdk-17-jdk-headless unzip curl git ca-certificates ccache \
+    && rm -rf /var/lib/apt/lists/*
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+
+# Node 22 + pnpm (pin matches the repo's packageManager)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g pnpm@9.15.9 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Android SDK: command-line tools + platform 36 + build-tools 36.0.0 + NDK
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+ENV ANDROID_HOME=/opt/android-sdk
+ARG ANDROID_PLATFORM=android-36
+ARG ANDROID_BUILD_TOOLS=36.0.0
+ARG ANDROID_NDK=28.2.13676358
+RUN mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools \
+    && curl -fsSL -o /tmp/cmdline-tools.zip \
+       https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \
+    && unzip -q /tmp/cmdline-tools.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools \
+    && mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/latest \
+    && rm /tmp/cmdline-tools.zip
+ENV PATH=${PATH}:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:${ANDROID_SDK_ROOT}/platform-tools
+RUN yes | sdkmanager --licenses > /dev/null \
+    && sdkmanager --install \
+       "platform-tools" \
+       "platforms;${ANDROID_PLATFORM}" \
+       "build-tools;${ANDROID_BUILD_TOOLS}" \
+       "ndk;${ANDROID_NDK}" > /dev/null \
+    && chown -R runner:runner ${ANDROID_SDK_ROOT}
+
+# ccache for NDK/native compile reuse (cache dir is a mounted PVC at runtime)
+ENV CMAKE_C_COMPILER_LAUNCHER=ccache
+ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+USER runner

--- a/apps/capturly-android-runner/README.md
+++ b/apps/capturly-android-runner/README.md
@@ -1,0 +1,18 @@
+# capturly-android-runner
+
+Custom GitHub Actions runner image for **Capturly Android release builds**, run on
+homelab compute via Actions Runner Controller (ARC). Extends
+`ghcr.io/actions/actions-runner` with the app's exact toolchain (JDK 17, Android
+SDK 36 / build-tools 36.0.0 / NDK 28.2.13676358, Node 22, pnpm, ccache) so the
+ephemeral runner pod is the full build environment.
+
+- **Built + pushed by** `.github/workflows/build-capturly-android-runner.yml` →
+  `ghcr.io/nx211/capturly-android-runner`.
+- **Consumed by** the `arc-runners-android` scale set
+  (`argocd/applications/arc-runners-android.yaml`), which only the trusted
+  `release-android` workflow in `capturly.app` targets via `runs-on: homelab-android`.
+
+Toolchain versions are pinned to `apps/mobile/android/build.gradle` in the
+`capturly.app` repo — bump this image when those change. See
+`docs/runbooks/capturly-android-arc-runner.md` for setup, rotation, and the
+SOC 2 control notes.

--- a/arc-runners-android/build-cache-pvc.yaml
+++ b/arc-runners-android/build-cache-pvc.yaml
@@ -1,0 +1,18 @@
+---
+# Persistent Gradle + ccache store shared across ephemeral runner pods. Because
+# the runner is scale-to-zero and pods rotate per job, the cache lives here, not
+# in the pod. ReadWriteOnce is sufficient with maxRunners: 1 (jobs serialize).
+# If maxRunners is raised, switch to a ReadWriteMany storageClass.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: arc-android-build-cache
+  namespace: arc-runners
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  # storageClassName omitted → cluster default RWO class. Set explicitly if the
+  # homelab default is not the intended tier.

--- a/arc-runners-android/externalsecret-github-app.yaml
+++ b/arc-runners-android/externalsecret-github-app.yaml
@@ -1,0 +1,37 @@
+---
+# GitHub App credentials ARC uses to register runners with the capturly.app repo.
+# Source of truth is Bitwarden Secrets Manager (ClusterSecretStore
+# bitwarden-secrets-manager); ESO materializes them into the `arc-github-app`
+# secret the gha-runner-scale-set chart consumes.
+#
+# Create these three secrets in Bitwarden SM (project Capturly) from a REPO-SCOPED
+# GitHub App (permissions: Actions R/W, Administration R/W, Metadata R) installed
+# on Corey-Alan-Consulting/capturly.app:
+#   capturly-arc-github-app-id                → the App ID
+#   capturly-arc-github-app-installation-id   → the installation ID on the repo
+#   capturly-arc-github-app-private-key        → the App private key (PEM)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: arc-github-app
+  namespace: arc-runners
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: arc-github-app
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+  data:
+    - secretKey: github_app_id
+      remoteRef:
+        key: capturly-arc-github-app-id
+    - secretKey: github_app_installation_id
+      remoteRef:
+        key: capturly-arc-github-app-installation-id
+    - secretKey: github_app_private_key
+      remoteRef:
+        key: capturly-arc-github-app-private-key

--- a/arc-runners-android/networkpolicy.yaml
+++ b/arc-runners-android/networkpolicy.yaml
@@ -25,6 +25,23 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+    # Kubernetes API server. Required so the runner can create workflow-job pods
+    # under containerMode: kubernetes (and harmless for containerMode: none). The
+    # control-plane node (blacktalon 10.20.0.250:6443) is the post-DNAT endpoint;
+    # the `kubernetes` ClusterIP (10.43.0.1:443) covers pre-DNAT. Both are inside
+    # the RFC1918 block denied below, so they must be allowed explicitly.
+    - to:
+        - ipBlock:
+            cidr: 10.20.0.250/32
+      ports:
+        - protocol: TCP
+          port: 6443
+    - to:
+        - ipBlock:
+            cidr: 10.43.0.1/32
+      ports:
+        - protocol: TCP
+          port: 443
     # Outbound HTTPS to the public internet only — private ranges (cluster
     # services, other namespaces, homelab hosts) are excluded to block lateral
     # movement.

--- a/arc-runners-android/networkpolicy.yaml
+++ b/arc-runners-android/networkpolicy.yaml
@@ -1,0 +1,40 @@
+---
+# Egress restriction for the Android runner pods. The runner executes build code;
+# this denies it any path INTO the rest of the homelab (lateral movement) while
+# allowing the outbound HTTPS it needs (GitHub, Google/Play/WIF, Bitwarden, npm,
+# Maven/Gradle). DNS is allowed to cluster DNS only.
+#
+# NOTE: plain k8s NetworkPolicy cannot allowlist by FQDN — it blocks private
+# ranges as a portable anti-lateral-movement baseline. For true FQDN egress
+# allowlisting, replace with a CiliumNetworkPolicy (example in the runbook).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: arc-android-runner-egress
+  namespace: arc-runners
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # Cluster DNS
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Outbound HTTPS to the public internet only — private ranges (cluster
+    # services, other namespaces, homelab hosts) are excluded to block lateral
+    # movement.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443

--- a/argocd/applications/arc-controller.yaml
+++ b/argocd/applications/arc-controller.yaml
@@ -1,0 +1,57 @@
+---
+# Actions Runner Controller (ARC) — the operator that manages self-hosted GitHub
+# Actions runner scale sets. Installs the controller + AutoscalingRunnerSet CRDs
+# only; the runner scale set CR lives in the `arc-runners-android` app. Follows
+# the third-party-operator pattern (see external-secrets-operator, redis-operator).
+#
+# PREREQ: the chart is published to an OCI registry. Register it once so Argo can
+# pull it (public, no creds):
+#   argocd repo add ghcr.io/actions/actions-runner-controller-charts \
+#     --type helm --enable-oci
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-controller
+  namespace: argocd
+  annotations:
+    # Controller + CRDs must exist before any AutoscalingRunnerSet CR syncs.
+    argocd.argoproj.io/sync-wave: "-2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: ghcr.io/actions/actions-runner-controller-charts
+    chart: gha-runner-scale-set-controller
+    targetRevision: 0.14.2
+    helm:
+      valuesObject:
+        replicaCount: 1
+        resources:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-systems
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      # AutoscalingRunnerSet CRDs are large; SSA avoids the client-side
+      # last-applied-configuration annotation size limit.
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd/applications/arc-runners-android-config.yaml
+++ b/argocd/applications/arc-runners-android-config.yaml
@@ -1,0 +1,30 @@
+---
+# Namespace-scoped supporting resources for the Capturly Android runner scale set:
+# the ESO-synced GitHub App secret, an egress-restricting NetworkPolicy, and the
+# persistent build cache. Plain-YAML directory source so it stays simple and
+# self-heals independently of the upstream ARC chart app.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-runners-android-config
+  namespace: argocd
+  annotations:
+    # Before the runner scale set (wave 0) so the GitHub App secret exists first.
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: main
+    path: arc-runners-android
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-runners
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/applications/arc-runners-android.yaml
+++ b/argocd/applications/arc-runners-android.yaml
@@ -1,0 +1,87 @@
+---
+# Capturly Android release runner scale set. Ephemeral, repo-scoped, scale-to-zero
+# GitHub Actions runners that build + sign the release AAB on homelab compute.
+# Only the TRUSTED release-android workflow (tag / workflow_dispatch) targets
+# `runs-on: homelab-android`; untrusted PR builds stay on GitHub-hosted runners.
+#
+# Auth to GitHub is via a repo-scoped GitHub App whose credentials ESO syncs from
+# Bitwarden into the `arc-github-app` secret (see arc-runners-android/). WIF to
+# GCP/Play stays keyless from the workflow — no cloud key here.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-runners-android
+  namespace: argocd
+  annotations:
+    # Sync after the controller/CRDs (wave -2) and the config app (wave -1).
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: ghcr.io/actions/actions-runner-controller-charts
+    chart: gha-runner-scale-set
+    targetRevision: 0.14.2
+    helm:
+      # The scale set name is what workflows reference as `runs-on`.
+      releaseName: homelab-android
+      valuesObject:
+        githubConfigUrl: https://github.com/Corey-Alan-Consulting/capturly.app
+        # Pre-created by ESO (arc-runners-android/externalsecret-github-app.yaml).
+        githubConfigSecret: arc-github-app
+        # Point at the controller SA explicitly instead of relying on the chart's
+        # in-cluster label discovery (name derives from the arc-controller app's
+        # release name; namespace is the controller app's destination).
+        controllerServiceAccount:
+          namespace: arc-systems
+          name: arc-controller-gha-rs-controller
+        runnerScaleSetName: homelab-android
+        # Releases are infrequent and serialized; one runner keeps a single
+        # ReadWriteOnce build-cache PVC conflict-free.
+        minRunners: 0
+        maxRunners: 1
+        # Runner runs the job steps in its own pod — the image IS the build env.
+        template:
+          spec:
+            securityContext:
+              # runner uid/gid so the job can write the mounted cache PVC.
+              fsGroup: 1001
+            containers:
+              - name: runner
+                image: ghcr.io/nx211/capturly-android-runner:0.1.0
+                command: ["/home/runner/run.sh"]
+                resources:
+                  requests:
+                    cpu: "2"
+                    memory: 6Gi
+                  limits:
+                    cpu: "6"
+                    memory: 12Gi
+                volumeMounts:
+                  - name: build-cache
+                    mountPath: /home/runner/.gradle
+                    subPath: gradle
+                  - name: build-cache
+                    mountPath: /home/runner/.cache/ccache
+                    subPath: ccache
+            volumes:
+              - name: build-cache
+                persistentVolumeClaim:
+                  claimName: arc-android-build-cache
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-runners
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/docs/runbooks/capturly-android-arc-runner.md
+++ b/docs/runbooks/capturly-android-arc-runner.md
@@ -1,0 +1,90 @@
+# Runbook: Capturly Android self-hosted ARC runner
+
+Ephemeral, repo-scoped GitHub Actions runners on homelab k8s that build + sign the
+Capturly **Android release AAB**. Only the trusted `release-android` workflow
+(`runs-on: homelab-android`) uses them; PR/CI Android builds stay GitHub-hosted.
+iOS is **not** covered (needs macOS hardware; stays cloud). Rationale:
+`framework/decisions/0016-self-hosted-arc-runners.md`.
+
+## Components
+
+| Where | What |
+|---|---|
+| `argocd/applications/arc-controller.yaml` | ARC controller + CRDs (ns `arc-systems`) |
+| `argocd/applications/arc-runners-android.yaml` | `homelab-android` runner scale set (ns `arc-runners`) |
+| `argocd/applications/arc-runners-android-config.yaml` | directory app for the extras below |
+| `arc-runners-android/externalsecret-github-app.yaml` | GitHub App creds from Bitwarden → `arc-github-app` secret |
+| `arc-runners-android/networkpolicy.yaml` | egress lock-down (no lateral movement) |
+| `arc-runners-android/build-cache-pvc.yaml` | persistent Gradle + ccache store |
+| `apps/capturly-android-runner/Dockerfile` | runner image (`ghcr.io/nx211/capturly-android-runner`) |
+| `.github/workflows/build-capturly-android-runner.yml` | builds/pushes the image |
+
+## One-time setup (in order)
+
+1. **GitHub App** (repo-scoped). Create an App on `Corey-Alan-Consulting/capturly.app`
+   with permissions **Actions: R/W**, **Administration: R/W**, **Metadata: R**.
+   Install it on that repo only. Note the App ID + installation ID; generate a
+   private key.
+2. **Bitwarden SM** (project Capturly) — create three secrets:
+   - `capturly-arc-github-app-id`
+   - `capturly-arc-github-app-installation-id`
+   - `capturly-arc-github-app-private-key` (the PEM)
+3. **Register the OCI Helm repo** with ArgoCD (public, no creds):
+   ```
+   argocd repo add ghcr.io/actions/actions-runner-controller-charts --type helm --enable-oci
+   ```
+4. **Storage class** — confirm `build-cache-pvc.yaml` binds on the cluster default
+   RWO class; set `storageClassName` explicitly if needed.
+5. **Build the runner image** — merge to `main` (or run the workflow) so
+   `ghcr.io/nx211/capturly-android-runner:0.1.0` exists before the scale set syncs.
+6. **GitHub Environment** `android-release` on capturly.app — add a required
+   reviewer and restrict deployment to the `@capturly/mobile@*` tag. This is the
+   SOC 2 change-management gate.
+7. **Merge the ArgoCD apps.** Sync order is handled by waves: controller (`-2`) →
+   config/ESO (`-1`) → runner scale set (`0`).
+
+## Validate (before trusting a real release)
+
+1. Controller healthy: `kubectl -n arc-systems get pods`.
+2. Secret materialized: `kubectl -n arc-runners get secret arc-github-app`.
+3. Runner registers: GitHub → capturly.app → Settings → Actions → Runners →
+   **homelab-android** listener online; `kubectl -n arc-runners get pods`.
+4. **Dry run**: `release-android` via `workflow_dispatch` with `runner=homelab-android`.
+   Watch it pull the image, hit the build cache, sign, and produce the AAB +
+   attestation. (Approve the environment gate when prompted.) To avoid a real Play
+   push during validation, temporarily skip the publish step or point it at the
+   internal track.
+5. Only then cut a real tag.
+
+## Secret rotation
+
+- **GitHub App key** — rotate in the App settings, update
+  `capturly-arc-github-app-private-key` in Bitwarden SM. ESO re-syncs within
+  `refreshInterval` (1h) or force: `kubectl -n arc-runners annotate externalsecret
+  arc-github-app force-sync=$(date +%s) --overwrite`.
+- **Android signing keystore** — lives in Bitwarden SM (project Capturly), fetched
+  per-run by the workflow; rotate there. Never stored on the runner.
+- **BWS access token** — the ESO ClusterSecretStore credential; rotate per the
+  platform-infra credential-rotation runbook.
+
+## SOC 2 control notes
+
+- **Trusted execution / separation:** only tag/dispatch events reach this runner;
+  no fork PR code. Enforced by `release-android.yml` triggers + the `android-release`
+  environment.
+- **Least privilege:** repo-scoped App, `minRunners: 0`, ephemeral pods, egress
+  NetworkPolicy (blocks RFC1918 → no lateral movement).
+- **Provenance:** the workflow emits keyless SLSA build provenance for the AAB.
+- **Logging:** runner pod logs are scraped by promtail → Loki; retain per policy.
+- **Availability:** releases depend on the homelab. Break-glass = re-run
+  `release-android` with `runner=ubuntu-latest`.
+- **Audit scope:** self-hosting brings this cluster's physical/network/patching
+  controls in-scope. Keep the rack access-controlled and the nodes patched.
+
+## FQDN egress (optional hardening)
+
+Plain k8s NetworkPolicy can't allowlist by hostname. If the cluster CNI is Cilium,
+replace `networkpolicy.yaml` with a `CiliumNetworkPolicy` using `toFQDNs` for
+`github.com`, `*.actions.githubusercontent.com`, `*.googleapis.com`,
+`*.bitwarden.com`, `registry.npmjs.org`, `dl.google.com`, and the Gradle/Maven
+hosts.

--- a/docs/runbooks/capturly-android-arc-runner.md
+++ b/docs/runbooks/capturly-android-arc-runner.md
@@ -81,6 +81,23 @@ iOS is **not** covered (needs macOS hardware; stays cloud). Rationale:
 - **Audit scope:** self-hosting brings this cluster's physical/network/patching
   controls in-scope. Keep the rack access-controlled and the nodes patched.
 
+## Reusing this for another app
+
+The ARC **controller is cluster-shared** — a second app does not redeploy it. Give
+each app its **own** repo-scoped, scale-to-zero scale set on that controller
+(per-app isolation beats one shared org runner). To onboard app `foo`:
+
+1. Copy `apps/capturly-android-runner/` → build `foo`'s toolchain image (a Node/
+   container app needs a **dind-capable** image; iOS needs a Mac — not here).
+2. Copy `argocd/applications/arc-runners-android.yaml` + the `arc-runners-android/`
+   directory → new names/namespace, set `runnerScaleSetName: foo-staging`,
+   `githubConfigUrl` to `foo`'s repo, and the `capturly-arc-github-app-*` Bitwarden
+   keys to `foo`'s App.
+3. In `foo`'s CI: for a **container** build, call `deploy-workflows`'
+   `build-push-generic` with `runner: foo-staging`; for a bespoke build, set
+   `runs-on: foo-staging` directly. GitHub-hosted (`ubuntu-latest`) stays the
+   default and the break-glass fallback.
+
 ## FQDN egress (optional hardening)
 
 Plain k8s NetworkPolicy can't allowlist by hostname. If the cluster CNI is Cilium,


### PR DESCRIPTION
## What

Self-hosted **Actions Runner Controller** scale set (`homelab-android`) that builds + **signs** the Capturly Android release AAB on homelab compute. GitHub stays the orchestrator and store-promotion surface; only the trusted `release-android` workflow (tag / dispatch) targets it. PR/CI Android builds stay GitHub-hosted. iOS is out of scope (needs macOS hardware).

Rationale: `framework/decisions/0016-self-hosted-arc-runners.md`.

## Components
- `argocd/applications/arc-controller.yaml` — `gha-runner-scale-set-controller` (OCI 0.14.2), ns `arc-systems`.
- `argocd/applications/arc-runners-android.yaml` — `gha-runner-scale-set` (0.14.2): ephemeral, `minRunners: 0`, explicit controller SA, custom image + shared Gradle/ccache PVC.
- `argocd/applications/arc-runners-android-config.yaml` + `arc-runners-android/` — ESO GitHub App secret (Bitwarden SM), egress NetworkPolicy (no lateral movement), build-cache PVC.
- `apps/capturly-android-runner/` — runner image (JDK 17 + Android SDK 36 / NDK 28.2.13676358 + Node 22 + pnpm + ccache), pinned to the app's `build.gradle`.
- `.github/workflows/build-capturly-android-runner.yml` → `ghcr.io/nx211/capturly-android-runner`.
- `docs/runbooks/capturly-android-arc-runner.md` — setup, validation, rotation, SOC 2 controls.

## Keyless / SOC 2 posture
- WIF stays keyless from self-hosted (workflow side). Only new long-lived secret: a repo-scoped GitHub App key in Bitwarden SM (no OIDC path for ARC registration).
- Trusted-events-only + ephemeral + repo-scoped + egress-restricted; `android-release` environment reviewer gate on the workflow side; keyless SLSA attestation on the AAB.
- Honest trade-off: self-hosting brings this cluster into SOC 2 audit scope (physical/network/patching/availability) — see the ADR + runbook.

## Validation
- `helm template` renders both charts at **0.14.2** (controller 10 objects, scale set 6); runner image, cache volumes, `fsGroup`, `minRunners/maxRunners`, command all wired.
- `actionlint` clean on the build workflow.
- Cluster-side steps (OCI repo registration, deploy, runner registration, dry-run release) are in the runbook — they need the live cluster.

## Before this works (one-time, in the runbook)
Create the GitHub App + Bitwarden secrets, `argocd repo add … --enable-oci`, build the runner image, add the `android-release` environment on capturly.app. **Paired with capturly.app PR (draft) — deploy this first; that PR must not merge until `homelab-android` registers.**
