### PR TITLE
feat(provisioning): Restate engine + spine + deploy side (ADR-0019 Phase 2a)

### DIFF
--- a/apps/provisioning-engine/Dockerfile
+++ b/apps/provisioning-engine/Dockerfile
@@ -1,0 +1,24 @@
+# provisioning-engine — Restate durable-execution service (ADR-0019 Phase 2a).
+# Build via the Tekton node/linux channel (ADR-0017) or `docker build`.
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY prisma ./prisma
+RUN npx prisma generate
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json ./
+RUN npm install --omit=dev
+# Carry the generated Prisma client + query engine from the build stage.
+COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=build /app/node_modules/@prisma ./node_modules/@prisma
+COPY --from=build /app/dist ./dist
+USER 1000
+EXPOSE 9080
+CMD ["node", "dist/index.js"]

--- a/apps/provisioning-engine/README.md
+++ b/apps/provisioning-engine/README.md
@@ -1,0 +1,44 @@
+# provisioning-engine (ADR-0019 Phase 2a)
+
+The **Restate durable-execution engine** for the tenant provisioning saga — L1 of
+the control-plane stack ([ADR-0018](../../../framework/decisions/0018-control-plane-target-stack.md)).
+It replaces the atlas `engine.ts` + Pub/Sub worker; the island handlers are ported
+unchanged (ADR-0015 injected store).
+
+## What's here (Phase 2a)
+- `src/workflow.ts` — the `provisionTenant` Restate workflow, keyed by the opaque
+  `provisioningId`. `run` drives each island via `ctx.run()` (durable, retried);
+  the `status` shared handler exposes phase + per-island conditions.
+- `src/islands/spine.ts` — the **spine** island, ported verbatim from atlas (pure
+  Prisma, no SaaS — so Phase 2a needs **no NPM_TOKEN**).
+- `src/types.ts`, `prisma/schema.prisma`, `Dockerfile`.
+
+This is a **scaffold** — the code is complete, but unlike the Phase-1 manifests it
+can't be dry-run-verified; it needs building + a DB + Restate registration.
+
+## Activation runbook
+1. **Control DB** — apply a CloudNativePG cluster (the homelab has the operator) and
+   set `DATABASE_URL`. Then `DATABASE_URL=… npx prisma migrate deploy`.
+2. **Build the image** — via the Tekton node/linux channel ([ADR-0017](../../../framework/decisions/0017-tekton-build-platform.md))
+   or `docker build`, push to the homelab registry. (Add a `.tekton/` PipelineRun
+   referencing the appropriate channel — `nextjs-build` is Next.js-shaped, so a
+   generic node/linux channel + Dockerfile build task is the better fit.)
+3. **Deploy** the engine (Deployment/Service on :9080) with `DATABASE_URL` from ESO.
+4. **Register with Restate** — `restate deployments register http://provisioning-engine.provisioning.svc:9080`
+   (or the Restate admin API via a one-shot Job).
+5. **Point the webhook at Restate** — upgrade `provisioning/webhook.yaml` so the sync
+   hook submits `POST <restate-ingress>/provisionTenant/<provisioningId>/run` (fire-
+   and-forget) and reads `.../provisionTenant/<provisioningId>/status`, mapping that
+   to `Tenant.status`.
+6. **Test** — `kubectl -n provisioning apply` a Tenant → spine runs through Restate →
+   `Provisioning` row created → `phase: Live`.
+
+## Design decision to lock in Phase 2b
+`run` executes **once per key** — correct for first provision, but the 300s **drift
+resync** needs re-reconcile. Options: (a) a Restate **Virtual Object** with a
+repeatable `reconcile` handler (recommended), or (b) a fresh workflow per run keyed
+by `runId`. Decide when porting `dns`.
+
+## Phase 2b
+Add the **dns** island (`@corey-alan-consulting/cloudflare` — needs `NPM_TOKEN` for
+the restricted scope + Cloudflare creds via ESO) and its `Domain` model.

