### PR TITLE
feat(staging): Phase 1 cluster hardening (audit-first) + business/personal isolation

### DIFF
--- a/argocd/applications/business-plane.yaml
+++ b/argocd/applications/business-plane.yaml
@@ -1,0 +1,29 @@
+---
+# Business-plane isolation primitives: labeled namespaces, default-deny ingress,
+# the `business` ArgoCD project, and the business-critical PriorityClass. Kept in
+# the `default` project because it bootstraps the `business` project itself.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: business-plane
+  namespace: argocd
+  annotations:
+    # Earliest — namespaces/labels/priorityclass must exist before the build fleet.
+    argocd.argoproj.io/sync-wave: "-6"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: main
+    path: business-plane
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/argocd/applications/kyverno-policies-business.yaml
+++ b/argocd/applications/kyverno-policies-business.yaml
@@ -1,0 +1,28 @@
+---
+# Strict supply-chain policies scoped to the business plane only (personal
+# services run many registries and unsigned images — out of scope). AUDIT first;
+# graduate to Enforce once policy-reporter shows the business namespaces clean.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno-policies-business
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: main
+    path: kyverno-policies-business
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/argocd/applications/kyverno-policies.yaml
+++ b/argocd/applications/kyverno-policies.yaml
@@ -1,0 +1,37 @@
+---
+# Pod Security Standards + best-practice baseline (Kyverno's maintained bundle),
+# cluster-wide in AUDIT. This surfaces every gap (including the many personal
+# self-hosted services that run privileged / as root / with hostPath) without
+# breaking anything. Review PolicyReports in policy-reporter, then graduate
+# individual policies to Enforce — starting with the business namespaces.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno-policies
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://kyverno.github.io/kyverno/
+    chart: kyverno-policies
+    targetRevision: 3.8.2
+    helm:
+      valuesObject:
+        # AUDIT everywhere first (see doc: graduate to Enforce per namespace).
+        # Baseline cluster-wide; the business namespaces additionally carry PSA
+        # `restricted` audit/warn labels, so restricted is covered where it matters.
+        validationFailureAction: Audit
+        podSecurityStandard: baseline
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/argocd/applications/kyverno.yaml
+++ b/argocd/applications/kyverno.yaml
@@ -1,0 +1,50 @@
+---
+# Kyverno admission engine (staging). Mirrors the prod control (platform-infra)
+# so staging can validate policy compliance, not just app behavior. Policies are
+# rolled out in AUDIT first (kyverno-policies + kyverno-policies-business apps);
+# nothing is rejected until each policy is deliberately graduated to Enforce.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno
+  namespace: argocd
+  annotations:
+    # Engine + CRDs before any policy app that references them.
+    argocd.argoproj.io/sync-wave: "-5"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://kyverno.github.io/kyverno/
+    chart: kyverno
+    targetRevision: 3.8.2
+    helm:
+      valuesObject:
+        # Single replica per controller — staging is resource-constrained. The
+        # admission webhook uses failurePolicy per policy; Audit policies never
+        # block, so a brief controller blip cannot wedge deploys.
+        admissionController:
+          replicas: 1
+        backgroundController:
+          replicas: 1
+        reportsController:
+          replicas: 1
+        cleanupController:
+          replicas: 1
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd/applications/policy-reporter.yaml
+++ b/argocd/applications/policy-reporter.yaml
@@ -1,0 +1,41 @@
+---
+# Policy Reporter — the audit surface for Kyverno PolicyReports. This is how you
+# "audit the actual cluster and fine-tune before enforcing": the UI aggregates
+# every Audit-mode violation so you can see what would break under Enforce, per
+# namespace, before graduating any policy. Mirrors prod (kyverno-policy-reporter).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: policy-reporter
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://kyverno.github.io/policy-reporter
+    chart: policy-reporter
+    targetRevision: 3.8.1
+    helm:
+      valuesObject:
+        # Kyverno plugin + the read-only UI (reachable in-cluster / via Tailscale;
+        # not publicly exposed — staging is internal only).
+        kyverno:
+          enabled: true
+        ui:
+          enabled: true
+        plugin:
+          kyverno:
+            enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: policy-reporter
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/argocd/applications/tetragon.yaml
+++ b/argocd/applications/tetragon.yaml
@@ -1,0 +1,39 @@
+---
+# Tetragon — eBPF runtime security/observability (staging). Mirrors prod
+# (platform-infra/argocd/applications/tetragon.yaml, helm.cilium.io 1.7.0).
+# Deployed in OBSERVE mode: it records process/exec/network events but enforces
+# nothing yet. Highest-value runtime control here because the build runners
+# execute third-party build code — this is the eyes on that surface (CC6.6/6.8).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tetragon
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://helm.cilium.io
+    chart: tetragon
+    targetRevision: 1.7.0
+    helm:
+      valuesObject:
+        # Observe only — no enforcement TracingPolicies in Phase 1.
+        tetragon:
+          enablePolicyFilter: true
+        # Ship process/network events to stdout → promtail → Loki (retention per
+        # logging-monitoring-policy). Export tuning is a fine-tune item.
+        exportDirectory: /var/run/cilium/tetragon
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tetragon
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/business-plane/appproject.yaml
+++ b/business-plane/appproject.yaml
@@ -1,0 +1,36 @@
+---
+# ArgoCD project that fences the business/build apps off from the personal ones.
+# Apps in this project may deploy ONLY into the business namespaces from the
+# homelab-infra repo + the pinned upstream charts — so a personal app manifest
+# can never land in a business namespace, and vice versa. Move the build-fleet
+# Applications to `project: business` (arc-controller, arc-runners-android[-config]).
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: business
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: SOC-2 in-scope business / build-fleet workloads
+  sourceRepos:
+    - https://github.com/NX211/homelab-infra.git
+    - ghcr.io/actions/actions-runner-controller-charts
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: arc-systems
+    - server: https://kubernetes.default.svc
+      namespace: arc-runners
+  # ARC installs its own cluster-scoped CRDs/RBAC; allow the kinds it needs.
+  clusterResourceWhitelist:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRole
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+    - group: ""
+      kind: Namespace
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"

