### PR TITLE
fix(build-platform): use PaC default ACL, drop non-existent maintainers team

### DIFF
--- a/build-targets/capturly/nextjs-untrusted.yaml
+++ b/build-targets/capturly/nextjs-untrusted.yaml
@@ -7,8 +7,8 @@ tier: untrusted
 repo: Corey-Alan-Consulting/capturly.app
 runtimeClass: gvisor
 
-pac:
-  policy:
-    # ⚠️ TODO: real GitHub team slug(s); the PaC App must be installed on the repo.
-    pull_request: [capturly-maintainers]
-    ok_to_test: [capturly-maintainers]
+# No pac.policy: use PaC's default ACL (owner + write-collaborators auto-run;
+# external/fork PRs need a maintainer /ok-to-test). The capturly-maintainers team
+# does not exist in the Corey-Alan-Consulting org, and naming a missing team makes
+# the policy check 404 and deny everyone. Add a real team slug here only if one is
+# created.

--- a/helm-charts/build-namespace/templates/repository.yaml
+++ b/helm-charts/build-namespace/templates/repository.yaml
@@ -1,9 +1,13 @@
 {{- if eq .Values.tier "untrusted" }}
 ---
 # Pipelines-as-Code Repository for the UNTRUSTED PR tier. PaC matches this repo's
-# PR events to this namespace and runs the .tekton/ PipelineRun here. The policy
-# gates who can trigger: fork/external PRs do not run until a maintainer comments
-# /ok-to-test (design §6) — the control that vets untrusted code before it runs.
+# PR events to this namespace and runs the .tekton/ PipelineRun here.
+#
+# By default (no policy set) PaC's built-in ACL applies: owner + write-access
+# collaborators auto-run; genuine external/fork PRs wait for a maintainer
+# `/ok-to-test` (design §6) — the control that vets untrusted code before it runs.
+# Only set pac.policy.* to a GitHub TEAM slug that actually exists in the org — a
+# missing team makes the policy check 404 and denies EVERYONE (incl. the owner).
 #
 # The PaC GitHub App must be installed on {{ .Values.repo }} first.
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
@@ -13,8 +17,14 @@ metadata:
   namespace: {{ include "bn.namespace" . }}
 spec:
   url: https://github.com/{{ .Values.repo }}
+{{- if or .Values.pac.policy.pull_request .Values.pac.policy.ok_to_test }}
   settings:
     policy:
+{{- if .Values.pac.policy.pull_request }}
       pull_request: {{ .Values.pac.policy.pull_request | toJson }}
+{{- end }}
+{{- if .Values.pac.policy.ok_to_test }}
       ok_to_test: {{ .Values.pac.policy.ok_to_test | toJson }}
+{{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Fix: PaC PR checks denied everyone (missing GitHub team)

The untrusted PR check never ran because the `capturly` Repository policy named a GitHub team that doesn't exist:

```
policy check: pull_request, team: capturly-maintainers is not found on the organization: Corey-Alan-Consulting
GET /orgs/Corey-Alan-Consulting/teams/capturly-maintainers/members → 404
User NX211 is not allowed to trigger CI via pull_request in this repo.
```

A missing team makes PaC's ACL check 404 and **deny every author, including the repo owner**, so no `capturly-nextjs-pr` PipelineRun started (verified in the PaC controller logs — the webhook path itself works fine).

### Change
- Chart: make `settings.policy` render **only** when a team slug is configured (guarded).
- Inventory: drop the `capturly-maintainers` override → PaC uses its **default ACL** (owner + write-collaborators auto-run; genuine external/fork PRs still need a maintainer `/ok-to-test`). Same untrusted-vetting posture, no dependency on a non-existent team.

After merge + Argo sync, re-trigger the check on an open PR with a `/retest` comment or a new push (PaC doesn't retroactively run past events).
