### PR TITLE
feat(provisioning): migrate Job + migrate-capable engine image (Phase 2a activation)

### DIFF
--- a/apps/provisioning-engine/Dockerfile
+++ b/apps/provisioning-engine/Dockerfile
@@ -19,6 +19,8 @@ RUN npm install --omit=dev
 COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=build /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=build /app/dist ./dist
+# Schema stays so the same image can run `prisma db push` (the migrate Job).
+COPY --from=build /app/prisma ./prisma
 USER 1000
 EXPOSE 9080
 CMD ["node", "dist/index.js"]

--- a/apps/provisioning-engine/README.md
+++ b/apps/provisioning-engine/README.md
@@ -17,12 +17,16 @@ This is a **scaffold** — the code is complete, but unlike the Phase-1 manifest
 can't be dry-run-verified; it needs building + a DB + Restate registration.
 
 ## Activation runbook
-1. **Control DB** — apply a CloudNativePG cluster (the homelab has the operator) and
-   set `DATABASE_URL`. Then `DATABASE_URL=… npx prisma migrate deploy`.
-2. **Build the image** — via the Tekton node/linux channel ([ADR-0017](../../../framework/decisions/0017-tekton-build-platform.md))
-   or `docker build`, push to the homelab registry. (Add a `.tekton/` PipelineRun
-   referencing the appropriate channel — `nextjs-build` is Next.js-shaped, so a
-   generic node/linux channel + Dockerfile build task is the better fit.)
+1. **Control DB** — already deployed by `provisioning/control-db.yaml` (CloudNativePG,
+   secret `provisioning-db-app`). Create the schema with the migrate Job (uses this
+   same image): `kubectl -n provisioning apply -f provisioning/examples/migrate-job.yaml`.
+2. **Build the image** — **note:** the Tekton catalog does *not* build container images
+   yet (it does web CI-checks + Android only, [ADR-0017](../../../framework/decisions/0017-tekton-build-platform.md)).
+   So for now: `docker build` this dir and push to the homelab registry, then set that
+   image in `engine.yaml` **and** `examples/migrate-job.yaml`. Longer term, either add a
+   container-build channel to the catalog, or make this an app repo on the
+   `deploy-workflows` GitHub Actions path (→ Artifact Registry). This image is
+   migrate-capable (serves on :9080 **and** runs `prisma db push`).
 3. **Deploy** the engine (Deployment/Service on :9080) with `DATABASE_URL` from ESO.
 4. **Register with Restate** — `restate deployments register http://provisioning-engine.provisioning.svc:9080`
    (or the Restate admin API via a one-shot Job).

--- a/apps/provisioning-engine/package.json
+++ b/apps/provisioning-engine/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "@prisma/client": "^6.2.0",
-    "@restatedev/restate-sdk": "^1.7.0"
+    "@restatedev/restate-sdk": "^1.7.0",
+    "prisma": "^6.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",
-    "prisma": "^6.2.0",
     "typescript": "^5.7.0"
   }
 }

--- a/provisioning/examples/migrate-job.yaml
+++ b/provisioning/examples/migrate-job.yaml
@@ -1,0 +1,42 @@
+---
+# Create/sync the control-DB schema (activation step 1). Uses the SAME engine
+# image (it carries the prisma CLI + schema), so no separate migrate image.
+# NOT synced by ArgoCD (examples/) — apply AFTER the engine image is built and set
+# below, and after the control DB is Ready:
+#   kubectl -n provisioning apply -f provisioning/examples/migrate-job.yaml
+# `db push` syncs the schema directly (no migration files needed for the first cut).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: provisioning-db-migrate
+  namespace: provisioning
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: provisioning-db-migrate
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: migrate
+          image: provisioning-engine:UNBUILT # ← same image you set in engine.yaml
+          command: ["./node_modules/.bin/prisma", "db", "push", "--skip-generate"]
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: provisioning-db-app
+                  key: uri
+            - name: HOME
+              value: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]


### PR DESCRIPTION
Moves Phase 2a toward activation, and corrects the build story.

**Finding:** the Tekton catalog has **no container-image build** (only web CI-checks + Android — [ADR-0017](../../../framework/decisions/0017-tekton-build-platform.md) hasn't reached container builds; app images come from the `deploy-workflows` GitHub Actions path → Artifact Registry). So the engine image can't be built via `nextjs-build`; a `.tekton` PipelineRun wouldn't help.

**Changes:**
- **One image, migrate + serve** — moved `prisma` to dependencies and the Dockerfile now keeps `prisma/` in the runtime layer, so the engine image both serves on :9080 and can run `prisma db push`. No separate migrate image.
- **`provisioning/examples/migrate-job.yaml`** — creates the control-DB schema via `prisma db push` using that image (not synced; applied by hand after the image is built + set). Dry-run validated (Kyverno/PSA clean).
- **README** — activation runbook updated: control DB is deployed; build the image via `docker build` (interim, until a container-build channel exists) and set it in `engine.yaml` + the migrate Job.

**Remaining decision (the real blocker): how to build the engine image** —
(a) manual `docker build` + push to the homelab registry (quickest),
(b) make `provisioning-engine` an app repo on the deploy-workflows path,
(c) add a container-build channel to the Tekton catalog (the ADR-0017 gap).

Once the image exists: apply the migrate Job, set the image + scale the engine to 1, apply the register Job → `kubectl apply` a Tenant runs `spine` in Restate.