### PR TITLE
fix(tekton): disable Results (postgres PVC never binds)

### DIFF
--- a/tekton/config/tektonconfig.yaml
+++ b/tekton/config/tektonconfig.yaml
@@ -24,3 +24,9 @@ spec:
     # (design §5, ADR-0005). Left at install defaults here so Phase 0 only stands
     # the controller up.
     disabled: false
+  result:
+    # Disabled: the operator creates the Results postgres PVC with
+    # storageClassName="" (opts out of dynamic provisioning), so it never binds
+    # on this cluster and keeps TektonConfig from going Ready. Run history +
+    # evidence come from Loki + `tkn` + Chains->Rekor instead (design §3).
+    disabled: true


### PR DESCRIPTION
With the operator now installed (#587), `TektonConfig` won't reach `Ready` because the **Tekton Results** postgres PVC is stuck `Pending` — the operator creates it with `storageClassName: ""`, which explicitly opts out of dynamic provisioning, so `local-path` never binds it. Pipelines + Triggers are up and builds can run regardless.

Results is optional; run history + evidence are covered by Loki + `tkn` + Chains→Rekor (design §3). Set `spec.result.disabled: true` so the operator drops the Results component and TektonConfig goes Ready. (Re-enable later with a configured DB storage class if you want the Results API.)