### PR TITLE
feat(tekton): Phase 2 — untrusted PR tier (PaC + gVisor + Verdaccio)

### DIFF
--- a/argocd/applications/build-registry-proxy.yaml
+++ b/argocd/applications/build-registry-proxy.yaml
@@ -1,0 +1,35 @@
+---
+# Verdaccio npm registry proxy — the trusted component that lets the zero-secret
+# untrusted build tier install private packages without holding the npm token
+# (Phase 2, design §1). Syncs before the build namespaces (wave -1).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: build-registry-proxy
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: business
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: main
+    path: build-registry-proxy
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: build-registry-proxy
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd/applications/capturly-nextjs-untrusted.yaml
+++ b/argocd/applications/capturly-nextjs-untrusted.yaml
@@ -1,0 +1,35 @@
+---
+# capturly nextjs untrusted-tier PR-check namespace (Phase 2). Zero-secret SA,
+# egress-locked, npm via Verdaccio, PaC Repository + the web-ci task. Runs under
+# gVisor (set on the PaC PipelineRun in capturly/.tekton). Design §1/§7.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: capturly-nextjs-untrusted
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: business
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: main
+    path: build-targets/capturly-nextjs-untrusted
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: capturly-builds-untrusted
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/build-catalog/pipelines/nextjs-build.yaml
+++ b/build-catalog/pipelines/nextjs-build.yaml
@@ -1,0 +1,55 @@
+---
+# Channel pipeline: nextjs-build (UNTRUSTED PR tier). Clone → web-ci checks. No
+# secrets, no publish. Consumed from a project's .tekton/ PipelineRun via the git
+# resolver, which sets runtimeClassName: gvisor and the zero-secret SA. PaC
+# provides the git auth for the private clone via the bound basic-auth workspace.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: nextjs-build
+  labels:
+    app.kubernetes.io/part-of: build-catalog
+spec:
+  params:
+    - name: repo-url
+      type: string
+    - name: revision
+      type: string
+      default: ""
+  workspaces:
+    - name: source
+    - name: npmrc
+    - name: basic-auth       # PaC-provided git token for the private clone
+      optional: true
+  tasks:
+    - name: clone
+      workspaces:
+        - { name: output, workspace: source }
+        - { name: basic-auth, workspace: basic-auth }
+      taskSpec:
+        workspaces:
+          - name: output
+          - name: basic-auth
+            optional: true
+        steps:
+          - name: git-clone
+            image: alpine/git:2.45.2
+            script: |
+              #!/bin/sh
+              set -eu
+              # PaC mounts a .git-credentials/.gitconfig into the basic-auth ws.
+              if [ -f "$(workspaces.basic-auth.path)/.git-credentials" ]; then
+                cp "$(workspaces.basic-auth.path)/.git-credentials" "$HOME/.git-credentials"
+                cp "$(workspaces.basic-auth.path)/.gitconfig" "$HOME/.gitconfig" 2>/dev/null || true
+                git config --global credential.helper store
+              fi
+              cd "$(workspaces.output.path)"
+              git clone "$(params.repo-url)" .
+              [ -n "$(params.revision)" ] && git checkout "$(params.revision)" || true
+    - name: checks
+      runAfter: [clone]
+      taskRef:
+        name: web-ci
+      workspaces:
+        - { name: source, workspace: source }
+        - { name: npmrc, workspace: npmrc }

