### PR TITLE
feat(tekton): Phase 1 — trusted Android release on Tekton

### DIFF
--- a/.github/workflows/build-capturly-android-toolchain.yml
+++ b/.github/workflows/build-capturly-android-toolchain.yml
@@ -1,0 +1,82 @@
+name: Build capturly-android-toolchain
+
+# Builds the Tekton step image for Capturly Android release builds (Node/pnpm/
+# JDK17/Android SDK+NDK) and pushes it to GHCR, then pins the published digest
+# into the android-build catalog pipeline so builds pull an immutable image
+# (ADR-0004). Runs on changes to the image or this workflow, or on demand.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "apps/capturly-android-toolchain/**"
+      - ".github/workflows/build-capturly-android-toolchain.yml"
+
+concurrency:
+  group: build-capturly-android-toolchain
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/nx211/capturly-android-toolchain
+  VERSION: "0.1.0"
+  PIPELINE: build-catalog/pipelines/android-build.yaml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GITOPS_APP_ID }}
+          private-key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: apps/capturly-android-toolchain
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          sbom: false
+          tags: |
+            ${{ env.IMAGE }}:${{ env.VERSION }}
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:sha-${{ github.sha }}
+
+      - uses: mikefarah/yq@v4
+
+      - name: Pin digest into the android-build pipeline
+        env:
+          REF: ${{ env.IMAGE }}:${{ env.VERSION }}@${{ steps.push.outputs.digest }}
+        run: |
+          yq -i '(.spec.params[] | select(.name == "toolchain-image") | .default) = strenv(REF)' "$PIPELINE"
+
+      - name: Commit pin-back
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- "$PIPELINE"; then
+            echo "No change; digest already pinned."
+            exit 0
+          fi
+          git add "$PIPELINE"
+          git commit -m "chore(android-toolchain): pin image ${{ steps.push.outputs.digest }}"
+          git push

