### PR TITLE
feat(nightingale): add karaoke app at karaoke.authoritah.tv

### DIFF
--- a/argocd/applications/nightingale.yaml
+++ b/argocd/applications/nightingale.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nightingale
+  namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: nightingale=razzaru/nightingale
+    argocd-image-updater.argoproj.io/nightingale.update-strategy: semver
+    # Track plain semver only — excludes the -cuda GPU and -amd64/-arm64
+    # single-arch tags so updates stay on the CPU multi-arch image.
+    argocd-image-updater.argoproj.io/nightingale.allow-tags: regexp:^\d+\.\d+\.\d+$
+    argocd-image-updater.argoproj.io/nightingale.helm.image-name: image.repository
+    argocd-image-updater.argoproj.io/nightingale.helm.image-tag: image.tag
+    argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/git-creds
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: HEAD
+    path: helm-charts/nightingale
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/coredns/configmap.yaml
+++ b/coredns/configmap.yaml
@@ -98,3 +98,4 @@ data:
     10.43.5.100 tools.authoritah.com
     10.43.5.100 transmission.authoritah.tv
     10.43.5.100 13ft.authoritah.link
+    10.43.5.100 karaoke.authoritah.tv

--- a/helm-charts/nightingale/Chart.yaml
+++ b/helm-charts/nightingale/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: nightingale
+description: Nightingale - ML-powered karaoke app (vocal separation, lyric transcription, pitch scoring)
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+
+keywords:
+  - nightingale
+  - karaoke
+  - music
+  - media
+
+maintainers:
+  - name: Homelab Admin

