### PR TITLE
feat(tekton): 3b-1 non-root build images (H1 prep)

### DIFF
--- a/.github/workflows/build-web-toolchain.yml
+++ b/.github/workflows/build-web-toolchain.yml
@@ -1,0 +1,81 @@
+name: Build build-web-toolchain
+
+# Generic Node+pnpm step image for the nextjs-build `web-ci` task. Pushes to GHCR
+# and pins the digest into web-ci's node-image default (ADR-0004). Runs on changes
+# to the image or this workflow, or on demand.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "apps/build-web-toolchain/**"
+      - ".github/workflows/build-web-toolchain.yml"
+
+concurrency:
+  group: build-web-toolchain
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/nx211/build-web-toolchain
+  VERSION: "0.1.0"
+  TASK: build-catalog/tasks/web-ci.yaml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GITOPS_APP_ID }}
+          private-key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: apps/build-web-toolchain
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          sbom: false
+          tags: |
+            ${{ env.IMAGE }}:${{ env.VERSION }}
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:sha-${{ github.sha }}
+
+      - uses: mikefarah/yq@v4
+
+      - name: Pin digest into the web-ci task
+        env:
+          REF: ${{ env.IMAGE }}:${{ env.VERSION }}@${{ steps.push.outputs.digest }}
+        run: |
+          yq -i '(.spec.params[] | select(.name == "node-image") | .default) = strenv(REF)' "$TASK"
+
+      - name: Commit pin-back
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- "$TASK"; then
+            echo "No change; digest already pinned."
+            exit 0
+          fi
+          git add "$TASK"
+          git commit -m "chore(web-toolchain): pin image ${{ steps.push.outputs.digest }}"
+          git push

--- a/apps/build-web-toolchain/Dockerfile
+++ b/apps/build-web-toolchain/Dockerfile
@@ -1,0 +1,13 @@
+# Generic web/nextjs build toolchain (Node 22 + pnpm), used as the step image for
+# the nextjs-build `web-ci` task across projects. Tools are PRE-BAKED so steps run
+# WITHOUT root at runtime (no `corepack enable`, which writes to /usr/local) —
+# required once set-security-context (H1) forces runAsNonRoot on all steps.
+#
+# node:22-bookworm (full, not slim) includes git + python3/make/g++ for any deps
+# with native (node-gyp) builds. pnpm is installed globally and is world-readable,
+# so an arbitrary non-root uid can run it.
+FROM node:22-bookworm
+
+RUN npm install -g pnpm@9.15.9 \
+    && npm cache clean --force \
+    && chmod -R a+rX /usr/local/lib/node_modules

--- a/apps/capturly-android-toolchain/Dockerfile
+++ b/apps/capturly-android-toolchain/Dockerfile
@@ -13,8 +13,14 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      unzip curl git ca-certificates ccache python3 python3-pip \
+      unzip curl git ca-certificates ccache python3 python3-pip openssl \
     && rm -rf /var/lib/apt/lists/*
+
+# Play-publish deps baked in so the step needs no runtime `pip install` (which
+# would need root under set-security-context, H1). openssl (above) + python3 are
+# also what the clone step uses to mint the GitHub App JWT.
+RUN pip3 install --no-cache-dir --break-system-packages \
+      google-api-python-client google-auth
 
 # Node 22 + pnpm (pin matches the repo's packageManager)
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \

--- a/build-catalog/pipelines/android-build.yaml
+++ b/build-catalog/pipelines/android-build.yaml
@@ -56,15 +56,16 @@ spec:
         params: []
         steps:
           - name: git-clone
-            image: alpine/git:2.45.2
+            # Toolchain image (openssl + python3 + curl + git pre-baked) so the
+            # step runs non-root under set-security-context — no runtime apk add.
+            image: $(params.toolchain-image)
             script: |
-              #!/bin/sh
+              #!/usr/bin/env bash
               # Clone the private repo with a ~1h GitHub App installation token
-              # minted at build time — nothing long-lived in the pod. The App key
-              # is the only stored secret (shared with PaC). set -e but never -x
-              # so the token is never echoed.
-              set -eu
-              apk add --no-cache --quiet curl jq openssl >/dev/null
+              # minted at build time — nothing long-lived in the pod. set -e but
+              # never -x so the token is never echoed. JSON parsed with python3
+              # (baked) instead of jq.
+              set -euo pipefail
 
               APP_ID="$(cat /github-app/app-id)"
               b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
@@ -76,8 +77,8 @@ spec:
 
               slug="$(printf '%s' "$(params.git-url)" | sed -E 's#https?://github.com/##; s#\.git$##')"
               gh="https://api.github.com"
-              inst="$(curl -sf -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" "$gh/repos/$slug/installation" | jq -r .id)"
-              token="$(curl -sf -X POST -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" "$gh/app/installations/$inst/access_tokens" | jq -r .token)"
+              inst="$(curl -sf -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" "$gh/repos/$slug/installation" | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])')"
+              token="$(curl -sf -X POST -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" "$gh/app/installations/$inst/access_tokens" | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])')"
 
               cd "$(workspaces.output.path)"
               git clone "https://x-access-token:${token}@github.com/${slug}.git" .

--- a/build-catalog/tasks/play-publish.yaml
+++ b/build-catalog/tasks/play-publish.yaml
@@ -56,7 +56,8 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
-        pip install --quiet google-api-python-client google-auth
+        # google-api-python-client + google-auth are baked into the toolchain
+        # image (no runtime pip install, so the step runs non-root under H1).
         python3 scripts/play-upload.py \
           --package "$(params.package)" \
           --aab "$(workspaces.source.path)/$(params.aab-path)" \

--- a/build-catalog/tasks/web-ci.yaml
+++ b/build-catalog/tasks/web-ci.yaml
@@ -13,7 +13,9 @@ spec:
   params:
     - name: node-image
       type: string
-      default: node:22-bookworm-slim
+      # Node+pnpm pre-baked (apps/build-web-toolchain) so the step runs non-root
+      # (no `corepack enable` write to /usr/local). Digest pinned by CI.
+      default: ghcr.io/nx211/build-web-toolchain:0.1.0
   workspaces:
     - name: source
     - name: npmrc            # configmap: .npmrc pointing at Verdaccio (no token)
@@ -31,7 +33,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
-        corepack enable && corepack prepare pnpm@9.15.9 --activate
+        # pnpm is baked into the image (non-root); no corepack enable needed.
         cp /config/npm/.npmrc "$HOME/.npmrc"   # registry = Verdaccio, no auth
         pnpm install --frozen-lockfile
         # apps/web type-checks against the compiled dist/ of its workspace deps.


### PR DESCRIPTION
**3b-1 — makes every build step run without root at runtime**, so `set-security-context` (H1) can be enabled cluster-wide in 3b-2 without breaking builds. No flag flip here; behavior is unchanged (just removes runtime root-installs).

- **new `build-web-toolchain`** image (Node 22 + pnpm pre-baked) + CI workflow; `web-ci` uses it and drops `corepack enable` (which writes to /usr/local → needs root)
- **android toolchain**: add `openssl`; bake `google-api-python-client`/`google-auth`; the clone step now runs on it (openssl+python3 JWT, **no `apk add`**); `play-publish` drops the runtime `pip install`

**Order:** merge this → the two image workflows rebuild → I fire a **smoke PipelineRun** to confirm the steps succeed non-root → then 3b-2 flips `set-security-context: true`.