--- a/build-catalog/tasks/web-ci.yaml
+++ b/build-catalog/tasks/web-ci.yaml
@@ -1,0 +1,43 @@
+---
+# Reusable catalog Task: untrusted web/nextjs PR checks. Faithful to capturly
+# ci.yml (lint-and-typecheck + build): install via the Verdaccio proxy (NO npm
+# token in the pod), build dependent packages, lint, type-check, then build+test
+# the web app. Zero secrets; runs under gVisor (set on the PipelineRun).
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: web-ci
+  labels:
+    app.kubernetes.io/part-of: build-catalog
+spec:
+  params:
+    - name: node-image
+      type: string
+      default: node:22-bookworm-slim
+  workspaces:
+    - name: source
+    - name: npmrc            # configmap: .npmrc pointing at Verdaccio (no token)
+      mountPath: /config/npm
+  steps:
+    - name: checks
+      image: $(params.node-image)
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: HOME
+          value: $(workspaces.source.path)
+        # Turbo/CI hints; no secrets.
+        - name: CI
+          value: "true"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        corepack enable && corepack prepare pnpm@9.15.9 --activate
+        cp /config/npm/.npmrc "$HOME/.npmrc"   # registry = Verdaccio, no auth
+        pnpm install --frozen-lockfile
+        # apps/web type-checks against the compiled dist/ of its workspace deps.
+        pnpm --filter "@capturly/web^..." --if-present build
+        pnpm run lint --filter='!@capturly/mobile'
+        pnpm run type-check --filter='!@capturly/mobile'
+        # Build + unit-test the web app.
+        pnpm --filter "@capturly/web" --if-present build
+        pnpm --filter "@capturly/web" --if-present test

--- a/build-registry-proxy/externalsecret-npm-uplink.yaml
+++ b/build-registry-proxy/externalsecret-npm-uplink.yaml
@@ -1,0 +1,25 @@
+---
+# The private-scope npm read token Verdaccio uses to fetch @corey-alan-consulting
+# packages from npmjs. This token lives ONLY here (a trusted platform component);
+# it is never mounted into an untrusted build pod. Read-only scope.
+#
+# ⚠️ TODO: add the org npm read token to Bitwarden SM (Staging - Capturly project)
+#    and set its UUID. (Same token the GitHub workflows use as NPM_TOKEN.)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: verdaccio-npm-uplink
+  namespace: build-registry-proxy
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-staging-capturly-web
+    kind: ClusterSecretStore
+  target:
+    name: verdaccio-npm-uplink
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+  data:
+    - secretKey: npm-token
+      remoteRef: { key: REPLACE-WITH-BWS-UUID-npm-read-token }

--- a/build-registry-proxy/kustomization.yaml
+++ b/build-registry-proxy/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: build-registry-proxy
+resources:
+  - networkpolicy-and-namespace.yaml
+  - externalsecret-npm-uplink.yaml
+  - verdaccio.yaml

--- a/build-registry-proxy/networkpolicy-and-namespace.yaml
+++ b/build-registry-proxy/networkpolicy-and-namespace.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: build-registry-proxy
+  labels:
+    build.capturly/component: registry-proxy
+---
+# Verdaccio egress: DNS + public HTTPS to npmjs only (no private ranges — it has
+# no reason to reach anything in-cluster outbound).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: verdaccio-egress
+  namespace: build-registry-proxy
+spec:
+  podSelector: { matchLabels: { app: verdaccio } }
+  policyTypes: [Egress]
+  egress:
+    - to: [{ namespaceSelector: {} }]
+      ports: [{ protocol: UDP, port: 53 }, { protocol: TCP, port: 53 }]
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]
+      ports: [{ protocol: TCP, port: 443 }]
+---
+# Verdaccio ingress: only untrusted build namespaces may reach the proxy on 4873.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: verdaccio-ingress
+  namespace: build-registry-proxy
+spec:
+  podSelector: { matchLabels: { app: verdaccio } }
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels: { build.capturly/tier: untrusted }
+      ports: [{ protocol: TCP, port: 4873 }]