--- a/apps/capturly-android-toolchain/Dockerfile
+++ b/apps/capturly-android-toolchain/Dockerfile
@@ -1,0 +1,49 @@
+# Toolchain image for Capturly Android release builds on Tekton.
+#
+# This is the STEP image the android-build catalog tasks run in — a plain
+# toolchain (not an actions-runner image; that ARC image was removed with the
+# Phase 0 cleanup). Bakes exactly what release-android needs so the ephemeral
+# build pod IS the environment and nothing is downloaded per run. Versions pinned
+# to apps/mobile/android/build.gradle: compileSdk 36 · buildToolsVersion 36.0.0 ·
+# ndkVersion 28.2.13676358 · JDK 17. Gradle comes from the repo wrapper (cached
+# on a PVC). Node/pnpm match the repo's packageManager.
+FROM eclipse-temurin:17-jdk-jammy
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      unzip curl git ca-certificates ccache python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node 22 + pnpm (pin matches the repo's packageManager)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g pnpm@9.15.9 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Android SDK: command-line tools + platform 36 + build-tools 36.0.0 + NDK
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+ENV ANDROID_HOME=/opt/android-sdk
+ARG ANDROID_PLATFORM=android-36
+ARG ANDROID_BUILD_TOOLS=36.0.0
+ARG ANDROID_NDK=28.2.13676358
+RUN mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools \
+    && curl -fsSL -o /tmp/cmdline-tools.zip \
+       https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \
+    && unzip -q /tmp/cmdline-tools.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools \
+    && mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/latest \
+    && rm /tmp/cmdline-tools.zip
+ENV PATH=${PATH}:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:${ANDROID_SDK_ROOT}/platform-tools
+RUN yes | sdkmanager --licenses > /dev/null \
+    && sdkmanager --install \
+       "platform-tools" \
+       "platforms;${ANDROID_PLATFORM}" \
+       "build-tools;${ANDROID_BUILD_TOOLS}" \
+       "ndk;${ANDROID_NDK}" > /dev/null
+
+ENV CMAKE_C_COMPILER_LAUNCHER=ccache
+ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+# Tekton runs steps as an arbitrary (often non-root) UID; keep the SDK readable.
+RUN chmod -R a+rX ${ANDROID_SDK_ROOT}

--- a/argocd/applications/capturly-builds-trusted.yaml
+++ b/argocd/applications/capturly-builds-trusted.yaml
@@ -1,0 +1,36 @@
+---
+# capturly Android trusted-tier build namespace (Phase 1). Namespace + SA +
+# egress netpol + signing/npm ESO + WIF cred config + the android-build catalog
+# tasks. The Pipeline is git-resolved from capturly/.tekton; the trigger is added
+# after the trusted-tier trigger decision. See docs/design/tekton-build-platform.md.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: capturly-builds-trusted
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: business
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: main
+    path: build-targets/capturly-android-trusted
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: capturly-builds-trusted
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/build-catalog/pipelines/android-build.yaml
+++ b/build-catalog/pipelines/android-build.yaml
@@ -1,0 +1,105 @@
+---
+# Channel pipeline: android-build. Authored once here; every project consumes it
+# from its .tekton/ PipelineRun via the git resolver + params (design §4). This
+# is the TRUSTED-tier release flow: build signed AAB → in-cluster approval gate
+# → keyless Play publish. Tekton Chains signs the PipelineRun for SLSA provenance
+# automatically (configured cluster-side).
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: android-build
+  labels:
+    app.kubernetes.io/part-of: build-catalog
+spec:
+  params:
+    - name: git-url
+      type: string
+    - name: git-revision
+      type: string
+      default: ""
+    - name: toolchain-image
+      type: string
+      default: ghcr.io/nx211/capturly-android-toolchain:0.1.0
+    - name: package
+      type: string
+      default: app.capturly.mobile
+    - name: track
+      type: string
+      default: alpha
+    - name: approvers
+      type: array
+      default: ["corey"]
+    - name: approvals-required
+      type: string
+      default: "1"
+  workspaces:
+    - name: source
+    - name: gradle-cache
+      optional: true
+    - name: keystore
+    - name: npmrc
+    - name: gcp-wif
+  tasks:
+    - name: clone
+      workspaces:
+        - name: output
+          workspace: source
+      taskSpec:
+        workspaces:
+          - name: output
+        params: []
+        steps:
+          - name: git-clone
+            image: alpine/git:2.45.2
+            script: |
+              #!/bin/sh
+              set -eu
+              cd "$(workspaces.output.path)"
+              git clone --depth 1 --branch "$(params.git-revision)" \
+                "$(params.git-url)" . 2>/dev/null || git clone "$(params.git-url)" .
+              [ -n "$(params.git-revision)" ] && git checkout "$(params.git-revision)" || true
+    - name: build
+      runAfter: [clone]
+      taskRef:
+        name: build-signed-aab
+      params:
+        - name: toolchain-image
+          value: $(params.toolchain-image)
+      workspaces:
+        - { name: source, workspace: source }
+        - { name: gradle-cache, workspace: gradle-cache }
+        - { name: keystore, workspace: keystore }
+        - { name: npmrc, workspace: npmrc }
+    # ── Change-management gate (design §6, RISK-BUILD-001) ──────────────────
+    # Blocks before publish until approvals-required approvers approve. Interim
+    # Tech-Preview component; fail-closed by construction (absent approval → the
+    # run stays pending, nothing publishes). VERIFY apiVersion/params against the
+    # installed manual-approval-gate release before trusting a real release.
+    - name: release-approval
+      runAfter: [build]
+      taskRef:
+        apiVersion: openshift-pipelines.org/v1alpha1
+        kind: ApprovalTask
+      params:
+        - name: approvers
+          value: $(params.approvers)
+        - name: numberOfApprovalsRequired
+          value: $(params.approvals-required)
+        - name: description
+          value: "Approve Play release of $(params.package) to $(params.track)"
+    - name: publish
+      runAfter: [release-approval]
+      taskRef:
+        name: play-publish
+      params:
+        - name: toolchain-image
+          value: $(params.toolchain-image)
+        - name: package
+          value: $(params.package)
+        - name: track
+          value: $(params.track)
+        - name: aab-path
+          value: $(tasks.build.results.aab-path)
+      workspaces:
+        - { name: source, workspace: source }
+        - { name: gcp-wif, workspace: gcp-wif }

--- a/build-catalog/tasks/build-signed-aab.yaml
+++ b/build-catalog/tasks/build-signed-aab.yaml
@@ -1,0 +1,83 @@
+---
+# Reusable catalog Task: build a signed Android release AAB.
+#
+# Faithful port of capturly/.github/workflows/release-android.yml (the trusted
+# release job): pnpm workspace deps → gradle bundleRelease with the Bitwarden
+# upload keystore → 16KB-alignment + policy-manifest checks. Toolchain lives in
+# the step image (design §4); signing material + npm auth arrive as secret-backed
+# workspaces so this Task stays project-agnostic.
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-signed-aab
+  labels:
+    app.kubernetes.io/part-of: build-catalog
+spec:
+  params:
+    - name: toolchain-image
+      description: Node+pnpm+JDK17+Android SDK image the build runs in.
+      type: string
+    - name: mobile-dir
+      description: Path to the mobile app within the repo.
+      type: string
+      default: apps/mobile
+  workspaces:
+    - name: source        # cloned repo (from git-clone)
+    - name: gradle-cache   # persistent ~/.gradle (optional but recommended)
+      optional: true
+    - name: keystore      # secret: upload-keystore.jks.b64, store-password, key-alias, key-password
+      mountPath: /secrets/keystore
+    - name: npmrc         # secret: .npmrc with the @corey-alan-consulting read token
+      mountPath: /secrets/npm
+  results:
+    - name: aab-path
+      description: Path to the built AAB within the source workspace.
+  steps:
+    - name: pnpm-workspace-deps
+      image: $(params.toolchain-image)
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: HOME
+          value: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        cp /secrets/npm/.npmrc "$HOME/.npmrc"
+        # Retry: @prisma/engines postinstall fetches binaries and can abort.
+        attempt=1; max=3
+        until pnpm install --frozen-lockfile; do
+          [ "$attempt" -ge "$max" ] && { echo "pnpm install failed"; exit 1; }
+          echo "retry $attempt/$max"; sleep $((attempt * 15)); attempt=$((attempt + 1))
+        done
+        # Metro resolves workspace deps via their built dist/ — compile first.
+        pnpm --filter "@capturly/mobile^..." --if-present build
+    - name: gradle-bundle-release
+      image: $(params.toolchain-image)
+      workingDir: $(workspaces.source.path)/$(params.mobile-dir)
+      env:
+        - name: HOME
+          value: $(workspaces.source.path)
+        # Signing material from the mounted keystore secret workspace.
+        - name: ANDROID_KEYSTORE_PASSWORD
+          valueFrom: { secretKeyRef: { name: capturly-android-signing, key: store-password } }
+        - name: ANDROID_KEY_ALIAS
+          valueFrom: { secretKeyRef: { name: capturly-android-signing, key: key-alias } }
+        - name: ANDROID_KEY_PASSWORD
+          valueFrom: { secretKeyRef: { name: capturly-android-signing, key: key-password } }
+        - name: SENTRY_AUTH_TOKEN
+          valueFrom: { secretKeyRef: { name: capturly-android-signing, key: sentry-auth-token } }
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # Materialize the upload keystore (base64 in the secret) to a temp path.
+        export ANDROID_KEYSTORE_PATH="$(mktemp -d)/upload-keystore.jks"
+        base64 -d /secrets/keystore/upload-keystore.jks.b64 > "$ANDROID_KEYSTORE_PATH"
+        ./gradlew bundleRelease --no-daemon
+        AAB="app/build/outputs/bundle/release/app-release.aab"
+        # 16KB page alignment (Play requirement) + policy-clean merged manifest.
+        python3 ../scripts/check-elf-alignment.py "$AAB"
+        MANIFEST="app/build/intermediates/merged_manifests/release/processReleaseManifest/AndroidManifest.xml"
+        if grep -E "AD_ID|READ_MEDIA_IMAGES|READ_MEDIA_VIDEO" "$MANIFEST"; then
+          echo "Policy-sensitive permission leaked into merged manifest"; exit 1
+        fi
+        echo -n "$(params.mobile-dir)/android/$AAB" > "$(results.aab-path.path)"

--- a/build-catalog/tasks/play-publish.yaml
+++ b/build-catalog/tasks/play-publish.yaml
@@ -38,7 +38,9 @@ spec:
           - serviceAccountToken:
               path: token
               expirationSeconds: 3600
-              audience: https://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/homelab-tekton/providers/homelab-oidc
+              # Must equal the external_account audience + the WIF provider's
+              # expected audience (homelab-staging/k3s-oidc; platform-infra).
+              audience: //iam.googleapis.com/projects/861533890029/locations/global/workloadIdentityPools/homelab-staging/providers/k3s-oidc
   steps:
     - name: publish
       image: $(params.toolchain-image)

--- a/build-catalog/tasks/play-publish.yaml
+++ b/build-catalog/tasks/play-publish.yaml
@@ -1,0 +1,62 @@
+---
+# Reusable catalog Task: publish an AAB to Google Play via keyless WIF.
+#
+# Keyless per-build identity (design §5, ADR-0005): a projected ServiceAccount
+# token (audience = the WIF pool) is exchanged by google-auth's external_account
+# credential config for the play-publisher SA — no downloaded key. The token's
+# subject is this pod's SA (capturly-android-trusted); the GCP-side pool/provider
+# that trusts the CLUSTER OIDC issuer is a platform-infra Terraform prereq.
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: play-publish
+  labels:
+    app.kubernetes.io/part-of: build-catalog
+spec:
+  params:
+    - name: toolchain-image
+      type: string
+    - name: package
+      type: string
+      default: app.capturly.mobile
+    - name: track
+      type: string
+      default: alpha
+    - name: aab-path
+      description: AAB path within the source workspace (from build-signed-aab).
+      type: string
+  workspaces:
+    - name: source
+    - name: gcp-wif        # configmap: credential-config.json (external_account)
+      mountPath: /gcp
+  volumes:
+    # Projected token whose audience matches the WIF provider. TTL is short;
+    # the token is minted per-run — this is the ephemeral build identity.
+    - name: gcp-oidc-token
+      projected:
+        sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 3600
+              audience: https://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/homelab-tekton/providers/homelab-oidc
+  steps:
+    - name: publish
+      image: $(params.toolchain-image)
+      workingDir: $(workspaces.source.path)/apps/mobile
+      volumeMounts:
+        - name: gcp-oidc-token
+          mountPath: /var/run/gcp
+          readOnly: true
+      env:
+        # external_account cred config points GOOGLE creds at the token file.
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /gcp/credential-config.json
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        pip install --quiet google-api-python-client google-auth
+        python3 scripts/play-upload.py \
+          --package "$(params.package)" \
+          --aab "$(workspaces.source.path)/$(params.aab-path)" \
+          --track "$(params.track)" \
+          --status completed

--- a/build-targets/capturly-android-trusted/externalsecret-git-and-webhook.yaml
+++ b/build-targets/capturly-android-trusted/externalsecret-git-and-webhook.yaml
@@ -47,4 +47,4 @@ spec:
       engineVersion: v2
   data:
     - secretKey: webhook-secret
-      remoteRef: { key: REPLACE-WITH-BWS-UUID-trusted-webhook-secret }
+      remoteRef: { key: a1d24301-63c2-45b3-ad62-b48d010f0f55 }  # CAPTURLY_TEKTON_TRUSTED_WEBHOOK_SECRET

--- a/build-targets/capturly-android-trusted/externalsecret-git-and-webhook.yaml
+++ b/build-targets/capturly-android-trusted/externalsecret-git-and-webhook.yaml
@@ -1,0 +1,50 @@
+---
+# Git basic-auth for cloning the private capturly.app source. The
+# `tekton.dev/git-0` annotation + linkage to the pipeline SA (see
+# namespace-and-sa.yaml `secrets:`) makes Tekton inject these creds into the
+# clone step automatically. Use the PaC GitHub App token or a scoped PAT.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: capturly-git
+  namespace: capturly-builds-trusted
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-staging-capturly-web
+    kind: ClusterSecretStore
+  target:
+    name: capturly-git
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/basic-auth
+      engineVersion: v2
+      metadata:
+        annotations:
+          tekton.dev/git-0: https://github.com
+  data:
+    - secretKey: username
+      remoteRef: { key: REPLACE-WITH-BWS-UUID-git-username }   # e.g. x-access-token
+    - secretKey: password
+      remoteRef: { key: REPLACE-WITH-BWS-UUID-git-token }
+---
+# HMAC secret the GitHub webhook signs with; the EventListener github interceptor
+# validates it. Set the same value on the capturly.app repo webhook.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: capturly-webhook
+  namespace: capturly-builds-trusted
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-staging-capturly-web
+    kind: ClusterSecretStore
+  target:
+    name: capturly-webhook
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+  data:
+    - secretKey: webhook-secret
+      remoteRef: { key: REPLACE-WITH-BWS-UUID-trusted-webhook-secret }

--- a/build-targets/capturly-android-trusted/externalsecret-npm.yaml
+++ b/build-targets/capturly-android-trusted/externalsecret-npm.yaml
@@ -1,0 +1,27 @@
+---
+# .npmrc granting read access to the private @corey-alan-consulting packages the
+# mobile workspace depends on. Templated from the org NPM_TOKEN (was a GitHub
+# secret; must be added to Bitwarden SM). Mounted as the `npmrc` workspace.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: capturly-npm
+  namespace: capturly-builds-trusted
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-staging-capturly-web
+    kind: ClusterSecretStore
+  target:
+    name: capturly-npm
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        .npmrc: |
+          //registry.npmjs.org/:_authToken={{ .npmToken }}
+          @corey-alan-consulting:registry=https://registry.npmjs.org/
+  data:
+    # ⚠️ TODO: add the org NPM read token to Bitwarden SM and set its UUID.
+    - secretKey: npmToken
+      remoteRef: { key: REPLACE-WITH-BWS-UUID-npm-token }

--- a/build-targets/capturly-android-trusted/externalsecret-signing.yaml
+++ b/build-targets/capturly-android-trusted/externalsecret-signing.yaml
@@ -1,0 +1,33 @@
+---
+# Android upload-keystore + signing material, synced from Bitwarden SM (project
+# Capturly) into the `capturly-android-signing` secret the build task mounts.
+# UUIDs are the SAME secrets release-android.yml already consumes (verified from
+# the workflow's bitwarden/sm-action block) — only sentry-auth-token is new.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: capturly-android-signing
+  namespace: capturly-builds-trusted
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-staging-capturly-web
+    kind: ClusterSecretStore
+  target:
+    name: capturly-android-signing
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+  data:
+    - secretKey: upload-keystore.jks.b64
+      remoteRef: { key: d58e27ce-900d-4ae4-a178-b48100fb27a4 }  # ANDROID_KEYSTORE_BASE64
+    - secretKey: store-password
+      remoteRef: { key: 3328a7d4-85af-4718-98b9-b48100fb28b3 }  # ANDROID_KEYSTORE_PASSWORD
+    - secretKey: key-alias
+      remoteRef: { key: 4561aaf7-9684-42f6-b2d7-b48100fb28ef }  # ANDROID_KEY_ALIAS
+    - secretKey: key-password
+      remoteRef: { key: 43bc3f16-1331-43ad-b343-b48100fb2932 }  # ANDROID_KEY_PASSWORD
+    # ⚠️ TODO: SENTRY_AUTH_TOKEN was a GitHub secret, not in Bitwarden. Create it
+    #    in Bitwarden SM (project Capturly) and set the UUID here.
+    - secretKey: sentry-auth-token
+      remoteRef: { key: REPLACE-WITH-BWS-UUID-sentry-auth-token }

--- a/build-targets/capturly-android-trusted/gradle-cache-pvc.yaml
+++ b/build-targets/capturly-android-trusted/gradle-cache-pvc.yaml
@@ -1,0 +1,13 @@
+---
+# Persistent Gradle/ccache store for the trusted Android build. RWO is fine —
+# releases are serialized (one at a time), so no concurrent-writer conflict.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: capturly-gradle-cache
+  namespace: capturly-builds-trusted
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi

--- a/build-targets/capturly-android-trusted/ingressroute.yaml
+++ b/build-targets/capturly-android-trusted/ingressroute.yaml
@@ -1,0 +1,23 @@
+---
+# Exposes the EventListener sink so GitHub can POST the tag-push webhook. This is
+# the ONE inbound path to the build platform (the Dashboard is not deployed, §10)
+# and it must be internet-reachable for GitHub. It is guarded by the webhook HMAC
+# (github interceptor) + the CEL tag filter — not by SSO (GitHub can't auth).
+#
+# ⚠️ TODO: set the real host; ensure public DNS + Traefik TLS resolve to it, and
+#    register this URL as the webhook on the capturly.app repo.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: capturly-android-trusted-el
+  namespace: capturly-builds-trusted
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`tekton-trusted.REPLACE.example`)
+      kind: Rule
+      services:
+        - name: el-capturly-android-trusted
+          port: 8080
+  tls: {}

