### PR TITLE
feat(provisioning): Tenant CRD + RBAC (ADR-0019 Phase 1)

### DIFF
--- a/argocd/applications/provisioning.yaml
+++ b/argocd/applications/provisioning.yaml
@@ -1,0 +1,39 @@
+---
+# Provisioning control-plane surface (ADR-0019 Phase 1): the Tenant CRD + RBAC.
+# Non-recursive, so the examples/ dir is NOT synced (no real Tenant is created).
+# CRD-safe: ServerSideApply + ServerSideDiff + negative sync-wave so the CRD lands
+# before anything references it.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: provisioning
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/nx211/homelab-infra.git
+    targetRevision: main
+    path: provisioning
+    directory:
+      recurse: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: provisioning
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/provisioning/examples/tenant-example.yaml
+++ b/provisioning/examples/tenant-example.yaml
@@ -1,0 +1,22 @@
+---
+# Example Tenant for manual testing — NOT synced by ArgoCD (examples/ is excluded
+# via directory.recurse: false). Apply by hand on staging to exercise the surface:
+#   kubectl -n provisioning apply -f provisioning/examples/tenant-example.yaml
+#   kubectl -n provisioning get tenants          # PHASE/DOMAIN columns
+#   kubectl -n provisioning describe tenant acme
+# No controller is wired yet (ADR-0019 Phase 1), so status stays empty until the
+# CompositeController + webhook land.
+apiVersion: platform.coreyalan.com/v1alpha1
+kind: Tenant
+metadata:
+  name: acme
+  namespace: provisioning
+spec:
+  email: ops@acme.example
+  domain: acme.example
+  provisionEmail: true
+  emailDomainName: acme.example
+  appName: acme-web
+  githubRepo: Corey-Alan-Consulting/acme-web
+  appHostname: acme.example
+  blueprint: managed-hosting@v1

--- a/provisioning/rbac.yaml
+++ b/provisioning/rbac.yaml
@@ -1,0 +1,28 @@
+---
+# RBAC surface for Tenants (ADR-0019 Phase 1). No bindings yet — the reconcile
+# webhook's ServiceAccount and human operators bind to these in later phases /
+# when a teammate is onboarded (ADR-0018 team-onboarding step).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tenant-admin
+  labels:
+    app.kubernetes.io/part-of: provisioning
+rules:
+  - apiGroups: [platform.coreyalan.com]
+    resources: [tenants]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [platform.coreyalan.com]
+    resources: [tenants/status]
+    verbs: [get, update, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tenant-viewer
+  labels:
+    app.kubernetes.io/part-of: provisioning
+rules:
+  - apiGroups: [platform.coreyalan.com]
+    resources: [tenants, tenants/status]
+    verbs: [get, list, watch]

--- a/provisioning/tenant-crd.yaml
+++ b/provisioning/tenant-crd.yaml
@@ -1,0 +1,126 @@
+---
+# Tenant — the desired-state provisioning object (ADR-0019, L1/L2 reconcile loop).
+# A Metacontroller CompositeController (added in the follow-up PR) reconciles it by
+# calling a sync webhook that drives a durable Restate saga over the island handlers.
+# This PR stands up the k8s-native surface + RBAC only; no controller wired yet.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tenants.platform.coreyalan.com
+spec:
+  group: platform.coreyalan.com
+  scope: Namespaced
+  names:
+    kind: Tenant
+    plural: tenants
+    singular: tenant
+    shortNames:
+      - tn
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Domain
+          type: string
+          jsonPath: .spec.domain
+        - name: Email
+          type: boolean
+          jsonPath: .spec.provisionEmail
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [email]
+              properties:
+                email:
+                  type: string
+                  description: Client email — the key the reconcile loop is scoped to (never used in resource names or logs).
+                  pattern: '^[^@\s]+@[^@\s]+\.[^@\s]+$'
+                userId:
+                  type: string
+                  description: Soft reference to the business-plane User (no cross-DB FK).
+                invoiceNinjaId:
+                  type: string
+                  description: Soft reference to the billing record.
+                domain:
+                  type: string
+                  description: Primary domain to provision (DNS island). A hostname with a TLD — not an IP.
+                  pattern: '^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$'
+                registrar:
+                  type: string
+                  enum: [namecom, external]
+                  default: external
+                provisionEmail:
+                  type: boolean
+                  default: false
+                emailDomainName:
+                  type: string
+                emailRegion:
+                  type: string
+                  enum: [US, EU]
+                  default: US
+                appName:
+                  type: string
+                githubRepo:
+                  type: string
+                  description: owner/repo of the client app.
+                  pattern: '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'
+                appHostname:
+                  type: string
+                  pattern: '^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$'
+                stagingBaseUrl:
+                  type: string
+                  pattern: '^https://'
+                blueprint:
+                  type: string
+                  description: Versioned managed-hosting blueprint stamped onto the tenant.
+                  default: managed-hosting@v1
+                decommissioned:
+                  type: boolean
+                  description: Set true to run the teardown/compensation saga (GDPR-erasure path).
+                  default: false
+            status:
+              type: object
+              properties:
+                provisioningId:
+                  type: string
+                  description: Opaque, stable id — the Restate saga key. Never the email.
+                phase:
+                  type: string
+                  enum: [Pending, Provisioning, Live, Partial, Failed, Decommissioned]
+                observedGeneration:
+                  type: integer
+                conditions:
+                  type: array
+                  description: One entry per island (spine/dns/email/app/staging).
+                  items:
+                    type: object
+                    required: [island, status]
+                    properties:
+                      island:
+                        type: string
+                        enum: [spine, dns, email, app, staging]
+                      status:
+                        type: string
+                        enum: [Pending, Running, OK, Skipped, Failed]
+                      attempt:
+                        type: integer
+                      detail:
+                        type: string
+                      lastError:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time


### PR DESCRIPTION
First slice of the L1/L2 reconcile loop ([ADR-0019](../framework/decisions/0019-provisioning-reconcile-metacontroller-restate.md)) — the **k8s-native provisioning surface**, no controller wired yet.

**Adds (staging/homelab):**
- `Tenant` CRD (`platform.coreyalan.com/v1alpha1`) — the desired-state spec (the old atlas `TenantSpec`: email, domain, provisionEmail, app/repo, staging, blueprint, decommissioned) + status (opaque `provisioningId`, `phase`, per-island `conditions[]`). Status subresource + printer columns (Phase/Domain/Email/Age). Basic pattern validation on email/domain/repo/hostname.
- `ClusterRole` `tenant-admin` / `tenant-viewer` — the RBAC surface (no bindings yet; the webhook SA + operators bind in later phases).
- ArgoCD `Application` `provisioning` (namespace `provisioning`, non-recursive so `examples/` isn't synced, CRD-safe SSA + ServerSideDiff + negative wave).

**Validated:** `kubectl apply --dry-run=server` on staging accepted the CRD + both ClusterRoles.

**Test after merge:**
```
kubectl -n provisioning apply -f provisioning/examples/tenant-example.yaml
kubectl -n provisioning get tenants     # PHASE/DOMAIN columns render; status empty (no controller yet)
```

**Next (Phase 1b):** the Metacontroller `CompositeController` + a status-only stub webhook (needs a small webhook service image) → closes the loop end-to-end with status mirroring, before any island logic (Phase 2).