### PR TITLE
feat(tekton): dedicated build App + build-scoped ESO account (H4, H8)

### DIFF
--- a/build-targets/capturly-android-trusted/externalsecret-github-app.yaml
+++ b/build-targets/capturly-android-trusted/externalsecret-github-app.yaml
@@ -1,8 +1,9 @@
 ---
-# GitHub App credentials for the trusted clone — reuses the PaC App's key (already
-# in the Build Platform project). The clone task mints a short-lived (~1h)
-# installation token from these at build time and clones with it, so there is NO
-# static git credential in the pod. Mounted as the `github-app` workspace.
+# GitHub App credentials for the trusted clone — the dedicated **build** App
+# (Contents:read only, separate from the PaC webhook App). The clone task mints a
+# short-lived (~1h) installation token from these at build time, so there is NO
+# static git credential and the token carries only clone scope. Mounted as the
+# `github-app` workspace.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -20,6 +21,6 @@ spec:
       engineVersion: v2
   data:
     - secretKey: app-id
-      remoteRef: { key: 2223f244-117c-4082-b537-b48d012230f2 }   # PAC_APP_ID
+      remoteRef: { key: 98c21209-8551-447f-8897-b48d0154e6f7 }   # BUILD_APP_ID (Contents:read-only App)
     - secretKey: app-private-key
-      remoteRef: { key: 6268d2a7-a068-48c0-8e80-b48d01226060 }   # PAC_APP_PRIVATE_KEY
+      remoteRef: { key: f331c75a-a7fb-4631-8c6d-b48d0154e73b }   # BUILD_APP_PRIVATE_KEY

--- a/build-targets/capturly-android-trusted/externalsecret-webhook.yaml
+++ b/build-targets/capturly-android-trusted/externalsecret-webhook.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-staging-capturly-web
+    name: bitwarden-build-platform
     kind: ClusterSecretStore
   target:
     name: capturly-webhook
@@ -20,4 +20,4 @@ spec:
       engineVersion: v2
   data:
     - secretKey: webhook-secret
-      remoteRef: { key: a1d24301-63c2-45b3-ad62-b48d010f0f55 }  # CAPTURLY_TEKTON_TRUSTED_WEBHOOK_SECRET
+      remoteRef: { key: 06a03bb9-88d3-4076-9302-b48d0154f9b6 }  # CAPTURLY_TEKTON_TRUSTED_WEBHOOK_SECRET (moved to Build Platform)

--- a/external-secrets-operator/manifests/clustersecretstore-build-platform.yaml
+++ b/external-secrets-operator/manifests/clustersecretstore-build-platform.yaml
@@ -4,7 +4,7 @@
 # Verdaccio npm uplink token) — kept OUT of any single project's scope. Reuses
 # the same bitwarden-credentials machine-account token as the other stores.
 #
-# ⚠️ The ESO machine account behind `bitwarden-credentials` must be granted read
+# ⚠️ The ESO machine account behind `bitwarden-credentials-build` must have read
 #    access to the "Build Platform" project in Bitwarden, or reads 404.
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
@@ -16,7 +16,9 @@ spec:
       auth:
         secretRef:
           credentials:
-            name: bitwarden-credentials
+            # Build-scoped machine account (reads only Build Platform + Capturly),
+            # separate from the broad web/app account (blast-radius, H8).
+            name: bitwarden-credentials-build
             namespace: external-secrets-system
             key: token
       apiURL: https://api.bitwarden.com

--- a/external-secrets-operator/manifests/clustersecretstore-capturly.yaml
+++ b/external-secrets-operator/manifests/clustersecretstore-capturly.yaml
@@ -4,7 +4,7 @@
 # the newer "Staging - Capturly" project the web app uses). The trusted Android
 # build reads its keystore + sentry token from here.
 #
-# ⚠️ The ESO machine account behind `bitwarden-credentials` must be granted read
+# ⚠️ The ESO machine account behind `bitwarden-credentials-build` must have read
 #    access to the "Capturly" project, or reads 404.
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
@@ -16,7 +16,9 @@ spec:
       auth:
         secretRef:
           credentials:
-            name: bitwarden-credentials
+            # Build-scoped machine account (reads only Build Platform + Capturly),
+            # separate from the broad web/app account (blast-radius, H8).
+            name: bitwarden-credentials-build
             namespace: external-secrets-system
             key: token
       apiURL: https://api.bitwarden.com


### PR DESCRIPTION
Stands up the two cross-cutting Phase 3 prerequisites (least-privilege identity):

**H4 — dedicated build App:** clone tokens are now minted from a new **Contents:read-only** GitHub App (`BUILD_APP_*`, id 4349756), not the broad PaC webhook App. The minted token carries clone scope only.

**H8 — build-scoped ESO account:** the build ClusterSecretStores (`bitwarden-build-platform`, `bitwarden-capturly`) now authenticate with `bitwarden-credentials-build` — a machine account that reads **only Build Platform + Capturly**. The webhook secret was moved out of Staging-Capturly into Build Platform, so **no build ExternalSecret touches the web-app project**. A leaked build token can no longer read web/DB secrets.

Prereqs (done by operator): build App created + installed on both repos; `bitwarden-credentials-build` k8s secret created; the build account granted Build Platform + Capturly.

Optional follow-up: revoke the old broad account's Build Platform + Capturly access for full separation.