### PR TITLE
fix(arc): address GitHub App secrets by Bitwarden UUID

### DIFF
--- a/arc-runners-android/externalsecret-github-app.yaml
+++ b/arc-runners-android/externalsecret-github-app.yaml
@@ -4,12 +4,13 @@
 # bitwarden-secrets-manager); ESO materializes them into the `arc-github-app`
 # secret the gha-runner-scale-set chart consumes.
 #
-# Create these three secrets in Bitwarden SM (project Capturly) from a REPO-SCOPED
-# GitHub App (permissions: Actions R/W, Administration R/W, Metadata R) installed
-# on Corey-Alan-Consulting/capturly.app:
-#   capturly-arc-github-app-id                → the App ID
-#   capturly-arc-github-app-installation-id   → the installation ID on the repo
-#   capturly-arc-github-app-private-key        → the App private key (PEM)
+# The three secrets live in Bitwarden SM (project Capturly), created from a
+# REPO-SCOPED GitHub App (Administration R/W + Metadata R, Actions R) installed on
+# Corey-Alan-Consulting/capturly.app. The Bitwarden ESO provider addresses secrets
+# by UUID, so remoteRef.key below is each secret's ID (names for reference):
+#   CAPTURLY_ARC_GITHUB_APP_ID               70d36903-a3fe-4522-a52f-b48b01313501
+#   CAPTURLY_ARC_GITHUB_APP_INSTALLATION_ID  20118fdd-4708-41e1-b217-b48b0132c7c8
+#   CAPTURLY_ARC_GITHUB_APP_PRIVATE_KEY      987a9abd-9144-4315-a0d4-b48b01336269
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -28,10 +29,10 @@ spec:
   data:
     - secretKey: github_app_id
       remoteRef:
-        key: capturly-arc-github-app-id
+        key: 70d36903-a3fe-4522-a52f-b48b01313501
     - secretKey: github_app_installation_id
       remoteRef:
-        key: capturly-arc-github-app-installation-id
+        key: 20118fdd-4708-41e1-b217-b48b0132c7c8
     - secretKey: github_app_private_key
       remoteRef:
-        key: capturly-arc-github-app-private-key
+        key: 987a9abd-9144-4315-a0d4-b48b01336269


### PR DESCRIPTION
The `arc-github-app` ExternalSecret used placeholder names as `remoteRef.key`; the Bitwarden ESO provider addresses secrets by **UUID** (confirmed against every working ExternalSecret on the cluster), so it was stuck in `SecretSyncedError`. Points the three keys at the real Bitwarden SM secret IDs. Once merged + synced, ESO materializes `arc-github-app` → the listener starts → the runner registers.