### PR TITLE
fix(tekton): set-security-context boolean (H1 didn't apply)

### DIFF
--- a/tekton/config/tektonconfig.yaml
+++ b/tekton/config/tektonconfig.yaml
@@ -22,7 +22,7 @@ spec:
     # drop ALL capabilities, disallow privilege escalation, seccomp RuntimeDefault.
     # Defense-in-depth on top of gVisor. Validated non-root with a smoke run of the
     # (tools-pre-baked) web + android images before enabling (3b-1).
-    set-security-context: "true"
+    set-security-context: true
   chain:
     # Chains controller runs now; keyless Sigstore signing (Fulcio/Rekor) + SLSA
     # provenance config is wired in Phase 1 with the trusted Android pipeline


### PR DESCRIPTION
#601 set `set-security-context: "true"` (string), but the TektonConfig CRD field is a **boolean** — the CR showed `"set-security-context":false` and `tekton-config` sat OutOfSync (Argo can't apply a string to a bool field), so H1 never actually enabled. Fix: unquoted `true`. After merge the operator reconciles it into the feature-flags ConfigMap (`set-security-context: "true"`) and new PipelineRuns get the hardened step securityContext.