--- a/build-registry-proxy/verdaccio.yaml
+++ b/build-registry-proxy/verdaccio.yaml
@@ -1,0 +1,91 @@
+---
+# Verdaccio — the trusted npm registry proxy that lets the ZERO-SECRET untrusted
+# build tier install private @corey-alan-consulting packages without ever holding
+# the npm token (design §1, Phase 2 decision 2026-07-20). Verdaccio holds the
+# read token (uplink auth to npmjs); untrusted pods point their .npmrc at this
+# service with NO credential, so a malicious PR postinstall has nothing to steal.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: verdaccio-config
+  namespace: build-registry-proxy
+data:
+  config.yaml: |
+    storage: /verdaccio/storage
+    # No user registration; anonymous read only (publish is denied everywhere).
+    auth:
+      htpasswd:
+        file: /verdaccio/storage/htpasswd
+        max_users: -1
+    uplinks:
+      npmjs:
+        url: https://registry.npmjs.org/
+        # Private-scope read token, injected from the mounted secret env.
+        auth:
+          type: bearer
+          token_env: NPM_TOKEN
+        maxage: 10m
+    packages:
+      '@corey-alan-consulting/*':
+        access: $anonymous          # in-cluster pods read without auth
+        publish: $authenticated     # nobody authenticates → publish denied
+        proxy: npmjs
+      '**':
+        access: $anonymous
+        publish: $authenticated
+        proxy: npmjs
+    server:
+      keepAliveTimeout: 60
+    log: { type: stdout, format: pretty, level: warn }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdaccio
+  namespace: build-registry-proxy
+  labels: { app: verdaccio }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: verdaccio }
+  template:
+    metadata:
+      labels: { app: verdaccio }
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        fsGroup: 10001
+      containers:
+        - name: verdaccio
+          image: verdaccio/verdaccio:6.2.0
+          ports:
+            - { containerPort: 4873, name: http }
+          env:
+            - name: NPM_TOKEN
+              valueFrom:
+                secretKeyRef: { name: verdaccio-npm-uplink, key: npm-token }
+          volumeMounts:
+            - { name: config, mountPath: /verdaccio/conf }
+            - { name: storage, mountPath: /verdaccio/storage }
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits: { cpu: "1", memory: 512Mi }
+          readinessProbe:
+            httpGet: { path: /-/ping, port: 4873 }
+            initialDelaySeconds: 5
+      volumes:
+        - name: config
+          configMap: { name: verdaccio-config }
+        - name: storage
+          emptyDir: {}          # proxy cache only; safe to lose
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: verdaccio
+  namespace: build-registry-proxy
+spec:
+  selector: { app: verdaccio }
+  ports:
+    - { port: 4873, targetPort: 4873, name: http }

--- a/build-targets/capturly-nextjs-untrusted/kustomization.yaml
+++ b/build-targets/capturly-nextjs-untrusted/kustomization.yaml
@@ -1,0 +1,13 @@
+# capturly nextjs UNTRUSTED-tier PR-check namespace + the web-ci catalog task the
+# nextjs-build pipeline references by name. The Pipeline is git-resolved from
+# capturly/.tekton; the trigger is PaC (pull_request). gVisor + zero-secret +
+# Verdaccio-only npm are what make running arbitrary PR code here defensible.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: capturly-builds-untrusted
+resources:
+  - namespace-and-sa.yaml
+  - networkpolicy.yaml
+  - npmrc-configmap.yaml
+  - repository.yaml
+  - ../../build-catalog/tasks/web-ci.yaml

--- a/build-targets/capturly-nextjs-untrusted/namespace-and-sa.yaml
+++ b/build-targets/capturly-nextjs-untrusted/namespace-and-sa.yaml
@@ -1,0 +1,21 @@
+---
+# Untrusted-tier build namespace for capturly PR checks (web/nextjs). Runs
+# arbitrary contributor code under gVisor with NO secrets and NO cloud identity
+# (design §1). The `build.capturly/tier: untrusted` label is what the Verdaccio
+# ingress NetworkPolicy allows through to the registry proxy.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capturly-builds-untrusted
+  labels:
+    build.capturly/tier: untrusted
+    build.capturly/project: capturly
+---
+# Zero-secret SA: no WIF binding, no cloud audience, no linked secrets. PaC
+# injects a short-lived, repo-scoped git token per run for the clone — the only
+# credential in the tier, and it is ephemeral.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capturly-nextjs-untrusted
+  namespace: capturly-builds-untrusted

