### PR TITLE
fix(argocd): treat Pending WaitForFirstConsumer PVCs as Healthy

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -42,6 +42,32 @@ argo-cd:
         hs.status = "Progressing"
         hs.message = "Waiting for CloudNativePG cluster to report Ready"
         return hs
+      # Argo's built-in PVC check reports Pending as Progressing and does not
+      # honour WaitForFirstConsumer, so a local-path PVC (the cluster's only SC,
+      # WFFC) that legitimately waits for its first consumer pins the owning app
+      # in Progressing forever (e.g. the gradle-cache on a build namespace before
+      # any build runs). Treat a Pending local-path PVC as Healthy; leave every
+      # other state at Argo's default assessment.
+      resource.customizations.health.PersistentVolumeClaim: |
+        local hs = {}
+        if obj.status ~= nil and obj.status.phase == "Pending"
+           and obj.spec.storageClassName == "local-path" then
+          hs.status = "Healthy"
+          hs.message = "WaitForFirstConsumer: binds on first consumer"
+          return hs
+        end
+        if obj.status ~= nil and obj.status.phase == "Bound" then
+          hs.status = "Healthy"
+          return hs
+        end
+        if obj.status ~= nil and obj.status.phase == "Lost" then
+          hs.status = "Degraded"
+          hs.message = "PVC lost its bound volume"
+          return hs
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for PVC to bind"
+        return hs
 
     params:
       # Run server without TLS (Traefik handles TLS termination)


### PR DESCRIPTION
## Treat Pending WaitForFirstConsumer PVCs as Healthy

Final piece of the fleet-green work. After #605 bound the gradle-cache PVC to `local-path`, `capturly-android-trusted` still read **Progressing** — because ArgoCD v3.4's built-in PVC health check reports `Pending` as `Progressing` and **does not honour `WaitForFirstConsumer`**. `local-path` (the cluster's only StorageClass) is WFFC, so the cache PVC legitimately stays Pending until the first build pod mounts it, pinning the app amber forever.

Adds a `resource.customizations.health.PersistentVolumeClaim` Lua check (same pattern as the existing CNPG one):
- Pending **and** `storageClassName: local-path` → **Healthy** (`WaitForFirstConsumer: binds on first consumer`)
- Bound → Healthy · Lost → Degraded · everything else → Argo's default Progressing

Scope: global argocd-cm health customization (self-managed argocd app). Only changes behavior for Pending local-path PVCs; a genuinely stuck non-WFFC PVC still surfaces, and a failed *consumer* pod surfaces independently.

After this merges the whole build fleet reads **Synced / Healthy**.
