### PR TITLE
fix(tekton): wire ANDROID_SENTRY_AUTH_TOKEN UUID (unblocks signing)

### DIFF
--- a/build-targets/capturly-android-trusted/externalsecret-signing.yaml
+++ b/build-targets/capturly-android-trusted/externalsecret-signing.yaml
@@ -30,4 +30,4 @@ spec:
     # ⚠️ TODO: SENTRY_AUTH_TOKEN was a GitHub secret, not in Bitwarden. Create it
     #    in Bitwarden SM (project Capturly) and set the UUID here.
     - secretKey: sentry-auth-token
-      remoteRef: { key: REPLACE-WITH-BWS-UUID-sentry-auth-token }
+      remoteRef: { key: dc0dc51c-e4d5-4496-9957-b48d0146011c }  # ANDROID_SENTRY_AUTH_TOKEN (placeholder value — update in Bitwarden)


### PR DESCRIPTION
Wires the last trusted-tier placeholder. The sentry key made `capturly-android-signing` error (ESO all-or-nothing), blocking the **keystore** secret too. Points at the created `ANDROID_SENTRY_AUTH_TOKEN` secret in Staging-Capturly so the ES syncs and `capturly-builds-trusted` goes Healthy. Its Bitwarden **value is a placeholder** — update it with a real Sentry token before an actual release (the build uploads sourcemaps with it).