### PR TITLE
feat(tekton): 3b-3 split Verdaccio into per-tier proxies (H3)

### DIFF
--- a/build-registry-proxy/networkpolicy-and-namespace.yaml
+++ b/build-registry-proxy/networkpolicy-and-namespace.yaml
@@ -6,15 +6,14 @@ metadata:
   labels:
     build.capturly/component: registry-proxy
 ---
-# Verdaccio egress: DNS + public HTTPS to npmjs only (no private ranges — it has
-# no reason to reach anything in-cluster outbound).
+# Both proxies' egress: DNS + public HTTPS to npmjs only (no private ranges).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: verdaccio-egress
   namespace: build-registry-proxy
 spec:
-  podSelector: { matchLabels: { app: verdaccio } }
+  podSelector: { matchLabels: { app.kubernetes.io/name: verdaccio } }
   policyTypes: [Egress]
   egress:
     - to: [{ namespaceSelector: {} }]
@@ -25,19 +24,33 @@ spec:
             except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]
       ports: [{ protocol: TCP, port: 443 }]
 ---
-# Verdaccio ingress: any build-tier namespace (trusted or untrusted) may reach the
-# proxy on 4873 — both install private deps through it, with no token in the pod.
+# Per-tier ingress (H3): the untrusted proxy accepts ONLY untrusted-tier
+# namespaces; the trusted proxy ONLY trusted-tier. A tier physically cannot reach
+# the other tier's cache.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: verdaccio-ingress
+  name: verdaccio-untrusted-ingress
   namespace: build-registry-proxy
 spec:
-  podSelector: { matchLabels: { app: verdaccio } }
+  podSelector: { matchLabels: { app: verdaccio-untrusted } }
   policyTypes: [Ingress]
   ingress:
     - from:
         - namespaceSelector:
-            matchExpressions:
-              - { key: build.capturly/tier, operator: Exists }
+            matchLabels: { build.capturly/tier: untrusted }
+      ports: [{ protocol: TCP, port: 4873 }]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: verdaccio-trusted-ingress
+  namespace: build-registry-proxy
+spec:
+  podSelector: { matchLabels: { app: verdaccio-trusted } }
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels: { build.capturly/tier: trusted }
       ports: [{ protocol: TCP, port: 4873 }]

--- a/build-registry-proxy/verdaccio.yaml
+++ b/build-registry-proxy/verdaccio.yaml
@@ -1,9 +1,9 @@
 ---
-# Verdaccio — the trusted npm registry proxy that lets the ZERO-SECRET untrusted
-# build tier install private @corey-alan-consulting packages without ever holding
-# the npm token (design §1, Phase 2 decision 2026-07-20). Verdaccio holds the
-# read token (uplink auth to npmjs); untrusted pods point their .npmrc at this
-# service with NO credential, so a malicious PR postinstall has nothing to steal.
+# Verdaccio npm registry proxies — TWO instances so the trusted and untrusted
+# build tiers share NO cache (H3). Each holds the read token (uplink to npmjs) and
+# serves private @corey-alan-consulting packages anonymously in-cluster, so build
+# pods hold no npm credential. Shared config; separate deployments + emptyDir
+# caches; a tier can only reach its own proxy (per-tier ingress netpol).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,7 +12,6 @@ metadata:
 data:
   config.yaml: |
     storage: /verdaccio/storage
-    # No user registration; anonymous read only (publish is denied everywhere).
     auth:
       htpasswd:
         file: /verdaccio/storage/htpasswd
@@ -20,15 +19,14 @@ data:
     uplinks:
       npmjs:
         url: https://registry.npmjs.org/
-        # Private-scope read token, injected from the mounted secret env.
         auth:
           type: bearer
           token_env: NPM_TOKEN
         maxage: 10m
     packages:
       '@corey-alan-consulting/*':
-        access: $anonymous          # in-cluster pods read without auth
-        publish: $authenticated     # nobody authenticates → publish denied
+        access: $anonymous
+        publish: $authenticated
         proxy: npmjs
       '**':
         access: $anonymous
@@ -41,37 +39,27 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: verdaccio
+  name: verdaccio-untrusted
   namespace: build-registry-proxy
-  labels: { app: verdaccio }
+  labels: { app: verdaccio-untrusted, app.kubernetes.io/name: verdaccio }
 spec:
   replicas: 1
   selector:
-    matchLabels: { app: verdaccio }
+    matchLabels: { app: verdaccio-untrusted }
   template:
     metadata:
-      labels: { app: verdaccio }
+      labels: { app: verdaccio-untrusted, app.kubernetes.io/name: verdaccio }
     spec:
-      # The `verdaccio` Service injects a docker-link env var VERDACCIO_PORT=
-      # tcp://<clusterip>:4873, which Verdaccio misreads as its listen ADDRESS
-      # ("Invalid address"). Disable service-link injection to stop it.
-      enableServiceLinks: false
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 10001
-        fsGroup: 10001
+      enableServiceLinks: false     # avoid VERDACCIO_PORT=tcp://... injection
+      securityContext: { runAsNonRoot: true, runAsUser: 10001, fsGroup: 10001 }
       containers:
         - name: verdaccio
           image: verdaccio/verdaccio:6.2.0
