### PR TITLE
fix(argocd): scope Server-Side Diff to build/tekton/kyverno apps

### DIFF
--- a/argocd/applications/build-registry-proxy.yaml
+++ b/argocd/applications/build-registry-proxy.yaml
@@ -9,6 +9,10 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    # Server-Side Diff for this app only: server-side dry-run apply so
+    # apiserver/webhook defaulting stops reading as false drift (with the
+    # field-manager ignoreDifferences in argocd-cm). Not global (see argocd values).
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/applications/kyverno-policies-business.yaml
+++ b/argocd/applications/kyverno-policies-business.yaml
@@ -9,6 +9,10 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
+    # Server-Side Diff for this app only: server-side dry-run apply so
+    # apiserver/webhook defaulting stops reading as false drift (with the
+    # field-manager ignoreDifferences in argocd-cm). Not global (see argocd values).
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/applications/kyverno-policies.yaml
+++ b/argocd/applications/kyverno-policies.yaml
@@ -11,6 +11,10 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "-4"
+    # Server-Side Diff for this app only: server-side dry-run apply so
+    # apiserver/webhook defaulting stops reading as false drift (with the
+    # field-manager ignoreDifferences in argocd-cm). Not global (see argocd values).
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/applications/kyverno.yaml
+++ b/argocd/applications/kyverno.yaml
@@ -11,6 +11,10 @@ metadata:
   annotations:
     # Engine + CRDs before any policy app that references them.
     argocd.argoproj.io/sync-wave: "-5"
+    # Server-Side Diff for this app only: server-side dry-run apply so
+    # apiserver/webhook defaulting stops reading as false drift (with the
+    # field-manager ignoreDifferences in argocd-cm). Not global (see argocd values).
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/applications/tekton-manual-approval-gate.yaml
+++ b/argocd/applications/tekton-manual-approval-gate.yaml
@@ -10,6 +10,10 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    # Server-Side Diff for this app only: server-side dry-run apply so
+    # apiserver/webhook defaulting stops reading as false drift (with the
+    # field-manager ignoreDifferences in argocd-cm). Not global (see argocd values).
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/applications/tekton-operator.yaml
+++ b/argocd/applications/tekton-operator.yaml
@@ -12,6 +12,10 @@ metadata:
   annotations:
     # Operator + CRDs must exist before any TektonConfig / Tekton CR syncs.
     argocd.argoproj.io/sync-wave: "-2"
+    # Server-Side Diff for this app only: server-side dry-run apply so
+    # apiserver/webhook defaulting stops reading as false drift (with the
+    # field-manager ignoreDifferences in argocd-cm). Not global (see argocd values).
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/applications/tekton-pac.yaml
+++ b/argocd/applications/tekton-pac.yaml
@@ -10,6 +10,10 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    # Server-Side Diff for this app only: server-side dry-run apply so
+    # apiserver/webhook defaulting stops reading as false drift (with the
+    # field-manager ignoreDifferences in argocd-cm). Not global (see argocd values).
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -104,13 +104,11 @@ argo-cd:
     params:
       # Run server without TLS (Traefik handles TLS termination)
       server.insecure: true
-      # Server-Side Diff: the controller computes drift via a server-side dry-run
-      # apply, so apiserver defaulting and mutating-webhook writes (ESO remoteRef
-      # defaults, Kyverno admission/emitWarning, CRD preserveUnknownFields, etc.)
-      # no longer surface as false OutOfSync. Also what makes the managedFields
-      # managers ignoreDifferences above actually affect sync status (not just the
-      # CLI diff view). Recommended default for SSA-heavy clusters.
-      controller.diff.server.side: "true"
+      # NB: Server-Side Diff is scoped per-app (argocd.argoproj.io/compare-options:
+      # ServerSideDiff=true) on the build/tekton/kyverno apps that need it — NOT
+      # enabled globally, because cluster-wide SSD surfaced a false OutOfSync on
+      # traefik's Service/IngressClass (server-allocated fields) and selfHeal then
+      # thrashed it. Keep the blast radius to the apps whose drift we understand.
 
   # Application Controller - manages application state
   controller:


### PR DESCRIPTION
## Scope Server-Side Diff to the apps that need it (fix traefik regression)

#608 enabled Server-Side Diff **globally** and it did green the 7 false-drift apps — but it also surfaced a *new* false `OutOfSync` on **traefik**'s `Service` + `IngressClass` (server-allocated fields like `clusterIP`/`nodePort`), and traefik's `selfHeal` then thrashed re-applying it. That's the blast radius from a cluster-wide diff-engine change.

This reverts the global switch and enables SSD **per-app** instead:

- `helm-charts/argocd/values.yaml` — drop `controller.diff.server.side`.
- Add `argocd.argoproj.io/compare-options: ServerSideDiff=true` to exactly the 7 apps whose drift is diagnosed: `build-registry-proxy`, `tekton-operator`, `tekton-pac`, `tekton-manual-approval-gate`, `kyverno`, `kyverno-policies`, `kyverno-policies-business`.

Result: those 7 stay Synced (SSD + the argocd-cm field-manager `ignoreDifferences` from #607), and every other app — traefik included — returns to the proven client-side diff where it was already Synced. Blast radius = only the apps we understand.
