### PR TITLE
fix(nightingale): raise CPU limit and pin ML thread count

### DIFF
--- a/helm-charts/nightingale/templates/deployment.yaml
+++ b/helm-charts/nightingale/templates/deployment.yaml
@@ -42,6 +42,15 @@ spec:
         - name: NIGHTINGALE_LIBRARY_PATH
           value: {{ .Values.env.libraryPath | quote }}
         {{- end }}
+        # Keep ML thread pools in step with the CPU limit (see values.yaml).
+        - name: OMP_NUM_THREADS
+          value: {{ .Values.env.threads | quote }}
+        - name: MKL_NUM_THREADS
+          value: {{ .Values.env.threads | quote }}
+        - name: NUMEXPR_NUM_THREADS
+          value: {{ .Values.env.threads | quote }}
+        - name: OPENBLAS_NUM_THREADS
+          value: {{ .Values.env.threads | quote }}
         volumeMounts:
         - name: data
           mountPath: {{ .Values.env.dataPath }}

--- a/helm-charts/nightingale/values.yaml
+++ b/helm-charts/nightingale/values.yaml
@@ -49,14 +49,21 @@ env:
   bind: "0.0.0.0:8080"
   dataPath: /data
   libraryPath: /songs
+  # ML thread cap. PyTorch/OpenMP otherwise read the host's core count (56) and
+  # spawn one thread per core, which thrashes against the cgroup CPU limit and
+  # produces massive CFS throttling. Keep this equal to resources.limits.cpu.
+  threads: "24"
 
-# Resource limits — CPU-based ML (Demucs/UVR vocal separation + WhisperX
-# transcription) is compute- and memory-heavy while processing a song, then
-# idle. Requests stay low; limits allow bursting on demand.
+# Resource limits — CPU-based ML (mel_band_roformer vocal separation + WhisperX
+# transcription) is compute-heavy in a burst while first analysing a song, then
+# idle (results are cached per-song). blacktalon has 56 cores and sits near-idle,
+# so give the burst real headroom: at 6 cores a single 234s song took ~20 min
+# and sat throttled >60% of the time. Requests stay low so nothing is reserved
+# while idle; the limit bounds the burst so it can't starve live Plex transcodes.
 resources:
   requests:
-    cpu: 250m
+    cpu: "2"
     memory: 1Gi
   limits:
-    cpu: "6"
+    cpu: "24"
     memory: 8Gi


### PR DESCRIPTION
## Problem

Song analysis appeared "stuck at 15%" (the vocal-separation phase). Diagnosis on `blacktalon`:

- The pod was capped at **6 CPU cores** (`limits.cpu: "6"`) on a **56-core** node that sits near-idle (load avg ~9).
- The `mel_band_roformer` separation model runs on CPU (no GPU) and PyTorch spawned ~one thread per **host** core (56), thrashing against the 6-core cgroup cap.
- Result: a single 234s song spent **~20 minutes** separating while **CFS-throttled >60%** of every scheduling period (`nr_throttled` ~10k periods, `throttled_usec` ~8,570s).

It wasn't crashed — just starved. Separation is a one-time burst per song (cached afterward), so it should get real headroom.

## Fix

- **CPU**: `limits.cpu` 6 → **24**, `requests.cpu` 250m → **2**. Bounds the burst (can't starve live Plex transcodes) while cutting separation from ~20 min to a few minutes. Requests stay low so nothing is reserved while idle.
- **Thread pinning**: set `OMP_NUM_THREADS` / `MKL_NUM_THREADS` / `NUMEXPR_NUM_THREADS` / `OPENBLAS_NUM_THREADS` = 24 (driven by `env.threads`, kept equal to the CPU limit) so the ML thread pools stop oversubscribing the host core count and throttling.

## Validation

- `helm lint` passes; `helm template` renders the new env vars and resource values correctly.
- Takes effect after merge + Argo sync (the app has `selfHeal: true`, so a live `kubectl` patch would be reverted — the durable fix goes through the repo).