--- a/business-plane/namespaces.yaml
+++ b/business-plane/namespaces.yaml
@@ -1,0 +1,26 @@
+---
+# The "business plane" — namespaces that carry SOC-2-in-scope workloads (the build
+# fleet today; extend the label to other business namespaces later). Labeling them
+# `plane: business` is what the NetworkPolicies and namespace-scoped Kyverno
+# policies select on, so the personal self-hosted services (media stack, etc.)
+# stay outside the boundary and cannot reach in.
+#
+# Pod Security is set to AUDIT/WARN restricted (observe) — not enforce — so we can
+# see violations before turning the gate on.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: arc-systems
+  labels:
+    plane: business
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: arc-runners
+  labels:
+    plane: business
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/business-plane/networkpolicies.yaml
+++ b/business-plane/networkpolicies.yaml
@@ -1,0 +1,56 @@
+---
+# Personal ⇒ business isolation. K3s ships a NetworkPolicy controller, so these
+# ENFORCE (unlike the other Phase 1 controls, which are audit/observe). Each
+# business namespace denies all ingress by default, then re-allows only what it
+# needs. Nothing in the personal plane can open a connection into a business
+# namespace. (Egress from the runners is governed separately by the runner's own
+# policy; tightening that to the API server + FQDN is a fine-tune item — see the
+# runbook.)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: arc-systems
+spec:
+  podSelector: {}
+  policyTypes: [Ingress]
+  # no ingress rules ⇒ deny all inbound
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: arc-runners
+spec:
+  podSelector: {}
+  policyTypes: [Ingress]
+---
+# Allow Prometheus to scrape metrics from the business namespaces. Adjust the
+# namespace name if the monitoring stack lives elsewhere.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring-ingress
+  namespace: arc-systems
+spec:
+  podSelector: {}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring-ingress
+  namespace: arc-runners
+spec:
+  podSelector: {}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring

--- a/business-plane/priorityclass.yaml
+++ b/business-plane/priorityclass.yaml
@@ -1,0 +1,14 @@
+---
+# Business workloads outrank personal self-hosted services under resource
+# pressure: a noisy media job can never preempt or starve a release build. Set
+# `priorityClassName: business-critical` on business workloads (the ARC scale set,
+# controller). Below system-critical; not the global default, so personal
+# services stay at priority 0.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: business-critical
+value: 1000000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: "SOC-2 in-scope business workloads (build fleet). Preempts personal services under contention."