--- a/apps/provisioning-engine/package.json
+++ b/apps/provisioning-engine/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "provisioning-engine",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Restate durable-execution engine for the tenant provisioning saga (ADR-0019, L1).",
+  "scripts": {
+    "build": "prisma generate && tsc",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@prisma/client": "^6.2.0",
+    "@restatedev/restate-sdk": "^1.7.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "prisma": "^6.2.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/provisioning-engine/prisma/schema.prisma
+++ b/apps/provisioning-engine/prisma/schema.prisma
@@ -1,0 +1,41 @@
+// Control-DB schema — minimal for Phase 2a (spine only). The full atlas
+// control schema (coreyalan.com/docs/control-plane-schema.prisma) lands model by
+// model as islands are ported. binaryTargets includes musl for the alpine image.
+generator client {
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+// The spine: the email-keyed anchor; its id is the opaque provisioningId.
+model Provisioning {
+  id             String   @id @default(cuid())
+  email          String   @unique
+  userId         String?
+  invoiceNinjaId String?
+  status         String   @default("INITIATED")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+}
+
+// Skeletons so the ProvisioningStore Pick type resolves; fleshed out as the
+// dns/email/app/staging islands + run history are ported (Phase 2b+).
+model TenantSpec {
+  id    String @id @default(cuid())
+  email String @unique
+}
+
+model ProvisioningRun {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+}
+
+model ProvisioningStepAttempt {
+  id     String @id @default(cuid())
+  runId  String
+  system String
+}

--- a/apps/provisioning-engine/src/index.ts
+++ b/apps/provisioning-engine/src/index.ts
@@ -1,0 +1,7 @@
+// Serve the provisionTenant workflow. Restate discovers handlers over HTTP/2 on
+// this port; register the deployment with the Restate server after deploy
+// (see README — `restate deployments register`).
+import * as restate from '@restatedev/restate-sdk';
+import { provisionTenant } from './workflow.js';
+
+restate.serve({ services: [provisionTenant] });

--- a/apps/provisioning-engine/src/islands/spine.ts
+++ b/apps/provisioning-engine/src/islands/spine.ts
@@ -1,0 +1,27 @@
+// The spine island — ported verbatim from atlas
+// (packages/core/src/provisioning/islands/spine.ts). Births/repairs the
+// email-keyed Provisioning row (its id is the opaque provisioningId) and keeps
+// the business soft references in sync. Always desired; safe to run twice —
+// which is exactly what a Restate ctx.run() durable step needs.
+import type { IslandReconciler } from '../types.js';
+
+export const spineIsland: IslandReconciler = {
+  system: 'spine',
+  desired: () => true,
+  reconcile: async ({ spec, store }) => {
+    await store.provisioning.upsert({
+      where: { email: spec.email },
+      update: {
+        userId: spec.userId ?? undefined,
+        invoiceNinjaId: spec.invoiceNinjaId ?? undefined,
+      },
+      create: {
+        email: spec.email,
+        userId: spec.userId ?? null,
+        invoiceNinjaId: spec.invoiceNinjaId ?? null,
+        status: 'INITIATED',
+      },
+    });
+    return { status: 'OK', detail: 'spine ensured' };
+  },
+};

--- a/apps/provisioning-engine/src/types.ts
+++ b/apps/provisioning-engine/src/types.ts
@@ -1,0 +1,53 @@
+// Island reconciler interface — ported verbatim from atlas
+// (packages/core/src/provisioning/types.ts, ADR-0014/0015) so the atlas island
+// handlers drop in unchanged. The store is a structural subset of the Prisma
+// client (ADR-0015); any real PrismaClient is assignable.
+import type { PrismaClient } from '@prisma/client';
+
+export const ISLAND_ORDER = ['spine', 'dns', 'email', 'app', 'staging'] as const;
+export type IslandSystem = (typeof ISLAND_ORDER)[number];
+
+export type ProvisioningTrigger = 'API' | 'SCHEDULE' | 'TEARDOWN';
+
+// Only the delegates the islands touch (ADR-0015 structural-subset store).
+export type ProvisioningStore = Pick<
+  PrismaClient,
+  'tenantSpec' | 'provisioning' | 'provisioningRun' | 'provisioningStepAttempt'
+>;
+
+// The desired state (subset of the atlas TenantSpec — enough for spine+dns).
+export interface TenantSpec {
+  email: string;
+  userId?: string | null;
+  invoiceNinjaId?: string | null;
+  domain?: string | null;
+  provisionEmail?: boolean;
+  appName?: string | null;
+  githubRepo?: string | null;
+  stagingBaseUrl?: string | null;
+  decommissioned?: boolean;
+}
+
+export interface Logger {
+  info(msg: string, meta?: unknown): void;
+  error(msg: string, meta?: unknown): void;
+}
+
+export interface IslandContext {
+  readonly spec: TenantSpec;
+  readonly provisioning: unknown | null;
+  readonly trigger: ProvisioningTrigger;
+  readonly store: ProvisioningStore;
+  readonly logger: Logger;
+}
+
+export interface IslandOutcome {
+  readonly status: 'OK' | 'SKIPPED';
+  readonly detail?: string;
+}
+
+export interface IslandReconciler {
+  readonly system: IslandSystem;
+  desired(spec: TenantSpec, trigger: ProvisioningTrigger): boolean;
+  reconcile(ctx: IslandContext): Promise<IslandOutcome>;
+}

--- a/apps/provisioning-engine/src/workflow.ts
+++ b/apps/provisioning-engine/src/workflow.ts
@@ -1,0 +1,84 @@
+// provisionTenant — the durable reconcile saga (ADR-0019, L1).
+//
+// A Restate workflow keyed by the opaque provisioningId. `run` drives each
+// island via ctx.run() (durable, idempotent, retried-with-backoff by Restate),
+// and publishes per-island state that the `status` shared handler exposes — the
+// webhook polls that to fill Tenant.status. Restate replaces the atlas
+// engine.ts + Pub/Sub worker + StepAttempt log; the island handlers are unchanged.
+//
+// NOTE (design decision to lock in Phase 2b): `run` executes once per key, which
+// is right for the first provision. For *drift re-reconcile* (the 300s resync),
+// switch this to a Restate Virtual Object with a repeatable `reconcile` handler,
+// or invoke a fresh workflow per run keyed by runId. The stub webhook already
+// tolerates re-submits, so this scaffold proves spine→Restate end-to-end.
+import * as restate from '@restatedev/restate-sdk';
+import { PrismaClient } from '@prisma/client';
+import { ISLAND_ORDER, type IslandReconciler, type TenantSpec } from './types.js';
+import { spineIsland } from './islands/spine.js';
+
+const store = new PrismaClient();
+const logger = {
+  info: (msg: string, meta?: unknown) => console.log(JSON.stringify({ level: 'info', msg, meta })),
+  error: (msg: string, meta?: unknown) => console.error(JSON.stringify({ level: 'error', msg, meta })),
+};
+
+// Registered islands. dns/email/app/staging land in later phases (dns = 2b).
+const islands: IslandReconciler[] = [spineIsland];
+
+interface Condition {
+  island: string;
+  status: 'Pending' | 'Running' | 'OK' | 'Skipped' | 'Failed';
+  detail?: string;
+  lastError?: string;
+  lastTransitionTime: string;
+}
+
+export const provisionTenant = restate.workflow({
+  name: 'provisionTenant',
+  handlers: {
+    run: async (ctx: restate.WorkflowContext, spec: TenantSpec) => {
+      const trigger = spec.decommissioned ? 'TEARDOWN' : 'API';
+      const conditions: Condition[] = [];
+      const now = () => new Date().toISOString();
+      const publish = async () => ctx.set('conditions', conditions);
+
+      await ctx.set('phase', 'Provisioning');
+
+      for (const system of ISLAND_ORDER) {
+        const island = islands.find((i) => i.system === system);
+        // Not ported yet — honest Pending, not a silent skip (atlas §engine).
+        if (!island) {
+          conditions.push({ island: system, status: 'Pending', detail: 'no reconciler yet', lastTransitionTime: now() });
+          await publish();
+          continue;
+        }
+        if (!island.desired(spec, trigger)) {
+          conditions.push({ island: system, status: 'Skipped', lastTransitionTime: now() });
+          await publish();
+          continue;
+        }
+        try {
+          // Durable step: journaled + retried with backoff by Restate. Islands
+          // are idempotent, so replay/retry is safe.
+          const outcome = await ctx.run(system, () =>
+            island.reconcile({ spec, provisioning: null, trigger, store, logger }),
+          );
+          conditions.push({ island: system, status: outcome.status === 'OK' ? 'OK' : 'Skipped', detail: outcome.detail, lastTransitionTime: now() });
+        } catch (err) {
+          conditions.push({ island: system, status: 'Failed', lastError: String(err), lastTransitionTime: now() });
+        }
+        await publish();
+      }
+
+      const failed = conditions.some((c) => c.status === 'Failed');
+      await ctx.set('phase', spec.decommissioned ? 'Decommissioned' : failed ? 'Failed' : 'Live');
+      return { ok: !failed };
+    },
+
+    // Read-only handler the webhook polls (WorkflowSharedContext runs concurrently).
+    status: restate.handlers.workflow.shared(async (ctx: restate.WorkflowSharedContext) => ({
+      phase: (await ctx.get<string>('phase')) ?? 'Pending',
+      conditions: (await ctx.get<Condition[]>('conditions')) ?? [],
+    })),
+  },
+});

--- a/apps/provisioning-engine/tsconfig.json
+++ b/apps/provisioning-engine/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/provisioning/control-db.yaml
+++ b/provisioning/control-db.yaml
@@ -1,0 +1,21 @@
+---
+# Control DB for the provisioning engine (ADR-0019 Phase 2a). CloudNativePG
+# single-instance Postgres on local-path (staging). CNPG generates the
+# `provisioning-db-app` secret (keys: uri/host/user/password/dbname) — the engine
+# reads DATABASE_URL from its `uri` key. Run `prisma migrate deploy` against it
+# once (activation step 1) to create the Provisioning table.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: provisioning-db
+  namespace: provisioning
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  storage:
+    size: 2Gi
+    storageClass: local-path
+  bootstrap:
+    initdb:
+      database: provisioning
+      owner: provisioning

--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -1,0 +1,73 @@
+---
+# provisioning-engine Deployment — the Restate durable-execution service (L1).
+# Ships at replicas: 0 with a placeholder image so it syncs cleanly; activation
+# (README): build the image (Tekton), set it below, scale to 1, then register the
+# endpoint with Restate (provisioning/examples/restate-register-job.yaml).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: provisioning-engine
+  namespace: provisioning
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: provisioning-engine
+  namespace: provisioning
+  labels:
+    app.kubernetes.io/name: provisioning-engine
+    app.kubernetes.io/part-of: provisioning
+spec:
+  replicas: 0 # ↑ to 1 after building the image + registering with Restate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: provisioning-engine
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: provisioning-engine
+        app.kubernetes.io/part-of: provisioning
+    spec:
+      serviceAccountName: provisioning-engine
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: engine
+          image: provisioning-engine:UNBUILT # TODO: set to the Tekton-built image
+          ports:
+            - containerPort: 9080
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: provisioning-db-app
+                  key: uri
+            - name: RESTATE_ADMIN
+              value: http://restate.restate.svc.cluster.local:9070
+          resources:
+            requests: { cpu: 25m, memory: 64Mi }
+            limits: { cpu: 250m, memory: 256Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: provisioning-engine
+  namespace: provisioning
+  labels:
+    app.kubernetes.io/name: provisioning-engine
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: provisioning-engine
+  ports:
+    - port: 9080
+      targetPort: 9080
+      protocol: TCP

--- a/provisioning/examples/restate-register-job.yaml
+++ b/provisioning/examples/restate-register-job.yaml
@@ -1,0 +1,40 @@
+---
+# Register the provisioning-engine endpoint with Restate (activation step 4).
+# NOT synced by ArgoCD (examples/ is excluded) — apply by hand AFTER the engine
+# pod is running, so Restate can reach :9080 to discover its handlers:
+#   kubectl -n provisioning apply -f provisioning/examples/restate-register-job.yaml
+# Re-runnable: Restate updates the deployment on re-register.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: restate-register-provisioning-engine
+  namespace: provisioning
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: restate-register
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: register
+          image: curlimages/curl:8.10.1
+          command:
+            - sh
+            - -c
+            - >-
+              curl -sf -X POST http://restate.restate.svc.cluster.local:9070/deployments
+              -H 'content-type: application/json'
+              -d '{"uri":"http://provisioning-engine.provisioning.svc.cluster.local:9080"}'
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]

--- a/provisioning/webhook.yaml
+++ b/provisioning/webhook.yaml
@@ -1,12 +1,9 @@
 ---
-# Provisioning sync webhook — Phase 1b STUB (ADR-0019). Status-only: it computes
-# per-island desired state from Tenant.spec and writes Tenant.status; it emits no
-# children and calls no SaaS. Purpose: prove the loop end-to-end
-# (Metacontroller → webhook → status) before any island logic (Phase 2).
-#
-# Deliberately zero-dependency and ConfigMap-mounted on a stock node image, so it
-# ships with no build step. Phase 2 replaces it with a Tekton-built TS service
-# that drives the Restate saga (the "exercise the build channel" moment).
+# Provisioning sync webhook — Phase 2a: submits the Tenant to the Restate engine
+# and mirrors the workflow's state into Tenant.status. Still ConfigMap-mounted /
+# zero-dependency (Node 22 global fetch). Graceful fallback: while the engine is
+# unbuilt/unregistered, Restate calls fail and the webhook reports phase Pending —
+# so this is safe to ship before the engine is live.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,32 +11,41 @@ metadata:
   namespace: provisioning
 data:
   server.mjs: |
-    // Metacontroller CompositeController sync hook — Phase 1b stub (status only).
+    // Metacontroller CompositeController sync hook -> Restate engine.
     import { createServer } from 'node:http';
 
-    const ISLANDS = ['spine', 'dns', 'email', 'app', 'staging'];
-    const desired = (island, s) => ({
-      spine: true,
-      dns: Boolean(s.domain),
-      email: Boolean(s.provisionEmail),
-      app: Boolean(s.appName || s.githubRepo),
-      staging: Boolean(s.stagingBaseUrl),
-    }[island]);
+    const RESTATE = process.env.RESTATE_INGRESS ?? 'http://restate.restate.svc.cluster.local:8080';
+    const WF = 'provisionTenant';
 
-    function syncHook(request) {
+    async function driveRestate(id, spec) {
+      // Fire-and-forget submit (idempotent: re-submits to an existing workflow key
+      // are ignored by Restate). Then read the workflow's published state.
+      try {
+        await fetch(`${RESTATE}/${WF}/${encodeURIComponent(id)}/run/send`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(spec),
+        });
+      } catch { /* engine not up yet */ }
+      try {
+        const r = await fetch(`${RESTATE}/${WF}/${encodeURIComponent(id)}/status`, { method: 'POST' });
+        if (r.ok) return await r.json();
+      } catch { /* fall through to Pending */ }
+      return null;
+    }
+
+    async function syncHook(request) {
       const parent = request.parent ?? {};
       const spec = parent.spec ?? {};
       const meta = parent.metadata ?? {};
-      const now = new Date().toISOString();
-      const conditions = ISLANDS
-        .filter((i) => desired(i, spec))
-        .map((island) => ({ island, status: 'Pending', lastTransitionTime: now }));
+      const id = meta.uid ?? '';
+      const state = id ? await driveRestate(id, spec) : null;
       return {
         status: {
-          provisioningId: meta.uid ?? '',
-          phase: spec.decommissioned ? 'Decommissioned' : 'Pending',
+          provisioningId: id,
+          phase: state?.phase ?? 'Pending',
           observedGeneration: meta.generation ?? 0,
-          conditions,
+          conditions: state?.conditions ?? [],
         },
         children: [],
       };
@@ -50,16 +56,16 @@ data:
       if (req.method !== 'POST' || req.url !== '/sync') { res.writeHead(404).end(); return; }
       let body = '';
       req.on('data', (c) => (body += c));
-      req.on('end', () => {
+      req.on('end', async () => {
         try {
-          const payload = JSON.stringify(syncHook(JSON.parse(body || '{}')));
+          const payload = JSON.stringify(await syncHook(JSON.parse(body || '{}')));
           res.writeHead(200, { 'content-type': 'application/json' }).end(payload);
         } catch (err) {
           res.writeHead(500, { 'content-type': 'application/json' }).end(JSON.stringify({ error: String(err) }));
         }
       });
     });
-    server.listen(8080, () => console.log('provisioning-webhook stub listening on :8080'));
+    server.listen(8080, () => console.log('provisioning-webhook (restate) listening on :8080'));
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
The full **Phase 2a** slice — the L1 durable engine, its first island, and everything to run it on staging.

## Engine (code scaffold)
- `apps/provisioning-engine/` — the `provisionTenant` Restate workflow driving islands via `ctx.run()` + a `status` shared handler; **spine** island ported verbatim (pure Prisma, no NPM_TOKEN); `types.ts`, `schema.prisma`, `Dockerfile`.

## Deploy side (dry-run validated on staging)
- `provisioning/control-db.yaml` — CloudNativePG single-instance Postgres (`provisioning-db`, local-path) → generates the `provisioning-db-app` secret the engine reads `DATABASE_URL` from.
- `provisioning/engine.yaml` — engine Deployment (**`replicas: 0`**, placeholder image, so it syncs clean until built) + Service (:9080) + SA.
- `provisioning/webhook.yaml` — **upgraded** to submit the Tenant to Restate (`/provisionTenant/<uid>/run/send`) and mirror the workflow state into `Tenant.status`. **Graceful fallback:** until the engine is registered, Restate calls fail and it reports `phase: Pending` — so this is safe to ship now.
- `provisioning/examples/restate-register-job.yaml` — registers the engine with Restate admin (:9070); not synced, applied by hand after the engine is up.

## Activation (after merge) — `apps/provisioning-engine/README.md`
1. `prisma migrate deploy` against `provisioning-db`
2. build the engine image (Tekton), set it in `engine.yaml`, scale to `1`
3. `kubectl apply` the register Job
4. apply a Tenant → spine runs through Restate → `Provisioning` row → `phase: Live`

Everything except the image build is validated against the live API; on merge the control DB provisions and the webhook upgrades safely (Tenants stay `Pending` until activation).