--- a/helm-charts/nightingale/templates/_helpers.tpl
+++ b/helm-charts/nightingale/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nightingale.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "nightingale.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nightingale.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nightingale.labels" -}}
+helm.sh/chart: {{ include "nightingale.chart" . }}
+{{ include "nightingale.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nightingale.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nightingale.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm-charts/nightingale/templates/certificate.yaml
+++ b/helm-charts/nightingale/templates/certificate.yaml
@@ -1,0 +1,16 @@
+---
+{{- if .Values.ingress.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "nightingale.fullname" . }}-tls
+  labels:
+    {{- include "nightingale.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "nightingale.fullname" . }}-tls
+  issuerRef:
+    name: {{ .Values.ingress.clusterIssuer }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ .Values.ingress.host }}
+{{- end }}

--- a/helm-charts/nightingale/templates/deployment.yaml
+++ b/helm-charts/nightingale/templates/deployment.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nightingale.fullname" . }}
+  labels:
+    {{- include "nightingale.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  # RWO data PVC — never run two pods against it at once.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "nightingale.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nightingale.selectorLabels" . | nindent 8 }}
+    spec:
+      enableServiceLinks: false
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: nightingale
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.port }}
+          protocol: TCP
+        env:
+        - name: TZ
+          value: {{ .Values.env.TZ | quote }}
+        - name: NIGHTINGALE_BIND
+          value: {{ .Values.env.bind | quote }}
+        - name: NIGHTINGALE_DATA_PATH
+          value: {{ .Values.env.dataPath | quote }}
+        {{- if .Values.persistence.media.enabled }}
+        - name: NIGHTINGALE_LIBRARY_PATH
+          value: {{ .Values.env.libraryPath | quote }}
+        {{- end }}
+        volumeMounts:
+        - name: data
+          mountPath: {{ .Values.env.dataPath }}
+        {{- if .Values.persistence.media.enabled }}
+        - name: music
+          mountPath: {{ .Values.persistence.media.music.mountPath }}
+          readOnly: true
+        {{- end }}
+        # Web server binds on start; ML deps (~several GB) download lazily into
+        # /data on first use, so gate readiness/liveness on the TCP port only.
+        startupProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 30
+        livenessProbe:
+          tcpSocket:
+            port: http
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 5
+        readinessProbe:
+          tcpSocket:
+            port: http
+          periodSeconds: 15
+          timeoutSeconds: 5
+          failureThreshold: 3
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ include "nightingale.fullname" . }}-data
+      {{- if .Values.persistence.media.enabled }}
+      - name: music
+        hostPath:
+          path: {{ .Values.persistence.media.music.hostPath }}
+          type: Directory
+      {{- end }}

--- a/helm-charts/nightingale/templates/ingressroute.yaml
+++ b/helm-charts/nightingale/templates/ingressroute.yaml
@@ -1,0 +1,25 @@
+---
+{{- if .Values.ingress.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "nightingale.fullname" . }}
+  labels:
+    {{- include "nightingale.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: Host(`{{ .Values.ingress.host }}`)
+    kind: Rule
+    middlewares:
+    - name: authelia-forwardauth
+      namespace: default
+    - name: default-headers
+      namespace: default
+    services:
+    - name: {{ include "nightingale.fullname" . }}
+      port: {{ .Values.service.port }}
+  tls:
+    secretName: {{ include "nightingale.fullname" . }}-tls
+{{- end }}

--- a/helm-charts/nightingale/templates/pvc.yaml
+++ b/helm-charts/nightingale/templates/pvc.yaml
@@ -1,0 +1,18 @@
+---
+{{- if .Values.persistence.data.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "nightingale.fullname" . }}-data
+  labels:
+    {{- include "nightingale.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.persistence.data.storageClass }}
+  storageClassName: {{ .Values.persistence.data.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size }}
+{{- end }}

--- a/helm-charts/nightingale/templates/service.yaml
+++ b/helm-charts/nightingale/templates/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nightingale.fullname" . }}
+  labels:
+    {{- include "nightingale.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    {{- include "nightingale.selectorLabels" . | nindent 4 }}

--- a/helm-charts/nightingale/values.yaml
+++ b/helm-charts/nightingale/values.yaml
@@ -1,0 +1,62 @@
+# Nightingale Helm Chart Values
+
+# Image configuration
+# CPU (multi-arch) image. The `-cuda` variant needs an NVIDIA GPU + device
+# plugin on the node; this cluster runs CPU-only, so vocal separation and
+# transcription run on CPU (slower, but cached per-song after first play).
+image:
+  repository: razzaru/nightingale
+  tag: "1.0.0"
+  pullPolicy: IfNotPresent
+
+# Service configuration
+service:
+  port: 8080
+
+# Ingress configuration
+ingress:
+  enabled: true
+  host: karaoke.authoritah.tv
+  clusterIssuer: letsencrypt-prod
+
+# Node selection — pinned to blacktalon where the hostPath music library lives.
+nodeSelector:
+  kubernetes.io/hostname: blacktalon
+
+# Persistence
+persistence:
+  # Config, SQLite library db, stem/transcript cache, and the ~several-GB
+  # vendored ffmpeg/Python/PyTorch + ML models downloaded on first launch.
+  # Mounted at /data (NIGHTINGALE_DATA_PATH). Grows as more songs are processed.
+  data:
+    enabled: true
+    size: 20Gi
+    storageClass: local-path
+
+  # Music library (read-only) — the same hostPath Plex mounts and that lives
+  # under Jellyfin's /blacktalon/media root. Mounted at /songs
+  # (NIGHTINGALE_LIBRARY_PATH).
+  media:
+    enabled: true
+    music:
+      hostPath: /blacktalon/media/music
+      mountPath: /songs
+
+# Environment variables
+env:
+  TZ: America/New_York
+  # Bind on all interfaces so the Service can reach it.
+  bind: "0.0.0.0:8080"
+  dataPath: /data
+  libraryPath: /songs
+
+# Resource limits — CPU-based ML (Demucs/UVR vocal separation + WhisperX
+# transcription) is compute- and memory-heavy while processing a song, then
+# idle. Requests stay low; limits allow bursting on demand.
+resources:
+  requests:
+    cpu: 250m
+    memory: 1Gi
+  limits:
+    cpu: "6"
+    memory: 8Gi


### PR DESCRIPTION
## Summary

Adds [Nightingale](https://github.com/rzru/nightingale) — an ML-powered karaoke app (vocal separation, lyric transcription, pitch scoring) — to the ArgoCD stack at **karaoke.authoritah.tv**, reusing the same music library Plex and Jellyfin use.

Packaged as a local Helm chart wrapped by an ArgoCD Application, following the existing media-app pattern (lidarr/jellyfin).

## What's included

- **`helm-charts/nightingale/`** — new chart (Deployment, Service, IngressRoute, Certificate, PVC, helpers)
- **`argocd/applications/nightingale.yaml`** — ArgoCD Application (auto-registered by `root-apps`)
- **`coredns/configmap.yaml`** — split-horizon DNS entry for `karaoke.authoritah.tv`

## Key decisions

- **CPU image** `razzaru/nightingale:1.0.0` (multi-arch) — no GPU in the cluster. Image-updater tracks plain semver only, so it won't drift onto the `-cuda`/arch-specific tags.
- **Music library** mounted read-only at `/songs` from `hostPath: /blacktalon/media/music` — the exact path Plex uses (inside Jellyfin's `/blacktalon/media` root). Pod pinned to node **blacktalon**.
- **20Gi `local-path` PVC** at `/data` for the SQLite library db, stem/transcript cache, and the several-GB ML models downloaded on first launch.
- **Routing** via Traefik IngressRoute behind `authelia-forwardauth` + `default-headers`, with a cert-manager `Certificate` (`letsencrypt-prod`, HTTP-01). Traefik TLS termination provides the HTTPS secure-context the mic-based pitch scoring needs.
- Port 8080, `Recreate` strategy (RWO PVC), TCP-socket probes with a generous startupProbe for the first-launch model download.

## Notes before merge

- **Public DNS**: `karaoke.authoritah.tv` must resolve to the cluster's public IP in external DNS (managed outside this repo) for cert issuance and off-LAN access.
- **First launch is slow**: the setup wizard downloads several GB into `/data`, and CPU vocal-separation/transcription takes minutes per song (cached afterward).

## Validation

- `helm lint helm-charts/nightingale` — passes
- `helm template` renders all manifests correctly
