### PR TITLE
fix(tekton): read Android signing from the Capturly BWS project

### DIFF
--- a/build-targets/capturly-android-trusted/externalsecret-signing.yaml
+++ b/build-targets/capturly-android-trusted/externalsecret-signing.yaml
@@ -1,8 +1,8 @@
 ---
-# Android upload-keystore + signing material, synced from Bitwarden SM (project
-# Capturly) into the `capturly-android-signing` secret the build task mounts.
-# UUIDs are the SAME secrets release-android.yml already consumes (verified from
-# the workflow's bitwarden/sm-action block) — only sentry-auth-token is new.
+# Android upload-keystore + signing material, synced from the "Capturly" Bitwarden
+# project (where release-android.yml's keystore secrets live — NOT the newer
+# "Staging - Capturly" project) into the `capturly-android-signing` secret. Uses
+# the bitwarden-capturly store so the keystore UUIDs resolve.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -11,7 +11,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-staging-capturly-web
+    name: bitwarden-capturly
     kind: ClusterSecretStore
   target:
     name: capturly-android-signing
@@ -27,7 +27,5 @@ spec:
       remoteRef: { key: 4561aaf7-9684-42f6-b2d7-b48100fb28ef }  # ANDROID_KEY_ALIAS
     - secretKey: key-password
       remoteRef: { key: 43bc3f16-1331-43ad-b343-b48100fb2932 }  # ANDROID_KEY_PASSWORD
-    # ⚠️ TODO: SENTRY_AUTH_TOKEN was a GitHub secret, not in Bitwarden. Create it
-    #    in Bitwarden SM (project Capturly) and set the UUID here.
     - secretKey: sentry-auth-token
-      remoteRef: { key: dc0dc51c-e4d5-4496-9957-b48d0146011c }  # ANDROID_SENTRY_AUTH_TOKEN (placeholder value — update in Bitwarden)
+      remoteRef: { key: 028b61b9-62ff-46f9-ab5d-b48d01479e71 }  # ANDROID_SENTRY_AUTH_TOKEN (Capturly project; placeholder value — update in Bitwarden)

--- a/external-secrets-operator/manifests/clustersecretstore-capturly.yaml
+++ b/external-secrets-operator/manifests/clustersecretstore-capturly.yaml
@@ -1,0 +1,31 @@
+---
+# ClusterSecretStore for the original "Capturly" Bitwarden project — where the
+# Android **signing keystore** + the release-android workflow secrets live (not
+# the newer "Staging - Capturly" project the web app uses). The trusted Android
+# build reads its keystore + sentry token from here.
+#
+# ⚠️ The ESO machine account behind `bitwarden-credentials` must be granted read
+#    access to the "Capturly" project, or reads 404.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: bitwarden-capturly
+spec:
+  provider:
+    bitwardensecretsmanager:
+      auth:
+        secretRef:
+          credentials:
+            name: bitwarden-credentials
+            namespace: external-secrets-system
+            key: token
+      apiURL: https://api.bitwarden.com
+      identityURL: https://identity.bitwarden.com
+      bitwardenServerSDKURL: https://bitwarden-sdk-server.external-secrets-system.svc.cluster.local:9998
+      organizationID: "4650c1c8-8d22-4073-8a7d-b3cf011d5ff2"
+      projectID: "63f8918c-424f-419b-b9d8-b3cf012d480c"  # Capturly
+      caProvider:
+        type: Secret
+        name: bitwarden-tls-certs
+        namespace: external-secrets-system
+        key: ca.crt


### PR DESCRIPTION
`capturly-android-signing` was 404-ing on the **keystore** (`data[0]`), which blocked the whole secret. Root cause: the keystore lives in the original **"Capturly"** project (`63f8918c`, what release-android.yml uses), but the ESO store read **"Staging - Capturly"** (`e4e50481`) — different project.

Fix: add a **`bitwarden-capturly`** ClusterSecretStore for project `63f8918c` and point the signing ExternalSecret at it (keystore UUIDs now resolve; the sentry placeholder was moved to the same project).

⚠️ **One manual step:** grant the ESO machine account (`d7d98b6a…`, behind `bitwarden-credentials`) **read access to the "Capturly" project** — same as you did for Build Platform. Then `capturly-android-signing` syncs, the keystore materializes, and `capturly-builds-trusted` goes Healthy.