### PR TITLE
fix(jlshaw-link): give staging pods CPU and liveness headroom for cold start

### DIFF
--- a/staging-apps/jlshaw-link/values.yaml
+++ b/staging-apps/jlshaw-link/values.yaml
@@ -203,18 +203,26 @@ staging-app:
       cpu: 100m
       memory: 256Mi
     limits:
-      cpu: 500m
+      # 1000m: cold start compiles the whole server bundle on the main thread
+      # when the first readiness probe hits; at 500m the pod sat pinned at its
+      # limit with the event loop starved, failing even the trivial liveness
+      # route until the kubelet killed it mid-warmup (restart bursts on every
+      # jlshaw staging rollout).
+      cpu: 1000m
       memory: 768Mi
   # Liveness = process-only check; readiness = DB+Redis. Avoids restarting the
   # pod on a dependency blip (and rendering the SSR homepage on every probe).
+  # The chart has no startupProbe support, so the long initialDelay stands in
+  # for one: liveness must not kill the pod before the cold-start compile
+  # storm finishes.
   livenessProbe:
     enabled: true
     path: /api/health/live
     port: 3000
-    initialDelaySeconds: 30
+    initialDelaySeconds: 180
     periodSeconds: 10
     timeoutSeconds: 5
-    failureThreshold: 3
+    failureThreshold: 6
   readinessProbe:
     enabled: true
     path: /api/health


### PR DESCRIPTION
## Problem

Every jlshaw-link staging rollout crash-loops on the liveness probe before eventually stabilizing (the current pod took 16 restarts on the last rollout; today's release was stuck the same way).

Diagnosis from the cluster:
- The container answers `/api/health/live` at ~t=9s after start, then goes dark with CPU pinned at the 500m limit from ~t=15s until the kubelet kills it at ~t=75s.
- Thread accounting inside the container shows the main JS thread plus four V8 background-compile threads burning all available CPU — the first readiness probe (initialDelay 10s) triggers synchronous compilation of the full server bundle (Prisma client, auth, vendor chunks), which starves the event loop so even the dependency-free liveness route can't respond.
- The node itself idles at ~2% — this is purely container-level throttling.
- Liveness (30s delay + 3x10s) kills the pod mid-warmup every cycle; restarts only succeed once the node page cache makes a later attempt fast enough.

## Fix

- CPU limit 500m -> 1000m (halves the compile storm; the node has ample headroom)
- Liveness initialDelay 30s -> 180s, failureThreshold 3 -> 6 — standing in for a startupProbe, which the vendored chart doesn't support

Readiness is untouched: it only gates traffic and its early failures during warmup are correct behavior.

## Follow-up

Proper fix is `startupProbe` support in the shared `nextjs-app` chart (platform-infra), after which the liveness delay here can go back down.
