### PR TITLE
fix(coredns): split-horizon tekton-pac.coreyalan.com for HTTP-01

### DIFF
--- a/coredns/configmap.yaml
+++ b/coredns/configmap.yaml
@@ -70,6 +70,10 @@ data:
     10.43.5.100 call.coreyalan.com
     10.43.5.100 mrtc.coreyalan.com
     10.43.5.100 admin.coreyalan.com
+    # Tekton Pipelines-as-Code controller (build platform). Split-horizon so the
+    # cert-manager HTTP-01 self-check reaches Traefik instead of hairpinning to
+    # the public IP; GitHub's external webhook still hits the public IP:443.
+    10.43.5.100 tekton-pac.coreyalan.com
     10.43.5.100 sabnzbd.authoritah.tv
     10.43.5.100 jellyfin.authoritah.tv
     10.43.5.100 docs.authoritah.com


### PR DESCRIPTION
The `tekton-pac-tls` cert is stuck because cert-manager's HTTP-01 self-check can't reach `http://tekton-pac.coreyalan.com` — the cluster hairpins to its own public IP and times out. Add the host to the CoreDNS split-horizon block (`10.43.5.100`, Traefik ClusterIP) like the other homelab domains, so the self-check hits Traefik in-cluster. External Let's Encrypt + GitHub webhook traffic still resolves to the public IP. This is the same mechanism the file comment cites for the existing certs. After merge + CoreDNS reload (~15s), the cert should issue.