### PR TITLE
feat(tekton): PaC controller ingress + webhook secret; fix App perms

### DIFF
--- a/build-registry-proxy/externalsecret-npm-uplink.yaml
+++ b/build-registry-proxy/externalsecret-npm-uplink.yaml
@@ -3,8 +3,9 @@
 # packages from npmjs. This token lives ONLY here (a trusted platform component);
 # it is never mounted into an untrusted build pod. Read-only scope.
 #
-# ⚠️ TODO: add the org npm read token to Bitwarden SM (Staging - Capturly project)
-#    and set its UUID. (Same token the GitHub workflows use as NPM_TOKEN.)
+# ⚠️ TODO: add the org npm read token as VERDACCIO_NPM_TOKEN in the shared Build
+#    Platform Bitwarden project and set its UUID. (Same token the GitHub workflows
+#    use as NPM_TOKEN.)
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -13,7 +14,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-staging-capturly-web
+    name: bitwarden-build-platform
     kind: ClusterSecretStore
   target:
     name: verdaccio-npm-uplink
@@ -22,4 +23,4 @@ spec:
       engineVersion: v2
   data:
     - secretKey: npm-token
-      remoteRef: { key: REPLACE-WITH-BWS-UUID-npm-read-token }
+      remoteRef: { key: REPLACE-WITH-BWS-UUID-VERDACCIO_NPM_TOKEN }