--- a/build-targets/capturly-android-trusted/kustomization.yaml
+++ b/build-targets/capturly-android-trusted/kustomization.yaml
@@ -1,0 +1,19 @@
+# capturly Android trusted-tier build namespace + the catalog tasks the
+# android-build pipeline references by name (installed into this namespace so
+# taskRef resolution succeeds; the Pipeline itself is fetched via the git
+# resolver from .tekton). Trigger wiring (PaC Repository vs Tekton Triggers
+# EventListener) is added once the trusted-tier trigger mechanism is decided —
+# see the design note in the PR / runbook.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: capturly-builds-trusted
+resources:
+  - namespace-and-sa.yaml
+  - networkpolicy.yaml
+  - externalsecret-signing.yaml
+  - externalsecret-npm.yaml
+  - wif-credential-config.yaml
+  # Catalog tasks referenced by the android-build pipeline (name resolution
+  # happens in the PipelineRun namespace).
+  - ../../build-catalog/tasks/build-signed-aab.yaml
+  - ../../build-catalog/tasks/play-publish.yaml

--- a/build-targets/capturly-android-trusted/kustomization.yaml
+++ b/build-targets/capturly-android-trusted/kustomization.yaml
@@ -12,7 +12,13 @@ resources:
   - networkpolicy.yaml
   - externalsecret-signing.yaml
   - externalsecret-npm.yaml
