### PR TITLE
chore(tekton): wire VERDACCIO_NPM_TOKEN UUID

### DIFF
--- a/build-registry-proxy/externalsecret-npm-uplink.yaml
+++ b/build-registry-proxy/externalsecret-npm-uplink.yaml
@@ -23,4 +23,4 @@ spec:
       engineVersion: v2
   data:
     - secretKey: npm-token
-      remoteRef: { key: REPLACE-WITH-BWS-UUID-VERDACCIO_NPM_TOKEN }
+      remoteRef: { key: 9e42e8be-e302-4cec-b16a-b48d012616a0 }  # VERDACCIO_NPM_TOKEN


### PR DESCRIPTION
Wires the real `VERDACCIO_NPM_TOKEN` UUID (Build Platform BWS project) into the Verdaccio uplink ExternalSecret, replacing the placeholder. Last secret needed for the untrusted tier to install private deps through the proxy.