### PR TITLE
feat(tekton): 3b-2 enable set-security-context (H1)

### DIFF
--- a/tekton/config/tektonconfig.yaml
+++ b/tekton/config/tektonconfig.yaml
@@ -18,9 +18,11 @@ spec:
     # Beta fields cover the resolver + provenance features the catalog uses.
     # The git resolver (channel catalog, design §4) ships enabled by default.
     enable-api-fields: beta
-    # H1 (set-security-context) is deferred to 3b: it forces runAsNonRoot on all
-    # steps, which needs the tools pre-baked into images (no runtime apk add /
-    # corepack enable). Enabled once the non-root toolchain images land.
+    # H1: harden every step container cluster-wide — runAsNonRoot (uid 65532),
+    # drop ALL capabilities, disallow privilege escalation, seccomp RuntimeDefault.
+    # Defense-in-depth on top of gVisor. Validated non-root with a smoke run of the
+    # (tools-pre-baked) web + android images before enabling (3b-1).
+    set-security-context: "true"
   chain:
     # Chains controller runs now; keyless Sigstore signing (Fulcio/Rekor) + SLSA
     # provenance config is wired in Phase 1 with the trusted Android pipeline


### PR DESCRIPTION
Flips `set-security-context: true` cluster-wide, closing **H1**: every Tekton step now runs **runAsNonRoot (uid 65532), drop ALL capabilities, allowPrivilegeEscalation:false, seccomp RuntimeDefault** — defense-in-depth on top of gVisor.

De-risked first (3b-1): tools are baked into non-root images (no runtime `apk`/`corepack`/`pip`), and a **smoke run under the exact securityContext** confirmed both images work non-root (pnpm, openssl, python google-libs, and the openssl JWT-signing path all succeeded as uid 65532).

After merge: the operator reconciles TektonConfig; new PipelineRuns get the hardened step securityContext.