+  - externalsecret-git-and-webhook.yaml
   - wif-credential-config.yaml
+  - gradle-cache-pvc.yaml
+  # Trusted-tier trigger: Tekton Triggers (tag push → PipelineRun).
+  - triggers.yaml
+  - triggers-rbac.yaml
+  - ingressroute.yaml
   # Catalog tasks referenced by the android-build pipeline (name resolution
   # happens in the PipelineRun namespace).
   - ../../build-catalog/tasks/build-signed-aab.yaml

--- a/build-targets/capturly-android-trusted/namespace-and-sa.yaml
+++ b/build-targets/capturly-android-trusted/namespace-and-sa.yaml
@@ -21,3 +21,7 @@ kind: ServiceAccount
 metadata:
   name: capturly-android-trusted
   namespace: capturly-builds-trusted
+# Tekton injects the `tekton.dev/git-0`-annotated basic-auth secret into the
+# clone step so the private capturly.app source can be fetched.
+secrets:
+  - name: capturly-git

--- a/build-targets/capturly-android-trusted/namespace-and-sa.yaml
+++ b/build-targets/capturly-android-trusted/namespace-and-sa.yaml
@@ -1,0 +1,23 @@
+---
+# Trusted-tier build namespace for capturly Android releases. Isolated from the
+# untrusted PR tier (separate namespace, Phase 2) so untrusted code can never
+# reach the signing keystore or the cloud identity that live here (design §1).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capturly-builds-trusted
+  labels:
+    build.capturly/tier: trusted
+    build.capturly/project: capturly
+    build.capturly/channel: android
+---
+# Per-(project,channel,tier) ServiceAccount. Its projected OIDC token is the
+# per-build identity federated to GCP WIF (design §5); no static cloud key. The
+# GCP-side pool/provider trusting the cluster issuer for this SA subject
+# (system:serviceaccount:capturly-builds-trusted:capturly-android-trusted) is a
+# platform-infra Terraform prereq.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capturly-android-trusted
+  namespace: capturly-builds-trusted

