### PR TITLE
fix(tekton): unblock Argo sync (runtimeclass dest + git-resolved tasks)

### DIFF
--- a/argocd/applications/tekton-runtimeclasses.yaml
+++ b/argocd/applications/tekton-runtimeclasses.yaml
@@ -20,7 +20,9 @@ spec:
     path: tekton/runtimeclasses
   destination:
     server: https://kubernetes.default.svc
-    namespace: default
+    # RuntimeClass is cluster-scoped; this namespace is only Argo's tracking ns
+    # and must be allowed by the business AppProject (default is not).
+    namespace: tekton-pipelines
   syncPolicy:
     automated:
       prune: true

--- a/build-catalog/pipelines/android-build.yaml
+++ b/build-catalog/pipelines/android-build.yaml
@@ -61,7 +61,11 @@ spec:
     - name: build
       runAfter: [clone]
       taskRef:
-        name: build-signed-aab
+        resolver: git
+        params:
+          - { name: url, value: https://github.com/NX211/homelab-infra.git }
+          - { name: revision, value: main }
+          - { name: pathInRepo, value: build-catalog/tasks/build-signed-aab.yaml }
       params:
         - name: toolchain-image
           value: $(params.toolchain-image)
@@ -90,7 +94,11 @@ spec:
     - name: publish
       runAfter: [release-approval]
       taskRef:
-        name: play-publish
+        resolver: git
+        params:
+          - { name: url, value: https://github.com/NX211/homelab-infra.git }
+          - { name: revision, value: main }
+          - { name: pathInRepo, value: build-catalog/tasks/play-publish.yaml }
       params:
         - name: toolchain-image
           value: $(params.toolchain-image)

--- a/build-catalog/pipelines/nextjs-build.yaml
+++ b/build-catalog/pipelines/nextjs-build.yaml
@@ -49,7 +49,11 @@ spec:
     - name: checks
       runAfter: [clone]
       taskRef:
-        name: web-ci
+        resolver: git
+        params:
+          - { name: url, value: https://github.com/NX211/homelab-infra.git }
+          - { name: revision, value: main }
+          - { name: pathInRepo, value: build-catalog/tasks/web-ci.yaml }
       workspaces:
         - { name: source, workspace: source }
         - { name: npmrc, workspace: npmrc }

--- a/build-targets/capturly-android-trusted/kustomization.yaml
+++ b/build-targets/capturly-android-trusted/kustomization.yaml
@@ -1,9 +1,6 @@
-# capturly Android trusted-tier build namespace + the catalog tasks the
-# android-build pipeline references by name (installed into this namespace so
-# taskRef resolution succeeds; the Pipeline itself is fetched via the git
-# resolver from .tekton). Trigger wiring (PaC Repository vs Tekton Triggers
-# EventListener) is added once the trusted-tier trigger mechanism is decided —
-# see the design note in the PR / runbook.
+# capturly Android trusted-tier build namespace. The android-build pipeline and
+# its tasks are git-resolved from homelab-infra (public), so nothing catalog is
+# installed here — just the namespace, identity, secrets, and Tekton Triggers.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: capturly-builds-trusted
@@ -19,7 +16,5 @@ resources:
   - triggers.yaml
   - triggers-rbac.yaml
   - ingressroute.yaml
-  # Catalog tasks referenced by the android-build pipeline (name resolution
-  # happens in the PipelineRun namespace).
-  - ../../build-catalog/tasks/build-signed-aab.yaml
-  - ../../build-catalog/tasks/play-publish.yaml
+  # build-signed-aab + play-publish are git-resolved by the android-build
+  # pipeline (no cross-dir kustomize include).

--- a/build-targets/capturly-nextjs-untrusted/kustomization.yaml
+++ b/build-targets/capturly-nextjs-untrusted/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - networkpolicy.yaml
   - npmrc-configmap.yaml
   - repository.yaml
-  - ../../build-catalog/tasks/web-ci.yaml
+  # web-ci task is git-resolved by the nextjs-build pipeline (no cross-dir include)


### PR DESCRIPTION
On-cluster verification after the platform landed found two Argo sync failures:

1. **tekton-runtimeclasses** targeted namespace `default`, not allowed by the `business` AppProject → the **gvisor/kata RuntimeClasses were never created**. Repointed to `tekton-pipelines` (RuntimeClass is cluster-scoped; the ns is only Argo's tracking ns).
2. **build-target kustomizations** referenced `../../build-catalog/tasks/*` → kustomize's load-restrictor rejects out-of-dir paths, so `capturly-nextjs-untrusted` + `capturly-android-trusted` failed to render. Fixed by **git-resolving the tasks** in the android-build/nextjs-build pipelines (homelab-infra is public, so no resolver auth) and dropping the cross-dir includes. `kubectl kustomize` now renders both.

Note: the gvisor/kata RuntimeClass **objects** will apply after this, but the nodes still need the `runsc`/`kata` containerd handlers installed (separate node-bootstrap step) before untrusted pods can actually schedule.