### PR TITLE
feat(provisioning): CompositeController + stub webhook (ADR-0019 Phase 1b)

### DIFF
--- a/provisioning/compositecontroller.yaml
+++ b/provisioning/compositecontroller.yaml
@@ -1,0 +1,21 @@
+---
+# Metacontroller CompositeController — the L2 reconcile trigger (ADR-0019).
+# Watches Tenant and calls the sync webhook on every change + every
+# resyncPeriodSeconds (the drift pass). Phase 1b emits no child resources yet;
+# the webhook only writes Tenant.status. Children (ArgoCD Application, DNSEndpoint,
+# ExternalSecret) arrive in Phase 3.
+apiVersion: metacontroller.k8s.io/v1alpha1
+kind: CompositeController
+metadata:
+  name: tenant-provisioner
+spec:
+  generateSelector: true
+  resyncPeriodSeconds: 300
+  parentResource:
+    apiVersion: platform.coreyalan.com/v1alpha1
+    resource: tenants
+  childResources: []
+  hooks:
+    sync:
+      webhook:
+        url: http://provisioning-webhook.provisioning.svc.cluster.local:8080/sync

--- a/provisioning/webhook.yaml
+++ b/provisioning/webhook.yaml
@@ -1,0 +1,137 @@
+---
+# Provisioning sync webhook — Phase 1b STUB (ADR-0019). Status-only: it computes
+# per-island desired state from Tenant.spec and writes Tenant.status; it emits no
+# children and calls no SaaS. Purpose: prove the loop end-to-end
+# (Metacontroller → webhook → status) before any island logic (Phase 2).
+#
+# Deliberately zero-dependency and ConfigMap-mounted on a stock node image, so it
+# ships with no build step. Phase 2 replaces it with a Tekton-built TS service
+# that drives the Restate saga (the "exercise the build channel" moment).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: provisioning-webhook-code
+  namespace: provisioning
+data:
+  server.mjs: |
+    // Metacontroller CompositeController sync hook — Phase 1b stub (status only).
+    import { createServer } from 'node:http';
+
+    const ISLANDS = ['spine', 'dns', 'email', 'app', 'staging'];
+    const desired = (island, s) => ({
+      spine: true,
+      dns: Boolean(s.domain),
+      email: Boolean(s.provisionEmail),
+      app: Boolean(s.appName || s.githubRepo),
+      staging: Boolean(s.stagingBaseUrl),
+    }[island]);
+
+    function syncHook(request) {
+      const parent = request.parent ?? {};
+      const spec = parent.spec ?? {};
+      const meta = parent.metadata ?? {};
+      const now = new Date().toISOString();
+      const conditions = ISLANDS
+        .filter((i) => desired(i, spec))
+        .map((island) => ({ island, status: 'Pending', lastTransitionTime: now }));
+      return {
+        status: {
+          provisioningId: meta.uid ?? '',
+          phase: spec.decommissioned ? 'Decommissioned' : 'Pending',
+          observedGeneration: meta.generation ?? 0,
+          conditions,
+        },
+        children: [],
+      };
+    }
+
+    const server = createServer((req, res) => {
+      if (req.method === 'GET' && req.url === '/healthz') { res.writeHead(200).end('ok'); return; }
+      if (req.method !== 'POST' || req.url !== '/sync') { res.writeHead(404).end(); return; }
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        try {
+          const payload = JSON.stringify(syncHook(JSON.parse(body || '{}')));
+          res.writeHead(200, { 'content-type': 'application/json' }).end(payload);
+        } catch (err) {
+          res.writeHead(500, { 'content-type': 'application/json' }).end(JSON.stringify({ error: String(err) }));
+        }
+      });
+    });
+    server.listen(8080, () => console.log('provisioning-webhook stub listening on :8080'));
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: provisioning-webhook
+  namespace: provisioning
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: provisioning-webhook
+  namespace: provisioning
+  labels:
+    app.kubernetes.io/name: provisioning-webhook
+    app.kubernetes.io/part-of: provisioning
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: provisioning-webhook
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: provisioning-webhook
+        app.kubernetes.io/part-of: provisioning
+    spec:
+      serviceAccountName: provisioning-webhook
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: webhook
+          image: node:22-alpine
+          command: ["node", "/app/server.mjs"]
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+            initialDelaySeconds: 3
+          livenessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+            initialDelaySeconds: 10
+          resources:
+            requests: { cpu: 10m, memory: 32Mi }
+            limits: { cpu: 100m, memory: 64Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: code
+              mountPath: /app
+      volumes:
+        - name: code
+          configMap:
+            name: provisioning-webhook-code
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: provisioning-webhook
+  namespace: provisioning
+  labels:
+    app.kubernetes.io/name: provisioning-webhook
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: provisioning-webhook
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP


### PR DESCRIPTION
Closes the reconcile loop end-to-end with **no island logic yet** ([ADR-0019](../framework/decisions/0019-provisioning-reconcile-metacontroller-restate.md) Phase 1b).

**Adds (staging):**
- **Metacontroller `CompositeController` `tenant-provisioner`** — watches `Tenant`, calls the sync webhook on change + every `resyncPeriodSeconds: 300` (the drift pass). No child resources yet.
- **Stub sync webhook** — a zero-dependency Node hook (mounted from a ConfigMap on `node:22-alpine`, non-root, read-only rootfs) that computes per-island desired state from `Tenant.spec` and writes `Tenant.status` (`provisioningId`, `phase`, per-island `conditions[]`). Emits no children, calls no SaaS.

**Why ConfigMap-mounted, not built:** it ships with no build gate so the loop works the moment this merges. Phase 2 replaces it with a **Tekton-built TS service** driving the Restate saga — that's the real "exercise the build channel" step.

**Validated:** `kubectl apply --dry-run=server` on staging accepted all resources (Kyverno admission + PSA clean, image policy OK).

**Test after merge:**
```
kubectl -n provisioning apply -f provisioning/examples/tenant-example.yaml
kubectl -n provisioning get tenants          # PHASE -> Pending
kubectl -n provisioning get tenant acme -o jsonpath='{.status}' | jq   # conditions: spine/dns/email/app
```
That proves Metacontroller → webhook → status end-to-end. **Phase 2 next:** Restate saga + real island handlers (the atlas SaaS logic), as a Tekton-built service.