### PR TITLE
fix(build-platform): bind gradle PVC + silence server-defaulted drift

### DIFF
--- a/argocd/applications/build-targets.yaml
+++ b/argocd/applications/build-targets.yaml
@@ -51,6 +51,27 @@ spec:
       destination:
         server: https://kubernetes.default.svc
         namespace: "{{.project}}-builds-{{.tier}}"
+      # Fields the ESO / Tekton-Triggers admission webhooks default in on the
+      # server (not in the chart) — ignore them so trusted apps read Synced
+      # instead of perpetual amber. No-op for apps lacking these kinds.
+      ignoreDifferences:
+        - group: external-secrets.io
+          kind: ExternalSecret
+          jqPathExpressions:
+            - .spec.data[].remoteRef.conversionStrategy
+            - .spec.data[].remoteRef.decodingStrategy
+            - .spec.data[].remoteRef.metadataPolicy
+            - .spec.data[].remoteRef.nullBytePolicy
+            - .spec.target.deletionPolicy
+            - .spec.target.template.mergePolicy
+        - group: triggers.tekton.dev
+          kind: EventListener
+          jsonPointers:
+            - /spec/namespaceSelector
+            - /spec/resources
+          jqPathExpressions:
+            - .spec.triggers[].interceptors[].ref.kind
+            - .spec.triggers[].bindings[].kind
       syncPolicy:
         automated:
           prune: true

--- a/helm-charts/build-namespace/templates/gradle-cache.yaml
+++ b/helm-charts/build-namespace/templates/gradle-cache.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ include "bn.namespace" . }}
 spec:
   accessModes: ["ReadWriteOnce"]
+  storageClassName: {{ .Values.gradleCache.storageClassName }}
   resources:
     requests:
       storage: {{ .Values.gradleCache.size }}

--- a/helm-charts/build-namespace/values.yaml
+++ b/helm-charts/build-namespace/values.yaml
@@ -63,9 +63,13 @@ wif:
   impersonationUrl: ""  # https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<sa>:generateAccessToken
 
 # Persistent Gradle/ccache PVC (native builds). RWO — releases are serialized.
+# storageClassName is required: the cluster's local-path SC is NOT the default, so
+# an unset class never binds. local-path is WaitForFirstConsumer (binds on first
+# build pod), which Argo treats as Healthy while Pending.
 gradleCache:
   enabled: false
   size: 10Gi
+  storageClassName: local-path
 
 # Tekton Triggers: tag push -> EventListener -> PipelineRun.
 triggers:


### PR DESCRIPTION
## Make the build fleet fully green

Two small follow-ups from the 3b-4/5 migration (#604) so the ApplicationSet-generated apps read **Synced / Healthy** instead of amber.

### 1. Gradle PVC never binds
`capturly-gradle-cache` was `Pending` with `no storage class is set` — the cluster's only StorageClass (`local-path`) is **not the default**, and the chart left `storageClassName` unset. Every working PVC on the cluster sets it explicitly.

Fix: `storageClassName: local-path` (new `gradleCache.storageClassName` value). It's `WaitForFirstConsumer`, so it binds on the first Android build pod and Argo reports it Healthy while Pending.

> Note: `storageClassName` is immutable, so the already-adopted unbound PVC is deleted + recreated on-cluster at deploy (no data — it's an empty cache).

### 2. Benign OutOfSync on ESO / EventListener
The ESO and Tekton-Triggers admission webhooks default in fields the chart doesn't set (`remoteRef.{conversionStrategy,decodingStrategy,metadataPolicy,nullBytePolicy}`, `target.deletionPolicy`, `target.template.mergePolicy`, `namespaceSelector`, `resources`, interceptor/binding `kind`). Added a targeted `ignoreDifferences` block to the ApplicationSet template (enumerated from the live objects) — no-op for apps without those kinds.