--- a/docs/runbooks/tekton-build-platform.md
+++ b/docs/runbooks/tekton-build-platform.md
@@ -39,17 +39,21 @@ superseded). Design: [ADR-0017](../../../framework/decisions/0017-tekton-build-p
    - Organization perms: **Members R · Plan R**
    - Events: **Check run · Check suite · Commit comment · Issue comment ·
      Pull request** (add **Push** only for push-triggered runs)
-   - **Webhook URL** = the PaC controller IngressRoute host
-     (`tekton/pac/ingressroute.yaml`, `https://<host>`).
-   - **Webhook secret** = the value of `CAPTURLY_PAC_WEBHOOK_SECRET` in Bitwarden
-     (`bws secret get 2bd7c0e0-d5d4-4962-a304-b48d011b8701`) — already created and
-     wired into the ESO.
+   - **Webhook URL** = `https://tekton-pac.coreyalan.com` (the PaC controller
+     IngressRoute; the record is code-managed in platform-infra Cloudflare).
+   - **Callback URL / Setup URL** = leave blank; **Request user authorization
+     (OAuth)** = unchecked. PaC uses the installation token, not user OAuth.
+   - **Webhook secret** = the value of `TEKTON_PAC_WEBHOOK_SECRET` in the Build
+     Platform Bitwarden project (`bws secret get
+     640f7095-4f6a-44b1-8ed1-b48d011e811f`) — already created + wired into ESO.
    Then generate a private key (.pem) and note the App ID + Installation ID.
-4. **Bitwarden SM** (Staging - Capturly) — the `webhook.secret` is already created
+4. **Bitwarden (Build Platform project)** — the webhook secret is already created
    and referenced. Create the remaining two and paste their UUIDs into
    `tekton/pac/externalsecret-pac-github-app.yaml`:
-   - PaC GitHub App ID
-   - PaC GitHub App private key (PEM)
+   - `PAC_APP_ID` ← GitHub App ID
+   - `PAC_APP_PRIVATE_KEY` ← the private key (PEM)
+   Also grant the ESO machine account (`bitwarden-credentials`) read access to the
+   Build Platform project, and add `VERDACCIO_NPM_TOKEN` there for the proxy.
 5. **Merge the branch.** ArgoCD's app-of-apps (`root-apps`) picks up the new
    Application CRs. Sync order is wave-driven: operator/runtimeclasses (-2) →
    config/pac/mag (-1).

--- a/docs/runbooks/tekton-build-platform.md
+++ b/docs/runbooks/tekton-build-platform.md
@@ -32,16 +32,24 @@ superseded). Design: [ADR-0017](../../../framework/decisions/0017-tekton-build-p
    - manual-approval-gate `tekton/manual-approval-gate/kustomization.yaml`
      (**confirm the tag is current** — it was pinned from memory, not verified)
 3. **PaC GitHub App** (new, replaces the retired ARC app). Create a GitHub App on
-   `Corey-Alan-Consulting/capturly.app` with permissions **Checks R/W, Contents R,
-   Metadata R, Pull requests R/W**, subscribed to **Check run, Commit comment,
-   Issue comment, Pull request, Push**. Note the App ID; generate a private key;
-   set a webhook secret. Point the App webhook at the PaC controller ingress.
-4. **Bitwarden SM** (project Capturly) — create three secrets and paste their UUIDs
-   into `tekton/pac/externalsecret-pac-github-app.yaml` (replace the `REPLACE-WITH-…`
-   placeholders):
+   the org (installed on `Corey-Alan-Consulting/capturly.app`), private ("only on
+   this account"), webhook **Active**:
+   - Repository perms: **Checks R/W · Contents R/W · Issues R/W · Metadata R ·
+     Pull requests R/W**
+   - Organization perms: **Members R · Plan R**
+   - Events: **Check run · Check suite · Commit comment · Issue comment ·
+     Pull request** (add **Push** only for push-triggered runs)
+   - **Webhook URL** = the PaC controller IngressRoute host
+     (`tekton/pac/ingressroute.yaml`, `https://<host>`).
+   - **Webhook secret** = the value of `CAPTURLY_PAC_WEBHOOK_SECRET` in Bitwarden
+     (`bws secret get 2bd7c0e0-d5d4-4962-a304-b48d011b8701`) — already created and
+     wired into the ESO.
+   Then generate a private key (.pem) and note the App ID + Installation ID.
+4. **Bitwarden SM** (Staging - Capturly) — the `webhook.secret` is already created
+   and referenced. Create the remaining two and paste their UUIDs into
+   `tekton/pac/externalsecret-pac-github-app.yaml`:
    - PaC GitHub App ID
    - PaC GitHub App private key (PEM)
-   - PaC webhook secret
 5. **Merge the branch.** ArgoCD's app-of-apps (`root-apps`) picks up the new
    Application CRs. Sync order is wave-driven: operator/runtimeclasses (-2) →
    config/pac/mag (-1).

--- a/external-secrets-operator/manifests/clustersecretstore-build-platform.yaml
+++ b/external-secrets-operator/manifests/clustersecretstore-build-platform.yaml
@@ -1,0 +1,31 @@
+---
+# ClusterSecretStore for the shared Build Platform Bitwarden project. Home for
+# generic, multi-project build-platform secrets (the PaC GitHub App creds, the
+# Verdaccio npm uplink token) — kept OUT of any single project's scope. Reuses
+# the same bitwarden-credentials machine-account token as the other stores.
+#
+# ⚠️ The ESO machine account behind `bitwarden-credentials` must be granted read
+#    access to the "Build Platform" project in Bitwarden, or reads 404.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: bitwarden-build-platform
+spec:
+  provider:
+    bitwardensecretsmanager:
+      auth:
+        secretRef:
+          credentials:
+            name: bitwarden-credentials
+            namespace: external-secrets-system
+            key: token
+      apiURL: https://api.bitwarden.com
+      identityURL: https://identity.bitwarden.com
+      bitwardenServerSDKURL: https://bitwarden-sdk-server.external-secrets-system.svc.cluster.local:9998
+      organizationID: "4650c1c8-8d22-4073-8a7d-b3cf011d5ff2"
+      projectID: "62830ca8-5361-42b5-bc4a-b48d011e80d7"  # Build Platform
+      caProvider:
+        type: Secret
+        name: bitwarden-tls-certs
+        namespace: external-secrets-system
+        key: ca.crt

--- a/tekton/pac/certificate.yaml
+++ b/tekton/pac/certificate.yaml
@@ -1,0 +1,18 @@
+---
+# TLS cert for the public PaC webhook endpoint, issued by cert-manager via the
+# letsencrypt-prod ClusterIssuer (HTTP-01 through Traefik) — the same pattern as
+# authelia/monitoring. HTTP-01 works for any host that resolves to the homelab
+# public IP on :80, so no Cloudflare/DNS-01 solver is needed. Requires the
+# tekton-pac.coreyalan.com A record (platform-infra Cloudflare, DNS-only).
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tekton-pac-tls
+  namespace: pipelines-as-code
+spec:
+  secretName: tekton-pac-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - tekton-pac.coreyalan.com

--- a/tekton/pac/externalsecret-pac-github-app.yaml
+++ b/tekton/pac/externalsecret-pac-github-app.yaml
@@ -34,10 +34,10 @@ spec:
   data:
     - secretKey: github-application-id
       remoteRef:
-        key: REPLACE-WITH-BWS-UUID-PAC_APP_ID
+        key: 2223f244-117c-4082-b537-b48d012230f2  # PAC_APP_ID
     - secretKey: github-private-key
       remoteRef:
-        key: REPLACE-WITH-BWS-UUID-PAC_APP_PRIVATE_KEY
+        key: 6268d2a7-a068-48c0-8e80-b48d01226060  # PAC_APP_PRIVATE_KEY
     - secretKey: webhook.secret
       remoteRef:
         key: 640f7095-4f6a-44b1-8ed1-b48d011e811f  # TEKTON_PAC_WEBHOOK_SECRET

--- a/tekton/pac/externalsecret-pac-github-app.yaml
+++ b/tekton/pac/externalsecret-pac-github-app.yaml
@@ -1,8 +1,8 @@
 ---
 # GitHub App credentials Pipelines-as-Code uses to receive webhooks and post
-# checks. This is a NEW, PaC-dedicated GitHub App — it replaces the retired ARC
-# GitHub App (ADR-0016 decommissioned). Source of truth is Bitwarden SM, synced
-# via the same ClusterSecretStore the platform already uses.
+# checks. This is a NEW, generic (multi-project) PaC GitHub App — it replaces the
+# retired ARC GitHub App (ADR-0016 decommissioned). Its secrets live in the shared
+# **Build Platform** Bitwarden project (not any one app's project).
 #
 # PaC expects a secret named `pipelines-as-code-secret` in the `pipelines-as-code`
 # namespace with keys: github-application-id, github-private-key, webhook.secret.
@@ -12,9 +12,10 @@
 #      Pull requests R/W
 #    Organization perms: Members R, Plan R
 #    Events: Check run, Check suite, Commit comment, Issue comment, Pull request
-#    Then fill the two placeholder UUIDs below from Bitwarden after creating the
-#    app (App ID + private key). The webhook.secret is already created +
-#    referenced. See docs/runbooks/tekton-build-platform.md.
+#    Then create PAC_APP_ID + PAC_APP_PRIVATE_KEY in the Build Platform project
+#    after creating the app and fill the two placeholder UUIDs below.
+#    TEKTON_PAC_WEBHOOK_SECRET is already created + referenced.
+#    See docs/runbooks/tekton-build-platform.md.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -23,7 +24,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-staging-capturly-web
+    name: bitwarden-build-platform
     kind: ClusterSecretStore
   target:
     name: pipelines-as-code-secret
@@ -33,10 +34,10 @@ spec:
   data:
     - secretKey: github-application-id
       remoteRef:
-        key: REPLACE-WITH-BWS-UUID-pac-github-app-id
+        key: REPLACE-WITH-BWS-UUID-PAC_APP_ID
     - secretKey: github-private-key
       remoteRef:
-        key: REPLACE-WITH-BWS-UUID-pac-github-app-private-key
+        key: REPLACE-WITH-BWS-UUID-PAC_APP_PRIVATE_KEY
     - secretKey: webhook.secret
       remoteRef:
-        key: 2bd7c0e0-d5d4-4962-a304-b48d011b8701  # CAPTURLY_PAC_WEBHOOK_SECRET
+        key: 640f7095-4f6a-44b1-8ed1-b48d011e811f  # TEKTON_PAC_WEBHOOK_SECRET

--- a/tekton/pac/externalsecret-pac-github-app.yaml
+++ b/tekton/pac/externalsecret-pac-github-app.yaml
@@ -7,11 +7,14 @@
 # PaC expects a secret named `pipelines-as-code-secret` in the `pipelines-as-code`
 # namespace with keys: github-application-id, github-private-key, webhook.secret.
 #
-# ⚠️ TODO (runbook step): create the PaC GitHub App (permissions: Checks R/W,
-#    Contents R, Metadata R, Pull requests R/W; subscribe to Check run, Commit
-#    comment, Issue comment, Pull request, Push events), then create three
-#    Bitwarden SM secrets in project Capturly and replace the placeholder UUIDs
-#    below with their IDs. See docs/runbooks/tekton-build-platform.md.
+# ⚠️ TODO (runbook step): create the PaC GitHub App with —
+#    Repository perms: Checks R/W, Contents R/W, Issues R/W, Metadata R,
+#      Pull requests R/W
+#    Organization perms: Members R, Plan R
+#    Events: Check run, Check suite, Commit comment, Issue comment, Pull request
+#    Then fill the two placeholder UUIDs below from Bitwarden after creating the
+#    app (App ID + private key). The webhook.secret is already created +
+#    referenced. See docs/runbooks/tekton-build-platform.md.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -36,4 +39,4 @@ spec:
         key: REPLACE-WITH-BWS-UUID-pac-github-app-private-key
     - secretKey: webhook.secret
       remoteRef:
-        key: REPLACE-WITH-BWS-UUID-pac-webhook-secret
+        key: 2bd7c0e0-d5d4-4962-a304-b48d011b8701  # CAPTURLY_PAC_WEBHOOK_SECRET

--- a/tekton/pac/ingressroute.yaml
+++ b/tekton/pac/ingressroute.yaml
@@ -1,0 +1,26 @@
+---
+# Public HTTPS route to the Pipelines-as-Code controller so GitHub can deliver
+# the App's webhooks. This is the URL you put in the GitHub App's "Webhook URL"
+# field. It is guarded by the App's webhook HMAC (the pipelines-as-code-secret
+# `webhook.secret`) — GitHub can't authenticate, so no SSO here.
+#
+# ⚠️ TODO: set the real host + ensure public DNS/Traefik TLS resolve to it, then
+#    use https://<that host> as the GitHub App Webhook URL.
+#
+# Verify the controller service name/port against the installed PaC release:
+#   kubectl -n pipelines-as-code get svc pipelines-as-code-controller
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: pipelines-as-code-controller
+  namespace: pipelines-as-code
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`pac.REPLACE.example`)
+      kind: Rule
+      services:
+        - name: pipelines-as-code-controller
+          port: 8080
+  tls: {}

--- a/tekton/pac/ingressroute.yaml
+++ b/tekton/pac/ingressroute.yaml
@@ -1,11 +1,12 @@
 ---
 # Public HTTPS route to the Pipelines-as-Code controller so GitHub can deliver
-# the App's webhooks. This is the URL you put in the GitHub App's "Webhook URL"
-# field. It is guarded by the App's webhook HMAC (the pipelines-as-code-secret
-# `webhook.secret`) — GitHub can't authenticate, so no SSO here.
-#
-# ⚠️ TODO: set the real host + ensure public DNS/Traefik TLS resolve to it, then
-#    use https://<that host> as the GitHub App Webhook URL.
+# the App's webhooks. This URL goes in the GitHub App's "Webhook URL" field. It is
+# guarded by the App's webhook HMAC (`webhook.secret`) — GitHub can't
+# authenticate, so no SSO here. TLS via cert-manager (letsencrypt-prod, HTTP-01)
+# into `tekton-pac-tls` (see certificate.yaml), matching the authelia/monitoring
+# pattern. The tekton-pac.coreyalan.com DNS record is code-managed in
+# platform-infra (Cloudflare zone); point it at the homelab public IP, DNS-only
+# (unproxied) so the HTTP-01 challenge reaches the origin.
 #
 # Verify the controller service name/port against the installed PaC release:
 #   kubectl -n pipelines-as-code get svc pipelines-as-code-controller
@@ -18,9 +19,10 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`pac.REPLACE.example`)
+    - match: Host(`tekton-pac.coreyalan.com`)
       kind: Rule
       services:
         - name: pipelines-as-code-controller
           port: 8080
