### PR TITLE
fix(android-toolchain): drop --break-system-packages (jammy pip)

### DIFF
--- a/apps/capturly-android-toolchain/Dockerfile
+++ b/apps/capturly-android-toolchain/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Play-publish deps baked in so the step needs no runtime `pip install` (which
 # would need root under set-security-context, H1). openssl (above) + python3 are
 # also what the clone step uses to mint the GitHub App JWT.
-RUN pip3 install --no-cache-dir --break-system-packages \
+RUN pip3 install --no-cache-dir \
       google-api-python-client google-auth
 
 # Node 22 + pnpm (pin matches the repo's packageManager)


### PR DESCRIPTION
The android toolchain image build failed: `no such option: --break-system-packages`. Ubuntu 22.04 (jammy, the temurin base) ships pip 22.0 — the flag was added in pip 23, and jammy doesn't enforce PEP 668 anyway — so plain `pip3 install` works. (The web toolchain built fine.)