### PR TITLE
fix(kyverno): stop ArgoCD drift on Kyverno-owned policy fields

### DIFF
--- a/argocd/applications/kyverno-policies-business.yaml
+++ b/argocd/applications/kyverno-policies-business.yaml
@@ -26,3 +26,11 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
+  # Kyverno mutates its own policies (defaults + autogen) via its SSA field
+  # manager, which ArgoCD would otherwise flag as perpetual drift. Ignore the
+  # fields Kyverno owns; we still manage everything we set.
+  ignoreDifferences:
+    - group: kyverno.io
+      kind: ClusterPolicy
+      managedFieldsManagers:
+        - kyverno

--- a/argocd/applications/kyverno-policies.yaml
+++ b/argocd/applications/kyverno-policies.yaml
@@ -35,3 +35,11 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
+  # Kyverno mutates its own policies (defaults + autogen) via its SSA field
+  # manager, which ArgoCD would otherwise flag as perpetual drift. Ignore the
+  # fields Kyverno owns; we still manage everything we set.
+  ignoreDifferences:
+    - group: kyverno.io
+      kind: ClusterPolicy
+      managedFieldsManagers:
+        - kyverno


### PR DESCRIPTION
Kyverno mutates its own ClusterPolicies (defaults + autogen rules) via its `kyverno` SSA field manager, so ArgoCD showed `kyverno-policies` and `kyverno-policies-business` as perpetually OutOfSync (though Healthy and enforcing). Add `ignoreDifferences` on `managedFieldsManagers: [kyverno]` to both apps — cosmetic-only, the policies already work. Field managers confirmed on-cluster (argocd-controller + kyverno).