--- a/build-targets/capturly-nextjs-untrusted/networkpolicy.yaml
+++ b/build-targets/capturly-nextjs-untrusted/networkpolicy.yaml
@@ -1,0 +1,37 @@
+---
+# Untrusted-tier egress. The build runs arbitrary PR code, so this is the primary
+# containment (with gVisor). Allowed: cluster DNS, the Verdaccio proxy (all npm,
+# private included — no token in the pod), and public HTTPS for the git clone.
+# Denied: cloud metadata and all other private ranges (no lateral movement, no
+# k8s API, no Bitwarden, no other cluster service).
+#
+# ⚠️ HARDENING: public 443 is broad (needed for the GitHub clone) and leaves a
+#    postinstall an exfil path. Replace with a CiliumNetworkPolicy that FQDN-locks
+#    egress to github.com + the Verdaccio service to close it (design §8).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: capturly-untrusted-egress
+  namespace: capturly-builds-untrusted
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress:
+    - to: [{ namespaceSelector: {} }]
+      ports: [{ protocol: UDP, port: 53 }, { protocol: TCP, port: 53 }]
+    # Verdaccio registry proxy (in-cluster) — the only npm path; no token here.
+    - to:
+        - namespaceSelector:
+            matchLabels: { build.capturly/component: registry-proxy }
+      ports: [{ protocol: TCP, port: 4873 }]
+    # Public HTTPS for the git clone. Excludes RFC1918 + link-local (169.254.x,
+    # blocks the cloud metadata endpoint) to limit lateral movement / SSRF.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.0.0/16
+      ports: [{ protocol: TCP, port: 443 }]

--- a/build-targets/capturly-nextjs-untrusted/npmrc-configmap.yaml
+++ b/build-targets/capturly-nextjs-untrusted/npmrc-configmap.yaml
@@ -1,0 +1,14 @@
+---
+# .npmrc pointing all installs at the Verdaccio proxy — NO auth token. The proxy
+# holds the credential and fetches private @corey-alan-consulting packages from
+# npmjs on the pod's behalf, so the untrusted pod carries nothing to exfiltrate
+# (Phase 2 decision). Mounted as the `npmrc` workspace.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: capturly-untrusted-npmrc
+  namespace: capturly-builds-untrusted
+data:
+  .npmrc: |
+    registry=http://verdaccio.build-registry-proxy.svc.cluster.local:4873/
+    @corey-alan-consulting:registry=http://verdaccio.build-registry-proxy.svc.cluster.local:4873/

--- a/build-targets/capturly-nextjs-untrusted/repository.yaml
+++ b/build-targets/capturly-nextjs-untrusted/repository.yaml
@@ -1,0 +1,20 @@
+---
+# Pipelines-as-Code Repository for the UNTRUSTED PR tier. PaC matches capturly.app
+# PR events to this namespace and runs the .tekton/ PipelineRun here. The policy
+# gates who can trigger: fork/external PRs do not run until a maintainer comments
+# /ok-to-test (design §6) — the control that vets untrusted code before it runs.
+#
+# ⚠️ TODO: set `pull_request` / `ok_to_test` to the real GitHub team slug(s); the
+#    PaC GitHub App (Phase 0 externalsecret placeholder) must be created +
+#    installed on capturly.app first.
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: capturly
+  namespace: capturly-builds-untrusted
+spec:
+  url: https://github.com/Corey-Alan-Consulting/capturly.app
+  settings:
+    policy:
+      pull_request: ["capturly-maintainers"]
+      ok_to_test: ["capturly-maintainers"]

--- a/business-plane/appproject.yaml
+++ b/business-plane/appproject.yaml
@@ -33,6 +33,9 @@ spec:
     # Phase 1 per-project build namespaces ({project}-builds-{trusted,untrusted}).
     - server: https://kubernetes.default.svc
       namespace: "*-builds-*"
+    # Phase 2 Verdaccio npm registry proxy (untrusted-tier private-dep install).
+    - server: https://kubernetes.default.svc
+      namespace: build-registry-proxy
   # Tekton (operator + PaC + MAG) installs cluster-scoped CRDs/RBAC/webhooks; the
   # untrusted tier needs RuntimeClass; our apps apply the cluster-scoped
   # TektonConfig. First sync may surface an additional cluster kind an upstream

--- a/docs/design/tekton-build-platform.md
+++ b/docs/design/tekton-build-platform.md
@@ -53,6 +53,14 @@ compute defensible:
 2. **No cache/artifact path** flows untrusted → trusted (cache-poisoning is the classic
    supply-chain hole). Separate PVCs; the trusted tier warms its own.
 
