### PR TITLE
fix(argocd): ignore server-side defaulting drift on 7 healthy apps

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -68,6 +68,35 @@ argo-cd:
         hs.status = "Progressing"
         hs.message = "Waiting for PVC to bind"
         return hs
+      # Server-side defaulting that Argo flags as drift on healthy apps. Each
+      # entry suppresses ONLY cosmetic diffs (ignoreDifferences can never create
+      # drift), keyed by the SSA field manager that owns the defaulted fields
+      # where possible so it stays comprehensive as the objects evolve.
+      #
+      # ESO writes remoteRef.{conversion,decoding}Strategy / metadataPolicy /
+      # nullBytePolicy, target.deletionPolicy, template.mergePolicy on every
+      # ExternalSecret (build-registry-proxy, tekton-pac, the build fleet).
+      resource.customizations.ignoreDifferences.external-secrets.io_ExternalSecret: |
+        managedFieldsManagers:
+          - external-secrets
+      # Kyverno's controller defaults admission/emitWarning and writes
+      # status.autogen back onto every ClusterPolicy (kyverno-policies*).
+      resource.customizations.ignoreDifferences.kyverno.io_ClusterPolicy: |
+        managedFieldsManagers:
+          - kyverno
+      # The apiserver defaults spec.conversion:{strategy:None} onto CRDs whose
+      # manifests omit it (tekton-operator, kyverno, manual-approval-gate); it is
+      # not tracked under a field manager, so ignore the path. Also covers the
+      # cert-manager cainjector caBundle churn — both are diffs we never act on.
+      resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDefinition: |
+        jqPathExpressions:
+          - .spec.conversion
+      # The Job controller injects immutable batch.kubernetes.io/controller-uid
+      # selector + template labels (kyverno-migrate-resources).
+      resource.customizations.ignoreDifferences.batch_Job: |
+        jqPathExpressions:
+          - .spec.selector
+          - .spec.template.metadata.labels
 
     params:
       # Run server without TLS (Traefik handles TLS termination)


### PR DESCRIPTION
## Clear the 7 OutOfSync (but Healthy) apps

The Argo board shows 7 apps `OutOfSync` — all are **Healthy**; the drift is entirely cosmetic server-side defaulting, confirmed by SSA field-manager ownership. Nothing is broken and none of it is caused by the build-platform work.

| Apps | Drift | Owner |
|---|---|---|
| `build-registry-proxy`, `tekton-pac` | ESO `remoteRef.*Strategy/Policy`, `target.deletionPolicy`, `template.mergePolicy` | `external-secrets` |
| `kyverno-policies`, `kyverno-policies-business` | Kyverno `admission`/`emitWarning` defaults + `status.autogen` | `kyverno` |
| `kyverno`, `tekton-operator`, `tekton-manual-approval-gate` | apiserver `spec.conversion:{strategy:None}` on CRDs (+ kyverno migrate Job's controller-uid labels) | apiserver / job-controller |

Adds four global `resource.customizations.ignoreDifferences` to `argocd-cm`, keyed by field manager where the fields are manager-owned (comprehensive + future-proof), and by path for the apiserver/job-controller defaults. `ignoreDifferences` is **display-only** — it can only suppress diffs, never create them, so there is zero risk to currently-green apps.

This also covers future apps of these types (e.g. new build-targets ExternalSecrets), so it's the last drift-cleanup needed for a green board.
