### PR TITLE
fix(argocd): enable Server-Side Diff to end false-drift OutOfSync

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -84,13 +84,16 @@ argo-cd:
       resource.customizations.ignoreDifferences.kyverno.io_ClusterPolicy: |
         managedFieldsManagers:
           - kyverno
-      # The apiserver defaults spec.conversion:{strategy:None} onto CRDs whose
-      # manifests omit it (tekton-operator, kyverno, manual-approval-gate); it is
-      # not tracked under a field manager, so ignore the path. Also covers the
-      # cert-manager cainjector caBundle churn — both are diffs we never act on.
+      # CRDs: charts render spec.preserveUnknownFields:false and an empty
+      # metadata.labels:{} that the apiserver drops (tekton-operator,
+      # manual-approval-gate, kyverno); these are not manager-tracked, so ignore
+      # the paths. (Server-Side Diff above already handles this natively; kept as a
+      # fallback and to also cover cert-manager cainjector caBundle churn.)
       resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDefinition: |
-        jqPathExpressions:
-          - .spec.conversion
+        jsonPointers:
+          - /spec/preserveUnknownFields
+          - /metadata/labels
+          - /spec/conversion/webhook/clientConfig/caBundle
       # The Job controller injects immutable batch.kubernetes.io/controller-uid
       # selector + template labels (kyverno-migrate-resources).
       resource.customizations.ignoreDifferences.batch_Job: |
@@ -101,6 +104,13 @@ argo-cd:
     params:
       # Run server without TLS (Traefik handles TLS termination)
       server.insecure: true
+      # Server-Side Diff: the controller computes drift via a server-side dry-run
+      # apply, so apiserver defaulting and mutating-webhook writes (ESO remoteRef
+      # defaults, Kyverno admission/emitWarning, CRD preserveUnknownFields, etc.)
+      # no longer surface as false OutOfSync. Also what makes the managedFields
+      # managers ignoreDifferences above actually affect sync status (not just the
+      # CLI diff view). Recommended default for SSA-heavy clusters.
+      controller.diff.server.side: "true"
 
   # Application Controller - manages application state
   controller:


### PR DESCRIPTION
## Enable Server-Side Diff — the real fix for the 7 amber apps

Follow-up to #607. The 7 `OutOfSync`-but-`Healthy` apps drift **only** on server-side defaulting:

| App(s) | Defaulted field |
|---|---|
| `build-registry-proxy`, `tekton-pac` | ESO `remoteRef.*Strategy/Policy`, `target.deletionPolicy`, `template.mergePolicy` |
| `kyverno-policies`, `kyverno-policies-business` | Kyverno `admission`/`emitWarning` + `status.autogen` |
| `kyverno`, `tekton-operator`, `tekton-manual-approval-gate` | CRD `preserveUnknownFields: false` + empty `metadata.labels: {}` |

### Root cause (confirmed via `argocd app diff` in-pod)
#607's `managedFieldsManagers` ignores clear the CLI diff **view** but did **not** flip sync status — because **Server-Side Diff was off**. `managedFieldsManagers` needs SSD to affect the controller's status computation. Proof: `argocd app diff build-registry-proxy` = empty, yet `.status.sync.status = OutOfSync`. (My original CRD path was also wrong — real drift is `preserveUnknownFields`/`labels`, not `conversion`; corrected here.)

### Fix
- `controller.diff.server.side: "true"` — the controller diffs via a server-side dry-run apply, so apiserver/webhook defaulting stops reading as drift and the field-manager ignores take effect. This is the ArgoCD-recommended default for SSA-heavy clusters and fixes the whole class (incl. future apps), not just these 7.
- Corrected CRD `ignoreDifferences` paths as a fallback.

### Blast radius
Global diff-behavior change (~all apps), but SSD only makes diffs **more accurate** — it reduces false drift, never invents it. Requires an application-controller restart (params change); I'll roll it and verify the board goes fully green after merge.