--- a/build-targets/capturly-android-trusted/networkpolicy.yaml
+++ b/build-targets/capturly-android-trusted/networkpolicy.yaml
@@ -1,0 +1,40 @@
+---
+# Trusted-tier egress: allow the outbound HTTPS the release build needs (GitHub,
+# npm, Maven/Gradle, Google/Play/WIF/STS, Bitwarden) + cluster DNS + the k8s API
+# (Tekton), and DENY all other private ranges to block lateral movement into the
+# homelab. Mirrors the retired ARC egress posture; FQDN-precise allowlisting
+# would need a CiliumNetworkPolicy (noted in the runbook).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: capturly-trusted-egress
+  namespace: capturly-builds-trusted
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - { protocol: UDP, port: 53 }
+        - { protocol: TCP, port: 53 }
+    # Kubernetes API (Tekton pod orchestration). Adjust endpoints to the cluster.
+    - to:
+        - ipBlock: { cidr: 10.20.0.250/32 }
+      ports:
+        - { protocol: TCP, port: 6443 }
+    - to:
+        - ipBlock: { cidr: 10.43.0.1/32 }
+      ports:
+        - { protocol: TCP, port: 443 }
+    # Public HTTPS only; private ranges excluded (anti lateral-movement).
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - { protocol: TCP, port: 443 }