+> **Private-dep install without a token (Phase 2 decision, 2026-07-20).** Building
+> capturly needs the private `@corey-alan-consulting/*` packages, which normally requires
+> an npm read token — that would break invariant 1. Resolved with an in-cluster
+> **Verdaccio** proxy (`build-registry-proxy/`): the proxy holds the token and fetches
+> private packages from npmjs; untrusted pods point `.npmrc` at the proxy with **no
+> credential**, so a malicious PR postinstall has nothing to exfiltrate. The only
+> credential in the tier is PaC's short-lived, repo-scoped git token for the clone.
+
 ---
 
 ## 2. Data flow
@@ -188,7 +196,7 @@ price of full PaC — call it out to the auditor, don't hide it.
 |---|---|---|
 | **0 — Foundation** | **Remove the never-live ARC scaffolding (§12);** install Tekton Pipelines + PaC + Chains + Results; gVisor RuntimeClass on nodes; repurpose `business` AppProject; register PaC GitHub App | ARC apps pruned from ArgoCD; a hello-world PipelineRun signs + lands in Rekor; gVisor `RuntimeClass` schedulable |
 | **1 — Trusted Android** | port `release-android` to `.tekton/` + `android-build` catalog pipeline; per-SA WIF; keystore ESO; approval gate (interim `ApprovalTask` + fail-closed test, RISK-BUILD-001); Chains provenance | a real tag builds+signs+publishes via Tekton with a verified attestation and a recorded approval |
-| **2 — Untrusted tier** | `nextjs` PR builds: PaC `pull_request` → gVisor, zero-secret, egress-locked | a fork PR compiles+tests in the sandbox; proves it cannot reach secrets/metadata/RFC1918 |
+| **2 — Untrusted tier** ✅ built | `nextjs` PR builds: PaC `pull_request` → gVisor, zero-secret, egress-locked; private deps via the **Verdaccio proxy** (no npm token in the pod) | a fork PR compiles+tests in the sandbox; proves it cannot reach secrets/metadata/RFC1918 |
 | **3 — Catalog + multi-project** | git-resolver catalog for all channels; `ApplicationSet` over `build-targets`; onboard `coreyalan` | adding a (project, channel) is a single inventory PR that reconciles clean |
 
 > ARC decommission is **not a phase** — it never reached production, so its scaffolding is


### PR DESCRIPTION
## What

Phase 2 of the Tekton build platform (ADR-0017): the **untrusted PR tier** — capturly web/nextjs PR checks running on owned compute, **sandboxed (gVisor)** and **zero-secret**, triggered by PaC on `pull_request`.

## The key decision: private deps without a token

Building capturly needs the private `@corey-alan-consulting/*` packages, which normally needs an npm read token — that would break the untrusted tier's zero-secret invariant. Resolved with an in-cluster **Verdaccio** proxy: the proxy holds the token and fetches private packages from npmjs; **untrusted pods point `.npmrc` at the proxy with no credential**, so a malicious PR postinstall has nothing to exfiltrate. The only credential in the tier is PaC's short-lived, repo-scoped git token for the clone.

## Adds

- **`build-registry-proxy/`** — Verdaccio (deploy/svc/config), ESO npm uplink token, egress+ingress NetworkPolicy, namespace; Argo app (wave -1).
- **Catalog** — `nextjs-build` pipeline (clone → `web-ci`) + `web-ci` task (install via Verdaccio, build deps, lint, type-check, build+test), faithful to `ci.yml`.
- **`build-targets/capturly-nextjs-untrusted/`** — zero-secret SA, egress lock (DNS + Verdaccio + public 443 for the clone; deny metadata/RFC1918), no-token `.npmrc` ConfigMap, PaC `Repository` (`pull_request` + `ok_to_test`), Argo app.
- `business` AppProject: allow the `build-registry-proxy` namespace.

## Prereqs (see runbook) / follow-ups

- **PaC GitHub App** created + installed on capturly.app (the Phase 0 ESO placeholder); set the real maintainer team in the Repository policy.
- **npm read token** in Bitwarden for the Verdaccio uplink (`build-registry-proxy` ESO placeholder).
- gVisor RuntimeClass installed on nodes (Phase 0 node prereq).
- **Hardening:** the clone path needs public 443; a CiliumNetworkPolicy FQDN-locking egress to github.com + Verdaccio closes the residual exfil path (design §8).

The capturly `.tekton/nextjs-pr.yaml` PR trigger is a **separate capturly PR**.

## Validation

All manifests parse clean (`yq`).