### PR TITLE
docs(gvisor): track node-bootstrap for runsc (installer + template)

### DIFF
--- a/docs/runbooks/tekton-build-platform.md
+++ b/docs/runbooks/tekton-build-platform.md
@@ -20,12 +20,13 @@ superseded). Design: [ADR-0017](../../../framework/decisions/0017-tekton-build-p
 
 ## One-time setup (in order)
 
-1. **Node runtime prerequisites (NOT GitOps).** On each worker node, install and
-   register the sandbox handlers in containerd:
-   - `runsc` (gVisor) → `plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc`
-   - `kata` (Kata Containers) → the `kata` runtime handler
-   Record this in the node provisioning runbook — a rebuilt node silently loses
-   the sandbox. The `RuntimeClass` objects reference these handlers by name.
+1. **Node runtime prerequisites (NOT GitOps).** The untrusted tier runs under
+   gVisor; k3s does not auto-detect runsc, so each node that schedules build pods
+   needs the runsc binary + a containerd runtime entry. The tracked installer +
+   template live in **`node-bootstrap/gvisor/`** (which nodes, exact steps,
+   verification, and the optional full-GitOps DaemonSet/SUC path). A rebuilt node
+   silently loses the sandbox until re-run. Kata (for the Android/NDK untrusted
+   channel) is added later via `kata-deploy`.
 2. **Pin/verify release versions** before first sync:
    - operator `tekton/operator/kustomization.yaml` (v0.78.0 LTS)
    - PaC `tekton/pac/kustomization.yaml` (`release.k8s.yaml`, v0.41.1)

--- a/node-bootstrap/gvisor/README.md
+++ b/node-bootstrap/gvisor/README.md
@@ -1,0 +1,57 @@
+# Node bootstrap: gVisor (runsc)
+
+The Tekton **untrusted build tier** runs arbitrary PR code under gVisor
+(`runtimeClassName: gvisor`). k3s does **not** auto-detect runsc (its auto-detect
+list is only crun/spin/wasm*), so each node that schedules those pods needs the
+runsc binary + a containerd runtime entry. This is node-level (not GitOps); the
+script + template are tracked here so the steps are version-controlled and
+identical across nodes.
+
+## Which nodes?
+
+Every node an untrusted build pod can land on. With no taints, that's **all
+nodes**. To limit it, dedicate a build node instead:
+
+```bash
+kubectl taint  node <build-node> build.capturly/tier=untrusted:NoSchedule
+kubectl label  node <build-node> build.capturly/runtime=gvisor
+# then add a matching nodeSelector + toleration to the untrusted pipeline pods
+# (ask before doing this — it changes the build-catalog podTemplates)
+```
+
+## Install (per node, has sudo)
+
+```bash
+# copy install-runsc.sh to the node, then:
+sudo RUNSC_RELEASE=latest ./install-runsc.sh
+```
+
+Pin `RUNSC_RELEASE` to a dated release (e.g. `20250910`) for reproducibility.
+
+## Verify
+
+```bash
+kubectl get runtimeclass gvisor
+kubectl run gvtest --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"runtimeClassName":"gvisor"}}' --command -- sh -c 'uname -a'
+kubectl logs gvtest   # gVisor reports a synthetic kernel -> sandbox works
+kubectl delete pod gvtest
+```
+
+## Making it fully GitOps (optional, later)
+
+Node bootstrap can be automated + Argo-synced if manual runs become painful:
+
+- **system-upgrade-controller `Plan`** — a CRD that runs a host-privileged Job on
+  matching nodes; put the Plan (running this script) in `argocd/applications/`.
+- **Privileged installer DaemonSet** — mounts the host FS, installs runsc, writes
+  the tmpl, drains/reboots. More invasive.
+
+Both are heavier than a 4-node homelab needs today; the tracked script is the
+pragmatic middle ground (version-controlled *how*, manual *apply*).
+
+## Kata (later)
+
+The untrusted **Android/NDK** channel needs Kata, not gVisor (gVisor can't run
+some native syscalls). Kata has an official `kata-deploy` DaemonSet (GitOps-able)
+— add it when that channel lands (design §1/§8).

--- a/node-bootstrap/gvisor/install-runsc.sh
+++ b/node-bootstrap/gvisor/install-runsc.sh
@@ -45,10 +45,13 @@ fi
 echo "wrote/updated: $tmpl (plugin: $plugin)"
 
 echo "== 3/3 restart k3s to re-render containerd config =="
-if systemctl list-unit-files 2>/dev/null | grep -q '^k3s\.service'; then
+# Restart whichever unit is actually active (server runs k3s, agents k3s-agent).
+if systemctl is-active --quiet k3s; then
   sudo systemctl restart k3s          # server node (e.g. blacktalon)
-else
+elif systemctl is-active --quiet k3s-agent; then
   sudo systemctl restart k3s-agent    # agent node
+else
+  echo "WARN: neither k3s nor k3s-agent is active — restart the k3s unit manually."
 fi
 
 echo "== done. verify: sudo grep -A2 runsc ${cdir}/config*.toml =="

--- a/node-bootstrap/gvisor/install-runsc.sh
+++ b/node-bootstrap/gvisor/install-runsc.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Install gVisor (runsc) and register it as a k3s containerd runtime, so pods with
+# runtimeClassName: gvisor can schedule on this node. Run as a user with sudo on
+# EVERY node that will schedule untrusted build pods (Tekton untrusted tier).
+#
+# NOT GitOps: this touches node binaries + /var/lib/rancher/k3s and restarts k3s.
+# It is tracked here only so the steps are version-controlled + identical across
+# nodes. Idempotent — safe to re-run (e.g. after a node rebuild).
+set -euo pipefail
+
+# Pin a dated gVisor release for reproducibility (https://github.com/google/gvisor/releases).
+# "latest" is convenient but unpinned — set a date like 20250910 for prod repeatability.
+RUNSC_RELEASE="${RUNSC_RELEASE:-latest}"
+
+echo "== 1/3 install runsc + shim =="
+ARCH="$(uname -m)"
+URL="https://storage.googleapis.com/gvisor/releases/release/${RUNSC_RELEASE}/${ARCH}"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT; cd "$tmp"
+for f in runsc containerd-shim-runsc-v1; do
+  wget -q "${URL}/${f}" "${URL}/${f}.sha512"
+done
+sha512sum -c runsc.sha512 -c containerd-shim-runsc-v1.sha512
+chmod a+rx runsc containerd-shim-runsc-v1
+sudo mv runsc containerd-shim-runsc-v1 /usr/local/bin/   # must be on k3s containerd's PATH
+cd /
+
+echo "== 2/3 register the runtime in k3s containerd (detect containerd 1.x vs 2.x) =="
+cdir=/var/lib/rancher/k3s/agent/etc/containerd
+if [ -f "$cdir/config-v3.toml" ]; then
+  tmpl="$cdir/config-v3.toml.tmpl"; plugin='io.containerd.cri.v1.runtime'   # containerd 2.x
+else
+  tmpl="$cdir/config.toml.tmpl";     plugin='io.containerd.grpc.v1.cri'     # containerd 1.x
+fi
+block=$(printf '[plugins."%s".containerd.runtimes.runsc]\n  runtime_type = "io.containerd.runsc.v1"\n' "$plugin")
+if [ -f "$tmpl" ]; then
+  # Preserve any existing customizations; append runsc only if missing.
+  if ! sudo grep -q 'runtimes.runsc' "$tmpl"; then
+    printf '\n%s\n' "$block" | sudo tee -a "$tmpl" >/dev/null
+  fi
+else
+  # k3s renders config from this tmpl; {{ template "base" . }} keeps k3s's
+  # auto-generated base (crun/spin/wasm* runtimes) and we add runsc.
+  printf '{{ template "base" . }}\n\n%s\n' "$block" | sudo tee "$tmpl" >/dev/null
+fi
+echo "wrote/updated: $tmpl (plugin: $plugin)"
+
+echo "== 3/3 restart k3s to re-render containerd config =="
+if systemctl list-unit-files 2>/dev/null | grep -q '^k3s\.service'; then
+  sudo systemctl restart k3s          # server node (e.g. blacktalon)
+else
+  sudo systemctl restart k3s-agent    # agent node
+fi
+
+echo "== done. verify: sudo grep -A2 runsc ${cdir}/config*.toml =="


### PR DESCRIPTION
Adds `node-bootstrap/gvisor/` — a tracked, idempotent per-node installer + README for the runsc handler the untrusted tier needs (k3s doesn't auto-detect gVisor). Node bootstrap isn't native GitOps, so the *how* is version-controlled here and applied manually per node; the README documents the optional full-GitOps path (system-upgrade-controller Plan or a privileged DaemonSet) for later. Runbook now points at it.