### PR TITLE
fix(tekton): install operator from GitHub release, not GCS

### DIFF
--- a/tekton/operator/kustomization.yaml
+++ b/tekton/operator/kustomization.yaml
@@ -9,7 +9,12 @@
 # Pin: v0.78.x is the current LTS (released 2025-12-08, EOL 2026-12-08). Verify
 # and bump against https://github.com/tektoncd/operator/releases; keep the k8s
 # `release.yaml` (the OpenShift artifact is a different file).
+#
+# Use the GitHub release-download URL, NOT the storage.googleapis.com one: Argo's
+# kustomize misclassifies the GCS URL as a git repo and fails ("URL is a git
+# repository"). The github.com/.../releases/download/... form is treated as a
+# remote file (same pattern that works for tekton-pac).
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://storage.googleapis.com/tekton-releases/operator/previous/v0.78.0/release.yaml
+  - https://github.com/tektoncd/operator/releases/download/v0.78.0/release.yaml


### PR DESCRIPTION
**Root cause found while verifying capturly-builds-trusted + tekton-config health.** The Tekton **Operator never installed** — the only Tekton CRD present is PaC's `Repository`. The `tekton-operator` app fails manifest generation:

```
kustomize build tekton/operator: accumulating resources from
'https://storage.googleapis.com/.../release.yaml': URL is a git repository':
git fetch https://storage.googleapis.com/tekton-releases/operator HEAD -> repository not found
```

Argo's kustomize misclassifies the **GCS URL** as a git repo. No operator → no `TektonConfig`/`Pipeline`/`Triggers`/`Chains` CRDs → `tekton-config` and `capturly-builds-trusted` (EventListener) sit `Missing`, and **no build can actually run** (PaC's controller is up but has no Pipeline CRDs to create runs against).

Fix: install the operator from the **GitHub release-download URL** (verified 200, publishes `release.yaml`), which Argo's kustomize treats as a remote file — the same pattern that already works for `tekton-pac`. After merge + sync: operator installs → TektonConfig (profile basic) reconciles → Pipelines/Triggers/Results/Chains come up → the two apps go Healthy.