### PR TITLE
feat(tekton): 3a — split untrusted egress (H2)

### DIFF
--- a/build-targets/capturly-nextjs-untrusted/networkpolicy.yaml
+++ b/build-targets/capturly-nextjs-untrusted/networkpolicy.yaml
@@ -1,17 +1,17 @@
 ---
-# Untrusted-tier egress. The build runs arbitrary PR code, so this is the primary
-# containment (with gVisor). Allowed: cluster DNS, the Verdaccio proxy (all npm,
-# private included — no token in the pod), and public HTTPS for the git clone.
-# Denied: cloud metadata and all other private ranges (no lateral movement, no
-# k8s API, no Bitwarden, no other cluster service).
-#
-# ⚠️ HARDENING: public 443 is broad (needed for the GitHub clone) and leaves a
-#    postinstall an exfil path. Replace with a CiliumNetworkPolicy that FQDN-locks
-#    egress to github.com + the Verdaccio service to close it (design §8).
+# Untrusted-tier egress, SPLIT BY TASK (Phase 3 H2). The build runs arbitrary PR
+# code in the `checks` step (pnpm install → postinstall), so that pod gets NO
+# public egress — only cluster DNS + the Verdaccio proxy. Only the `clone` pod
+# (which runs no PR code, just git) may reach the public internet. NetworkPolicies
+# are additive, so each pod's egress is the union of the policies selecting it.
+# This closes the exfil path that a single public-443 rule left open, without
+# needing Cilium FQDN policies (this cluster has no Cilium CNI).
+
+# Baseline: cluster DNS for every pod (incl. Tekton's affinity-assistant).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: capturly-untrusted-egress
+  name: capturly-untrusted-dns
   namespace: capturly-builds-untrusted
 spec:
   podSelector: {}
@@ -19,13 +19,35 @@ spec:
   egress:
     - to: [{ namespaceSelector: {} }]
       ports: [{ protocol: UDP, port: 53 }, { protocol: TCP, port: 53 }]
-    # Verdaccio registry proxy (in-cluster) — the only npm path; no token here.
+---
+# `checks` (arbitrary PR code): Verdaccio ONLY — no public egress, no lateral.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: capturly-untrusted-checks-egress
+  namespace: capturly-builds-untrusted
+spec:
+  podSelector:
+    matchLabels: { tekton.dev/pipelineTask: checks }
+  policyTypes: [Egress]
+  egress:
     - to:
         - namespaceSelector:
             matchLabels: { build.capturly/component: registry-proxy }
       ports: [{ protocol: TCP, port: 4873 }]
-    # Public HTTPS for the git clone. Excludes RFC1918 + link-local (169.254.x,
-    # blocks the cloud metadata endpoint) to limit lateral movement / SSRF.
+---
+# `clone` (no PR code, git only): public HTTPS for the GitHub clone. Private
+# ranges + link-local (169.254 metadata) excluded (anti lateral-movement / SSRF).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: capturly-untrusted-clone-egress
+  namespace: capturly-builds-untrusted
+spec:
+  podSelector:
+    matchLabels: { tekton.dev/pipelineTask: clone }
+  policyTypes: [Egress]
+  egress:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0

--- a/docs/design/tekton-phase3-plan.md
+++ b/docs/design/tekton-phase3-plan.md
@@ -110,8 +110,8 @@ checklist.
 
 | Step | Work | Verify |
 |---|---|---|
-| **3a — Harden live bundles** | Add H1 securityContext + H2 split-egress to the *current* capturly bundles (before templating) | untrusted build pod has no public egress; a test exfil fails |
-| **3b — Chart + ApplicationSet** | Build `charts/build-namespace` + the ApplicationSet + inventory; migrate capturly | rendered manifests match live (+ hardening); apps Healthy |
+| **3a — Split egress (H2)** | Split the untrusted egress by task (clone gets internet; the arbitrary-code `checks` step gets Verdaccio only) | untrusted `checks` pod has no public egress; a test exfil fails |
+| **3b — Chart + non-root images + ApplicationSet** | Non-root toolchain images (tools pre-baked) so **H1 `set-security-context`** can be enabled cluster-wide; `charts/build-namespace` + ApplicationSet + inventory; migrate capturly | steps run non-root/drop-caps/seccomp; rendered manifests match live (+ hardening); apps Healthy |
 | **3c — Onboard coreyalan** | One inventory entry per tier | app generated + Healthy from a single file |
 | **3d — Trusted go-live gates** | H6 fail-closed test; H7 Chains keyless + verify-on-admit | release blocks without approval; artifact has a verified attestation |
 | **3e — Blast-radius (opt)** | H8 per-project ESO machine accounts; H4 dedicated build App; H10 build node | leaked build token ≠ all secrets |

--- a/tekton/config/tektonconfig.yaml
+++ b/tekton/config/tektonconfig.yaml
@@ -18,6 +18,9 @@ spec:
     # Beta fields cover the resolver + provenance features the catalog uses.
     # The git resolver (channel catalog, design §4) ships enabled by default.
     enable-api-fields: beta
+    # H1 (set-security-context) is deferred to 3b: it forces runAsNonRoot on all
+    # steps, which needs the tools pre-baked into images (no runtime apk add /
+    # corepack enable). Enabled once the non-root toolchain images land.
   chain:
     # Chains controller runs now; keyless Sigstore signing (Fulcio/Rekor) + SLSA
     # provenance config is wired in Phase 1 with the trusted Android pipeline


### PR DESCRIPTION
**3a hardening — closes the untrusted exfil hole (H2).** The untrusted `checks` step runs arbitrary PR code (`pnpm install` postinstall). It previously shared a single `public :443` egress rule (needed for the clone), leaving an exfil path. Now egress is **split by task** (`tekton.dev/pipelineTask` label):
- `checks` (arbitrary code) → **DNS + Verdaccio only**, no public egress
- `clone` (no PR code) → public :443 for the GitHub clone
- baseline DNS for all pods

No Cilium needed (this cluster has none). A postinstall can no longer reach the internet.

**H1 (set-security-context) is deferred to 3b:** enabling it forces `runAsNonRoot` on every step, but some steps need root at runtime (`apk add` in the android clone, `corepack enable` in web-ci). 3b bakes the tools into non-root toolchain images so H1 can be turned on cluster-wide without breaking builds. Plan doc updated.