### PR TITLE
fix(nightingale): raise memory limit to prevent transcription OOM

### DIFF
--- a/helm-charts/nightingale/values.yaml
+++ b/helm-charts/nightingale/values.yaml
@@ -60,10 +60,14 @@ env:
 # so give the burst real headroom: at 6 cores a single 234s song took ~20 min
 # and sat throttled >60% of the time. Requests stay low so nothing is reserved
 # while idle; the limit bounds the burst so it can't starve live Plex transcodes.
+#
+# Memory: the WhisperX transcription phase (after separation) loads its model and
+# spiked to ~7.9Gi, which OOMKilled the pod at an 8Gi limit mid-analysis. Raised
+# to 16Gi for headroom; the node has ample free RAM (limits ~45% allocated).
 resources:
   requests:
     cpu: "2"
-    memory: 1Gi
+    memory: 2Gi
   limits:
     cpu: "24"
-    memory: 8Gi
+    memory: 16Gi


### PR DESCRIPTION
## Problem

Follow-up to #638. With the CPU fix in place, vocal separation now completes in ~6 min — but the analysis still never finished:

- Right after separation, the **WhisperX transcription** phase ("Detecting language", 58%) loads its model and grew to **~7.9 Gi RSS**.
- That hit the **8Gi memory limit** → kernel `memory.oom.group` **OOMKilled** the pod (exit 137) at `01:21:00`, mid-analysis.
- The pod restarted back to idle, so the song never completed and appeared "stuck."

dmesg confirmed: `Memory cgroup out of memory: Killed process ... (python) ... anon-rss:8263384kB` under the pod's cgroup.

## Fix

- `limits.memory` **8Gi → 16Gi**, `requests.memory` 1Gi → 2Gi.
- The node has ample free RAM (limits only ~45% allocated), so 16Gi gives the transcription model comfortable headroom.

## Validation

- `helm lint` / `helm template` pass.
- Takes effect after merge + Argo sync; re-trigger the song afterward to confirm it completes end-to-end (separation → transcription → 100%).
