### PR TITLE
feat(jlshaw-link): add staging signed-documents bucket

### DIFF
--- a/helm-charts/seaweedfs/values.yaml
+++ b/helm-charts/seaweedfs/values.yaml
@@ -100,6 +100,10 @@ buckets:
   # grants Read/Write/List on both.
   - jlshaw-link-resources-staging
   - jlshaw-link-certificates-staging
+  # Executed e-signature PDFs (SignWell) — private; the `jlshaw` identity needs
+  # Read/Write/List on this bucket added to the seaweedfs-s3-config-json blob
+  # in Bitwarden.
+  - jlshaw-link-signed-documents-staging
 
 # ---------------------------------------------------------------------------
 # Ingress: external S3 endpoint via Traefik + cert-manager

--- a/staging-apps/jlshaw-link/values.yaml
+++ b/staging-apps/jlshaw-link/values.yaml
@@ -128,6 +128,12 @@ staging-app:
       value: jlshaw-link-resources-staging
     - name: S3_CERTIFICATES_BUCKET
       value: jlshaw-link-certificates-staging
+    # Private bucket for executed e-signature PDFs (SignWell). Required for
+    # document-completed processing; the app fails loudly without it. The
+    # `jlshaw` S3 identity needs Read/Write/List on this bucket in the
+    # seaweedfs-s3-config-json Bitwarden blob.
+    - name: S3_SIGNED_DOCUMENTS_BUCKET
+      value: jlshaw-link-signed-documents-staging
   envFrom:
     - secretRef:
         name: jlshaw-staging-secrets


### PR DESCRIPTION
## Summary

Staging counterpart of the jlshaw signed-documents storage (see the platform-infra PR of the same branch name). Private SeaweedFS bucket for executed e-signature PDFs.

- New bucket `jlshaw-link-signed-documents-staging` in the seaweedfs chart values.
- `S3_SIGNED_DOCUMENTS_BUCKET` env var added to the staging jlshaw-link app.
- The scoped `jlshaw` S3 identity gains Read/Write/List on the new bucket in the `seaweedfs-s3-config-json` Bitwarden blob (already applied there; values change documents it).

## Deploy note
The SeaweedFS filer must be restarted after merge to load the updated identities.