### PR TITLE
feat(arc): fence build fleet into the business ArgoCD project + priority class

### DIFF
--- a/argocd/applications/arc-controller.yaml
+++ b/argocd/applications/arc-controller.yaml
@@ -19,7 +19,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: business
   source:
     repoURL: ghcr.io/actions/actions-runner-controller-charts
     chart: gha-runner-scale-set-controller
@@ -27,6 +27,8 @@ spec:
     helm:
       valuesObject:
         replicaCount: 1
+        # Outrank personal services under contention (business-plane app).
+        priorityClassName: business-critical
         resources:
           requests:
             cpu: 25m

--- a/argocd/applications/arc-runners-android-config.yaml
+++ b/argocd/applications/arc-runners-android-config.yaml
@@ -14,7 +14,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: business
   source:
     repoURL: https://github.com/NX211/homelab-infra.git
     targetRevision: main

--- a/argocd/applications/arc-runners-android.yaml
+++ b/argocd/applications/arc-runners-android.yaml
@@ -18,7 +18,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: business
   source:
     repoURL: ghcr.io/actions/actions-runner-controller-charts
     chart: gha-runner-scale-set
@@ -44,6 +44,8 @@ spec:
         # Runner runs the job steps in its own pod — the image IS the build env.
         template:
           spec:
+            # Outrank personal services under contention (business-plane app).
+            priorityClassName: business-critical
             securityContext:
               # runner uid/gid so the job can write the mounted cache PVC.
               fsGroup: 1001


### PR DESCRIPTION
Completes the Phase 1 isolation wiring: moves the three arc-* apps into the `business` ArgoCD project (verified its whitelist covers the controller's cluster-scoped resources — ClusterRole/ClusterRoleBinding/CRD) and sets `priorityClassName: business-critical` on the controller + runner pods so personal services can't preempt a build. Safe: no resource kinds fall outside the project whitelist; validated with helm template.