--- a/build-targets/capturly-android-trusted/triggers-rbac.yaml
+++ b/build-targets/capturly-android-trusted/triggers-rbac.yaml
@@ -1,0 +1,37 @@
+---
+# ServiceAccount + RBAC for the EventListener sink: it must read Trigger CRs and
+# create PipelineRuns in this namespace. Binds the ClusterRoles the Tekton
+# Triggers install ships (tekton-triggers-eventlistener-roles /
+# -clusterroles). Distinct from the pipeline SA (capturly-android-trusted).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capturly-trigger
+  namespace: capturly-builds-trusted
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capturly-trigger-eventlistener
+  namespace: capturly-builds-trusted
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-eventlistener-roles
+subjects:
+  - kind: ServiceAccount
+    name: capturly-trigger
+    namespace: capturly-builds-trusted
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capturly-trigger-eventlistener-clusterroles
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-eventlistener-clusterroles
+subjects:
+  - kind: ServiceAccount
+    name: capturly-trigger
+    namespace: capturly-builds-trusted

--- a/build-targets/capturly-android-trusted/triggers.yaml
+++ b/build-targets/capturly-android-trusted/triggers.yaml
@@ -1,0 +1,88 @@
+---
+# Tekton Triggers wiring for the TRUSTED tier: a tag push on capturly.app →
+# EventListener (GitHub interceptor verifies the webhook HMAC + a CEL filter
+# limits to the @capturly/mobile@* release tag) → TriggerTemplate creates the
+# android-build PipelineRun in this namespace. PaC is NOT used here (its
+# repo→namespace 1:1 model can't split trusted/untrusted for one repo); PaC
+# drives the untrusted PR tier in Phase 2. Design §4/§6.
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: capturly-android-tag
+  namespace: capturly-builds-trusted
+spec:
+  params:
+    - name: git-url
+      value: $(body.repository.clone_url)
+    - name: git-revision
+      value: $(body.after)          # pushed commit SHA — clean checkout ref
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: capturly-android-release
+  namespace: capturly-builds-trusted
+spec:
+  params:
+    - name: git-url
+    - name: git-revision
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1
+      kind: PipelineRun
+      metadata:
+        generateName: capturly-android-release-
+      spec:
+        taskRunTemplate:
+          serviceAccountName: capturly-android-trusted
+        pipelineRef:
+          # Channel catalog via git resolver (design §4). Pin `revision` to a
+          # catalog tag once cut; `main` here for the skeleton. If NX211/homelab-
+          # infra is private, configure the git resolver token (runbook).
+          resolver: git
+          params:
+            - { name: url, value: https://github.com/NX211/homelab-infra.git }
+            - { name: revision, value: main }
+            - { name: pathInRepo, value: build-catalog/pipelines/android-build.yaml }
+        params:
+          - { name: git-url, value: $(tt.params.git-url) }
+          - { name: git-revision, value: $(tt.params.git-revision) }
+        workspaces:
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                accessModes: ["ReadWriteOnce"]
+                resources: { requests: { storage: 8Gi } }
+          - name: gradle-cache
+            persistentVolumeClaim: { claimName: capturly-gradle-cache }
+          - name: keystore
+            secret: { secretName: capturly-android-signing }
+          - name: npmrc
+            secret: { secretName: capturly-npm }
+          - name: gcp-wif
+            configMap: { name: capturly-gcp-wif }
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: capturly-android-trusted
+  namespace: capturly-builds-trusted
+spec:
+  serviceAccountName: capturly-trigger
+  triggers:
+    - name: tag-release
+      interceptors:
+        - ref: { name: github }
+          params:
+            - name: secretRef
+              value: { secretName: capturly-webhook, secretKey: webhook-secret }
+            - name: eventTypes
+              value: ["push"]
+        - ref: { name: cel }
+          params:
+            # Only the mobile release tag — not every push/branch.
+            - name: filter
+              value: "body.ref.startsWith('refs/tags/@capturly/mobile@')"
+      bindings:
+        - ref: capturly-android-tag
+      template:
+        ref: capturly-android-release

--- a/build-targets/capturly-android-trusted/wif-credential-config.yaml
+++ b/build-targets/capturly-android-trusted/wif-credential-config.yaml
@@ -4,11 +4,10 @@
 # the play-publish task mounts, exchanges it at STS for the play-publisher SA —
 # no downloaded key (ADR-0005). Mounted as the `gcp-wif` workspace.
 #
-# ⚠️ PREREQ (platform-infra Terraform): create a WIF pool + provider that trusts
-#    the CLUSTER OIDC issuer (not GitHub's) with attribute conditions on this SA
-#    subject, and grant it roles/iam.workloadIdentityUser on
-#    play-publisher-ci@capturly-app. Then set PROJECT_NUMBER + pool/provider IDs
-#    below AND the matching `audience` in build-catalog/tasks/play-publish.yaml.
+# Reuses the existing homelab-staging WIF pool / k3s-oidc provider (platform-infra
+# homelab-wif.tf) — the same one the ar-token-refresher federates through. The
+# platform-infra change adds this SA (capturly-android-trusted) to the provider's
+# attribute_condition and grants it workloadIdentityUser on play-publisher-ci@.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,7 +17,7 @@ data:
   credential-config.json: |
     {
       "type": "external_account",
-      "audience": "//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/homelab-tekton/providers/homelab-oidc",
+      "audience": "//iam.googleapis.com/projects/861533890029/locations/global/workloadIdentityPools/homelab-staging/providers/k3s-oidc",
       "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
       "token_url": "https://sts.googleapis.com/v1/token",
       "credential_source": {

--- a/build-targets/capturly-android-trusted/wif-credential-config.yaml
+++ b/build-targets/capturly-android-trusted/wif-credential-config.yaml
@@ -1,0 +1,29 @@
+---
+# GCP Workload Identity Federation credential config (external_account) for
+# keyless Play publishing. google-auth reads the projected SA token from the file
+# the play-publish task mounts, exchanges it at STS for the play-publisher SA —
+# no downloaded key (ADR-0005). Mounted as the `gcp-wif` workspace.
+#
+# ⚠️ PREREQ (platform-infra Terraform): create a WIF pool + provider that trusts
+#    the CLUSTER OIDC issuer (not GitHub's) with attribute conditions on this SA
+#    subject, and grant it roles/iam.workloadIdentityUser on
+#    play-publisher-ci@capturly-app. Then set PROJECT_NUMBER + pool/provider IDs
+#    below AND the matching `audience` in build-catalog/tasks/play-publish.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: capturly-gcp-wif
+  namespace: capturly-builds-trusted
+data:
+  credential-config.json: |
+    {
+      "type": "external_account",
+      "audience": "//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/homelab-tekton/providers/homelab-oidc",
+      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+      "token_url": "https://sts.googleapis.com/v1/token",
+      "credential_source": {
+        "file": "/var/run/gcp/token",
+        "format": { "type": "text" }
+      },
+      "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/play-publisher-ci@capturly-app.iam.gserviceaccount.com:generateAccessToken"
+    }

--- a/docs/design/tekton-build-platform.md
+++ b/docs/design/tekton-build-platform.md
@@ -25,7 +25,7 @@ The **unit of isolation is the trust tier**, not the runner.
 
 | | **Untrusted (PR/fork)** | **Trusted (release)** |
 |---|---|---|
-| Trigger | PaC `pull_request` (fork ⇒ `/ok-to-test` by a maintainer) | PaC protected-tag push |
+| Trigger | PaC `pull_request` (fork ⇒ `/ok-to-test` by a maintainer) | **Tekton Triggers** EventListener on tag push (see note) |
 | Code trust | arbitrary contributor code | maintainer-reviewed, merged |
 | Runtime | **gVisor** default; **Kata** for native/NDK channels (android) | standard (trusted); gVisor optional defense-in-depth |
 | Identity | zero-secret SA — no OIDC audience, no mounts | per-build SA → projected OIDC token → GCP WIF |
@@ -37,6 +37,15 @@ The **unit of isolation is the trust tier**, not the runner.
 | Gate | none needed (sandboxed, powerless) | in-cluster `ApprovalTask`, N approvers, author≠approver |
 | Namespace | `{project}-builds-untrusted` | `{project}-builds-trusted` |
 | Pod hardening | rootless, RO rootfs, seccomp RuntimeDefault, drop ALL caps, non-root uid, no-privesc | same hardening |
+
+> **Trigger split (decided Phase 1, 2026-07-20).** PaC maps a repo → one namespace, so it
+> cannot route one repo's PRs and tags to separate `…-untrusted`/`…-trusted` namespaces.
+> Trusted releases are therefore triggered by a **Tekton Triggers EventListener** (tag push
+> → GitHub interceptor verifies the webhook HMAC + a CEL tag filter → `TriggerTemplate`
+> creates the PipelineRun in the trusted namespace); PaC drives the untrusted PR tier. Both
+> stay in-cluster with GitHub as source; namespace isolation is preserved. The trusted
+> PipelineRun lives in the `TriggerTemplate` (not a `.tekton/` file), still referencing the
+> channel pipeline via the git resolver.
 
 **Never blur the tiers.** The two hard invariants that keep untrusted execution on owned
 compute defensible:


### PR DESCRIPTION
## What

Phase 1 of the Tekton build platform (ADR-0017): the **trusted-tier Android release** on Tekton, a faithful port of `release-android.yml`. Builds on the Phase 0 foundation (#576).

## Adds

- **Channel catalog** (git-resolved, reusable): `build-catalog/pipelines/android-build.yaml` = clone → `build-signed-aab` → **ApprovalTask gate** → keyless `play-publish`; Chains signs the run. `build-catalog/tasks/*`.
- **Trusted namespace** `capturly-builds-trusted`: per-build-OIDC SA, egress NetworkPolicy, ESO for signing (real Bitwarden UUIDs) + npm + git + webhook, WIF `external_account` cred config (real `homelab-staging`/`k3s-oidc` audience), Gradle PVC, Argo app.
- **Trusted trigger = Tekton Triggers** (not PaC): EventListener (GitHub interceptor verifies webhook HMAC + CEL tag filter) → TriggerTemplate creates the PipelineRun. PaC can't map one repo to two tier-namespaces, so PaC is reserved for the untrusted PR tier (Phase 2). Isolation preserved.
- **Toolchain image** `apps/capturly-android-toolchain` + build/pin-digest workflow.

## Depends on / prereqs

- **platform-infra PR (WIF)** — federates the build SA + `play-publisher-ci@capturly-app` impersonation. Must apply before Play publish authenticates.
- Bitwarden UUIDs still placeholder: `sentry-auth-token`, `npm-token`, git username/token (the webhook secret UUID is now wired). Real host for the EventListener IngressRoute + GitHub webhook registration.
- **Phase-1 gates before a real release:** fail-closed approval test (RISK-BUILD-001) + Chains keyless signing config. Verify the manual-approval-gate release tag.

## Validation

All manifests parse clean (`yq`). API specifics validated against Tekton/PaC docs (design §11).