-          ports:
-            - { containerPort: 4873, name: http }
+          ports: [{ containerPort: 4873, name: http }]
           env:
-            # Explicit listen port (belt-and-suspenders vs the injected var).
-            - name: VERDACCIO_PORT
-              value: "4873"
+            - { name: VERDACCIO_PORT, value: "4873" }
             - name: NPM_TOKEN
-              valueFrom:
-                secretKeyRef: { name: verdaccio-npm-uplink, key: npm-token }
+              valueFrom: { secretKeyRef: { name: verdaccio-npm-uplink, key: npm-token } }
           volumeMounts:
             - { name: config, mountPath: /verdaccio/conf }
             - { name: storage, mountPath: /verdaccio/storage }
@@ -82,17 +70,60 @@ spec:
             httpGet: { path: /-/ping, port: 4873 }
             initialDelaySeconds: 5
       volumes:
-        - name: config
-          configMap: { name: verdaccio-config }
-        - name: storage
-          emptyDir: {}          # proxy cache only; safe to lose
+        - { name: config, configMap: { name: verdaccio-config } }
+        - { name: storage, emptyDir: {} }
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: verdaccio
+  name: verdaccio-untrusted
   namespace: build-registry-proxy
 spec:
-  selector: { app: verdaccio }
-  ports:
-    - { port: 4873, targetPort: 4873, name: http }
+  selector: { app: verdaccio-untrusted }
+  ports: [{ port: 4873, targetPort: 4873, name: http }]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdaccio-trusted
+  namespace: build-registry-proxy
+  labels: { app: verdaccio-trusted, app.kubernetes.io/name: verdaccio }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: verdaccio-trusted }
+  template:
+    metadata:
+      labels: { app: verdaccio-trusted, app.kubernetes.io/name: verdaccio }
+    spec:
+      enableServiceLinks: false
+      securityContext: { runAsNonRoot: true, runAsUser: 10001, fsGroup: 10001 }
+      containers:
+        - name: verdaccio
+          image: verdaccio/verdaccio:6.2.0
+          ports: [{ containerPort: 4873, name: http }]
+          env:
+            - { name: VERDACCIO_PORT, value: "4873" }
+            - name: NPM_TOKEN
+              valueFrom: { secretKeyRef: { name: verdaccio-npm-uplink, key: npm-token } }
+          volumeMounts:
+            - { name: config, mountPath: /verdaccio/conf }
+            - { name: storage, mountPath: /verdaccio/storage }
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits: { cpu: "1", memory: 512Mi }
+          readinessProbe:
+            httpGet: { path: /-/ping, port: 4873 }
+            initialDelaySeconds: 5
+      volumes:
+        - { name: config, configMap: { name: verdaccio-config } }
+        - { name: storage, emptyDir: {} }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: verdaccio-trusted
+  namespace: build-registry-proxy
+spec:
+  selector: { app: verdaccio-trusted }
+  ports: [{ port: 4873, targetPort: 4873, name: http }]

--- a/build-targets/capturly-android-trusted/npmrc-configmap.yaml
+++ b/build-targets/capturly-android-trusted/npmrc-configmap.yaml
@@ -11,5 +11,5 @@ metadata:
   namespace: capturly-builds-trusted
 data:
   .npmrc: |
-    registry=http://verdaccio.build-registry-proxy.svc.cluster.local:4873/
-    @corey-alan-consulting:registry=http://verdaccio.build-registry-proxy.svc.cluster.local:4873/
+    registry=http://verdaccio-trusted.build-registry-proxy.svc.cluster.local:4873/
+    @corey-alan-consulting:registry=http://verdaccio-trusted.build-registry-proxy.svc.cluster.local:4873/

--- a/build-targets/capturly-nextjs-untrusted/npmrc-configmap.yaml
+++ b/build-targets/capturly-nextjs-untrusted/npmrc-configmap.yaml
@@ -10,5 +10,5 @@ metadata:
   namespace: capturly-builds-untrusted
 data:
   .npmrc: |
-    registry=http://verdaccio.build-registry-proxy.svc.cluster.local:4873/
-    @corey-alan-consulting:registry=http://verdaccio.build-registry-proxy.svc.cluster.local:4873/
+    registry=http://verdaccio-untrusted.build-registry-proxy.svc.cluster.local:4873/
+    @corey-alan-consulting:registry=http://verdaccio-untrusted.build-registry-proxy.svc.cluster.local:4873/


### PR DESCRIPTION
Closes **H3** (shared Verdaccio cache across tiers). Replaces the single proxy with **`verdaccio-untrusted` + `verdaccio-trusted`**, each with its own emptyDir cache — the tiers now share **no** npm cache. Each tier's `.npmrc` targets its own proxy, and **per-tier ingress NetworkPolicies** mean a tier physically cannot reach the other's proxy. Same uplink token/config; Argo prunes the old `verdaccio` deploy/svc.