### PR TITLE
fix(arc): read GitHub App secrets from the Staging - Capturly store

### DIFF
--- a/arc-runners-android/externalsecret-github-app.yaml
+++ b/arc-runners-android/externalsecret-github-app.yaml
@@ -1,8 +1,9 @@
 ---
 # GitHub App credentials ARC uses to register runners with the capturly.app repo.
-# Source of truth is Bitwarden Secrets Manager (ClusterSecretStore
-# bitwarden-secrets-manager); ESO materializes them into the `arc-github-app`
-# secret the gha-runner-scale-set chart consumes.
+# Source of truth is Bitwarden Secrets Manager, in the "Staging - Capturly"
+# project (ClusterSecretStore bitwarden-staging-capturly-web) — keeps the App key
+# scoped to a Capturly project, not the shared homelab one. ESO materializes them
+# into the `arc-github-app` secret the gha-runner-scale-set chart consumes.
 #
 # The three secrets live in Bitwarden SM (project Capturly), created from a
 # REPO-SCOPED GitHub App (Administration R/W + Metadata R, Actions R) installed on
@@ -19,7 +20,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: bitwarden-staging-capturly-web
     kind: ClusterSecretStore
   target:
     name: arc-github-app


### PR DESCRIPTION
The 3 GitHub App secrets now live in the `Staging - Capturly` Bitwarden project (`e4e50481`); switch the ExternalSecret from the shared `bitwarden-secrets-manager` store to `bitwarden-staging-capturly-web` (scoped to that project). UUIDs unchanged. Keeps the runner's App key in a Capturly-scoped project (better isolation than the shared homelab one). Once merged + synced: secret materializes → listener starts → runner registers.