### PR TITLE
fix(provisioning): auto-reload the webhook on ConfigMap change

### DIFF
--- a/provisioning/webhook.yaml
+++ b/provisioning/webhook.yaml
@@ -78,6 +78,10 @@ kind: Deployment
 metadata:
   name: provisioning-webhook
   namespace: provisioning
+  annotations:
+    # The hook logic is ConfigMap-mounted; a running node process won't re-read it.
+    # Reloader restarts the pod when provisioning-webhook-code changes.
+    reloader.stakater.com/auto: "true"
   labels:
     app.kubernetes.io/name: provisioning-webhook
     app.kubernetes.io/part-of: provisioning


### PR DESCRIPTION
The webhook's hook logic is ConfigMap-mounted, but a running `node` process won't re-read the file — so after the Phase-2a ConfigMap change the pod kept executing the pre-merge stub. Adds `reloader.stakater.com/auto: "true"` (Reloader is already running on the cluster) so the pod restarts when `provisioning-webhook-code` changes. Applying this also restarts the current pod onto the Restate-calling code. Matters for Phase 2b, where the ConfigMap changes again.