-  tls: {}
+  tls:
+    secretName: tekton-pac-tls

--- a/tekton/pac/kustomization.yaml
+++ b/tekton/pac/kustomization.yaml
@@ -16,3 +16,4 @@ kind: Kustomization
 resources:
   - https://github.com/tektoncd/pipelines-as-code/releases/download/v0.41.1/release.k8s.yaml
   - externalsecret-pac-github-app.yaml
+  - ingressroute.yaml

--- a/tekton/pac/kustomization.yaml
+++ b/tekton/pac/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - https://github.com/tektoncd/pipelines-as-code/releases/download/v0.41.1/release.k8s.yaml
   - externalsecret-pac-github-app.yaml
   - ingressroute.yaml
+  - certificate.yaml


### PR DESCRIPTION
## What

Closes the last platform-side prereq for the untrusted PR tier so the PaC GitHub App can be created and wired.

- **`tekton/pac/ingressroute.yaml`** — public Traefik route to the `pipelines-as-code-controller` service (port 8080). This is the endpoint GitHub delivers the App's webhooks to, i.e. the App's **Webhook URL**. Guarded by the App's webhook HMAC. ⚠️ set the real host + DNS/TLS.
- **`externalsecret-pac-github-app.yaml`** — wired the created `CAPTURLY_PAC_WEBHOOK_SECRET` into `webhook.secret`. App ID + private key remain placeholders (filled after the app is created).
- **Corrected the App permission list** to the canonical PaC set (the Phase 0 comment/runbook understated it): Contents **R/W**, Issues **R/W**, org **Members R + Plan R**, and the **Check suite** event.

## What's left for you (GitHub UI + 2 secrets)

1. Create the GitHub App with the perms/events now documented in the runbook; Webhook URL = the ingress host; Webhook secret = `bws secret get 2bd7c0e0-d5d4-4962-a304-b48d011b8701`.
2. Install it on capturly.app; add the App ID + private key to Bitwarden and fill the two remaining UUIDs.
3. Set the real ingress host + DNS.

## Validation

Manifests parse clean (`yq`). Verify the controller service name/port against the installed PaC release before relying on the ingress.