### PR TITLE
fix(verdaccio): stop Service env-var breaking the listen address

### DIFF
--- a/build-registry-proxy/verdaccio.yaml
+++ b/build-registry-proxy/verdaccio.yaml
@@ -52,6 +52,10 @@ spec:
     metadata:
       labels: { app: verdaccio }
     spec:
+      # The `verdaccio` Service injects a docker-link env var VERDACCIO_PORT=
+      # tcp://<clusterip>:4873, which Verdaccio misreads as its listen ADDRESS
+      # ("Invalid address"). Disable service-link injection to stop it.
+      enableServiceLinks: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 10001
@@ -62,6 +66,9 @@ spec:
           ports:
             - { containerPort: 4873, name: http }
           env:
+            # Explicit listen port (belt-and-suspenders vs the injected var).
+            - name: VERDACCIO_PORT
+              value: "4873"
             - name: NPM_TOKEN
               valueFrom:
                 secretKeyRef: { name: verdaccio-npm-uplink, key: npm-token }


### PR DESCRIPTION
Verdaccio was crash-looping with `Invalid address - http://0.0.0.0:tcp://10.43.x.x:4873`. Root cause: the `verdaccio` Service injects a docker-link env var `VERDACCIO_PORT=tcp://<clusterip>:4873`, which Verdaccio misreads as its **listen address**. Fix: `enableServiceLinks: false` on the pod + an explicit `VERDACCIO_PORT=4873`. (Found on-cluster; the npm secret itself is fine now.)