### PR TITLE
fix(restate): silence perpetual OutOfSync on the StatefulSet

### DIFF
--- a/argocd/applications/restate.yaml
+++ b/argocd/applications/restate.yaml
@@ -48,6 +48,15 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: restate
+  # The StatefulSet's volumeClaimTemplates are defaulted by the API server
+  # (apiVersion/volumeMode + a status block) and are immutable, so ArgoCD flags
+  # them as perpetual drift even under ServerSideApply — ignore them in the diff.
+  ignoreDifferences:
+    - group: apps
+      kind: StatefulSet
+      name: restate
+      jsonPointers:
+        - /spec/volumeClaimTemplates
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Restate showed SYNC=OutOfSync / HEALTH=Healthy (pod fine). Cause: the live StatefulSet's `volumeClaimTemplates` carry API-server defaults (`apiVersion: v1`, `volumeMode: Filesystem`, a `status` block) absent from the rendered chart, which ArgoCD diffs as drift even under ServerSideApply. VCTs are immutable, so this adds an `ignoreDifferences` for `/spec/volumeClaimTemplates`. No behavior change; clears the false OutOfSync.