### PR TITLE
fix(kyverno): mutateDigest false for the Audit verify-images policy

### DIFF
--- a/kyverno-policies-business/verify-image-signatures.yaml
+++ b/kyverno-policies-business/verify-image-signatures.yaml
@@ -32,6 +32,10 @@ spec:
       verifyImages:
         - imageReferences:
             - "ghcr.io/nx211/*"
+          # Audit mode can't rewrite the image to its digest, so mutation must be
+          # off (Kyverno rejects mutateDigest: true with Audit). Flip to true when
+          # this policy graduates to Enforce.
+          mutateDigest: false
           attestors:
             - entries:
                 - keyless:


### PR DESCRIPTION
Kyverno's webhook rejected `verify-image-signatures-business` — `mutateDigest` defaults to true, but Audit mode can't mutate images to digest, so it must be false. (The registry-allowlist policy synced fine.) Flip to true when graduating this policy to Enforce.