--- a/docs/runbooks/staging-phase1-hardening.md
+++ b/docs/runbooks/staging-phase1-hardening.md
@@ -1,0 +1,99 @@
+# Runbook: Staging Phase 1 — cluster hardening (audit-first)
+
+Brings the staging K3s cluster toward prod's SOC 2 posture **without enforcing
+anything yet**, and establishes a **business/personal isolation boundary** so the
+personal self-hosted services can't reach or starve the business (build) plane.
+Everything here is Audit/observe or safe-by-construction. Plan of record:
+`framework/platform/staging-build-platform.md` (Phase 1). Merge → deploy →
+**audit the actual cluster in policy-reporter** → fine-tune → then graduate to
+Enforce.
+
+## What this deploys
+
+| Component | Mode | ArgoCD app |
+|---|---|---|
+| Kyverno engine | — | `kyverno` (chart 3.8.2) |
+| Pod Security + best-practice policies | **Audit**, cluster-wide | `kyverno-policies` (3.8.2) |
+| Policy Reporter (+ UI) | audit dashboard | `policy-reporter` (3.8.1) |
+| Business supply-chain policies (registry allowlist, cosign verify) | **Audit**, `plane: business` only | `kyverno-policies-business` |
+| Tetragon | **observe** | `tetragon` (helm.cilium.io 1.7.0) |
+| Business plane (namespaces, default-deny ingress, AppProject, PriorityClass) | enforced (safe) | `business-plane` |
+
+## The isolation model (personal ⇏ business)
+
+- **Namespace boundary.** `arc-systems` + `arc-runners` are labeled `plane: business`.
+  Extend the label to any other business namespace to bring it inside the boundary.
+- **Network.** K3s runs a NetworkPolicy controller, so `default-deny-ingress` in the
+  business namespaces **enforces**: no personal pod can open a connection into a
+  business namespace. Only cluster monitoring is allowed in (metrics scrape).
+- **GitOps.** The `business` ArgoCD AppProject restricts business apps to business
+  namespaces + the pinned repos — a personal manifest can't target a business ns.
+  *Action:* set `project: business` on `arc-controller`, `arc-runners-android`,
+  `arc-runners-android-config`.
+- **Scheduling.** `business-critical` PriorityClass so a noisy personal service can
+  never preempt a build. *Action:* set `priorityClassName: business-critical` on the
+  ARC controller + scale-set pods. Optional hardening: taint a node
+  `plane=business:NoSchedule` and add the matching toleration/nodeSelector for true
+  hardware isolation.
+
+## Audit → Enforce workflow
+
+1. Sync the apps; open **policy-reporter UI** (internal/Tailscale only).
+2. Expect **many** violations from the personal services (privileged, run-as-root,
+   hostPath, `:latest`) — that's the point of Audit; they stay out of scope.
+3. Confirm the **business namespaces** are clean (or become clean after the
+   fine-tunes below).
+4. Graduate per policy, business namespaces first: set `validationFailureAction:
+   Enforce` (or move the namespace into an enforce cohort). Never enforce
+   cluster-wide in one step.
+
+## Required before enforcing `verify-image-signatures-business`
+
+The runner image must be **cosign-signed** or the (Audit) verify policy will flag
+it. Add keyless signing to `.github/workflows/build-capturly-android-runner.yml`
+(the runner-image build, on the `feat/capturly-android-arc-runner` branch / #557):
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+  id-token: write            # keyless Cosign
+# after Build & push (give it `id: build`):
+- uses: sigstore/cosign-installer@v3
+- run: cosign sign --yes "${IMAGE}@${DIGEST}"
+  env:
+    IMAGE: ${{ env.IMAGE }}
+    DIGEST: ${{ steps.build.outputs.digest }}
+```
+
+The policy's keyless `subject` already matches this repo's workflow identity.
+
+## Fine-tunes to do against the live cluster (before Enforce)
+
+- **Monitoring namespace name** in `business-plane/networkpolicies.yaml`
+  (`allow-monitoring-ingress`) — set it to wherever kube-prometheus-stack runs, or
+  metrics scraping of the business namespaces will be denied.
+- **Runner egress** (the policy from #557) currently allows DNS + public 443 but
+  blocks RFC1918 — the ARC listener also needs the **Kubernetes API**. Add an egress
+  allow for the API server's address/port (control-plane IP or the service CIDR) or
+  the listener can't create runner pods. Tighten to FQDN egress only if you add
+  Cilium (K3s' built-in controller does not do FQDN policies).
+- **PriorityClass / project** wiring on the ARC apps (see isolation model).
+
+## SOC 2 control map (Phase 1)
+
+| TSC | Control | Here |
+|---|---|---|
+| CC6.6 | Network security | default-deny ingress (business ns), Tetragon |
+| CC6.8 | Malicious code / admission | Kyverno PSS + supply-chain policies (Audit) |
+| CC7.1 | Vuln / change mgmt | pinned chart versions; image scanning is Phase 2 |
+| CC7.2 | Monitoring | Tetragon events → Loki; policy-reporter |
+| CC6.1/6.8 | Isolation / least-privilege | `business` AppProject, PriorityClass, PSS labels |
+
+## Validation
+
+- `helm template` renders kyverno / kyverno-policies / policy-reporter / tetragon
+  at the pinned versions; ArgoCD apps + policy manifests YAML-validated.
+- Cluster-side: sync order is wave-driven (business-plane -6 → kyverno -5 →
+  policies/tetragon -4 → reporters/business-policies -3). Confirm each app Healthy,
+  then work the policy-reporter audit.

--- a/docs/runbooks/staging-phase1-hardening.md
+++ b/docs/runbooks/staging-phase1-hardening.md
@@ -70,15 +70,17 @@ The policy's keyless `subject` already matches this repo's workflow identity.
 
 ## Fine-tunes to do against the live cluster (before Enforce)
 
-- **Monitoring namespace name** in `business-plane/networkpolicies.yaml`
-  (`allow-monitoring-ingress`) — set it to wherever kube-prometheus-stack runs, or
-  metrics scraping of the business namespaces will be denied.
-- **Runner egress** (the policy from #557) currently allows DNS + public 443 but
-  blocks RFC1918 — the ARC listener also needs the **Kubernetes API**. Add an egress
-  allow for the API server's address/port (control-plane IP or the service CIDR) or
-  the listener can't create runner pods. Tighten to FQDN egress only if you add
-  Cilium (K3s' built-in controller does not do FQDN policies).
+- **Monitoring namespace** — *confirmed* `monitoring` on the live cluster, which is
+  what `business-plane/networkpolicies.yaml` (`allow-monitoring-ingress`) already
+  targets. No change needed.
+- **Runner egress → Kubernetes API** — *fixed* on #557: the runner egress policy now
+  allows the API server (control-plane `10.20.0.250:6443` + `kubernetes` ClusterIP
+  `10.43.0.1:443`). FQDN egress still needs Cilium (K3s' built-in kube-router
+  controller does IP/namespace policies only, confirmed on the cluster).
 - **PriorityClass / project** wiring on the ARC apps (see isolation model).
+- **Node isolation (optional)** — nodes are role-labeled (`redtalon`=apps,compute;
+  `blacktalon`=control-plane,storage). Pin the fleet to a node via nodeSelector, or
+  taint one `plane=business:NoSchedule` + toleration, for hardware isolation.
 
 ## SOC 2 control map (Phase 1)
 

--- a/kyverno-policies-business/restrict-image-registries.yaml
+++ b/kyverno-policies-business/restrict-image-registries.yaml
@@ -1,0 +1,37 @@
+---
+# Business-plane images may only come from our GHCR namespace or the ARC upstream
+# charts. Mirrors prod's restrict-image-registries, scoped by the `plane: business`
+# namespace label so the personal services are untouched. AUDIT for now.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-image-registries-business
+  annotations:
+    policies.kyverno.io/title: Restrict Image Registries (business plane)
+    policies.kyverno.io/category: Supply Chain
+    policies.kyverno.io/severity: high
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: validate-registries
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaceSelector:
+                matchLabels:
+                  plane: business
+      validate:
+        message: >-
+          Business-plane images must come from ghcr.io/nx211/* or
+          ghcr.io/actions/* (ARC). Found a disallowed registry.
+        pattern:
+          spec:
+            =(ephemeralContainers):
+              - image: "ghcr.io/nx211/* | ghcr.io/actions/*"
+            =(initContainers):
+              - image: "ghcr.io/nx211/* | ghcr.io/actions/*"
+            containers:
+              - image: "ghcr.io/nx211/* | ghcr.io/actions/*"

--- a/kyverno-policies-business/verify-image-signatures.yaml
+++ b/kyverno-policies-business/verify-image-signatures.yaml
@@ -1,0 +1,41 @@
+---
+# Verify keyless Cosign signatures on our own (ghcr.io/nx211/*) images in the
+# business plane. Signed by the homelab-infra build workflows via Sigstore/OIDC
+# (no key). Mirrors prod's verify-image-signature. AUDIT for now — graduate to
+# Enforce per namespace once policy-reporter is clean. Third-party ARC images
+# (ghcr.io/actions/*) are allowlisted by registry, not required to be re-signed
+# by us.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-image-signatures-business
+  annotations:
+    policies.kyverno.io/title: Verify Image Signatures (business plane)
+    policies.kyverno.io/category: Supply Chain
+    policies.kyverno.io/severity: high
+spec:
+  validationFailureAction: Audit
+  background: false
+  # Fail-open on webhook error so a Sigstore/registry blip never wedges deploys.
+  failurePolicy: Ignore
+  webhookTimeoutSeconds: 30
+  rules:
+    - name: verify-nx211-signatures
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaceSelector:
+                matchLabels:
+                  plane: business
+      verifyImages:
+        - imageReferences:
+            - "ghcr.io/nx211/*"
+          attestors:
+            - entries:
+                - keyless:
+                    subject: "https://github.com/NX211/homelab-infra/.github/workflows/*"
+                    issuer: "https://token.actions.githubusercontent.com"
+                    rekor:
+                      url: https://rekor.sigstore.dev


### PR DESCRIPTION
## What

Phase 1 of the staging build platform: bring the K3s staging cluster toward **prod's SOC 2 posture — audit-first, nothing enforced** — and establish a **business ⇔ personal isolation boundary** so the personal self-hosted services can't reach or starve the SOC-2-in-scope build plane. Plan of record: `framework/platform/staging-build-platform.md`. Merge → deploy → **audit in policy-reporter** → fine-tune → then graduate to Enforce.

## Admission control (Audit)
- **Kyverno 3.8.2** engine + **kyverno-policies** (Pod Security baseline) cluster-wide in **Audit** — surfaces every gap (incl. the personal stack) without rejecting anything.
- **policy-reporter 3.8.1** (+ UI) — the audit surface to see what *would* break under Enforce, per namespace.
- **Business supply-chain policies** (registry allowlist `ghcr.io/nx211|actions`, keyless **cosign** signature verify) scoped to `plane: business` only.

## Runtime (observe)
- **Tetragon 1.7.0** (mirrors prod, helm.cilium.io) in observe mode — eyes on the third-party code the build runners execute.

## Isolation (enforced, safe) — the "personal can't affect business" ask
- `plane: business` namespaces (`arc-systems`, `arc-runners`) with PSA `restricted` **audit/warn** labels.
- **default-deny ingress** — K3s runs a NetworkPolicy controller, so this *enforces*: no personal pod can open a connection into a business namespace.
- **`business` ArgoCD project** fences GitOps (a personal manifest can't target a business ns).
- **`business-critical` PriorityClass** — a noisy personal service can never preempt a build.

## Deliberately NOT enforced yet
Everything above is Audit/observe or safe-by-construction. Graduation to Enforce is per-namespace, business-first, after reviewing policy-reporter — steps + fine-tunes (monitoring-ns name, runner egress→API-server allow, priority/project wiring, runner-image cosign snippet) are in `docs/runbooks/staging-phase1-hardening.md`.

## Validation
- `helm template` renders kyverno / kyverno-policies (11 policies, Audit) / policy-reporter / tetragon at pinned versions; all ArgoCD apps + policy/NetworkPolicy manifests YAML-clean.
- Cluster-side sync order is wave-driven (business-plane −6 → kyverno −5 → policies/tetragon −4 → reporters/business-policies −3).

Independent of #557 (build fleet) and #341 (Capturly). Merge this to stand up the hardening; audit; fine-tune; enforce later.
