### PR TITLE
feat(provisioning): activate the engine (image + pull secret)

### DIFF
--- a/ar-token-refresher/rbac.yaml
+++ b/ar-token-refresher/rbac.yaml
@@ -34,3 +34,29 @@ subjects:
   - kind: ServiceAccount
     name: ar-token-refresher
     namespace: ar-pull-system
+---
+# The control-plane provisioning-engine runs in `provisioning` and pulls from the
+# coreyalan-provisioning AR — the refresher writes its pull secret here too.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ar-pull-secret-writer
+  namespace: provisioning
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ar-token-refresher
+  namespace: provisioning
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ar-pull-secret-writer
+subjects:
+  - kind: ServiceAccount
+    name: ar-token-refresher
+    namespace: ar-pull-system

--- a/ar-token-refresher/refresher.yaml
+++ b/ar-token-refresher/refresher.yaml
@@ -69,6 +69,21 @@ data:
         | kubectl apply -f -
     done
     echo "refreshed ${NS}: ${SECRETS}"
+
+    # Control-plane provisioning-engine (coreyalan-provisioning AR) — same token.
+    printf '%s\n' \
+      'apiVersion: v1' \
+      'kind: Secret' \
+      'metadata:' \
+      '  name: gcr-pull-secret-provisioning-engine' \
+      '  namespace: provisioning' \
+      '  annotations:' \
+      '    reloader.stakater.com/ignore: "true"' \
+      'type: kubernetes.io/dockerconfigjson' \
+      'data:' \
+      "  .dockerconfigjson: ${DOCKERCFG_B64}" \
+      | kubectl apply -f -
+    echo "refreshed provisioning: gcr-pull-secret-provisioning-engine"
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/name: provisioning-engine
     app.kubernetes.io/part-of: provisioning
 spec:
-  replicas: 0 # ↑ to 1 after building the image + registering with Restate
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: provisioning-engine
@@ -29,6 +29,8 @@ spec:
         app.kubernetes.io/part-of: provisioning
     spec:
       serviceAccountName: provisioning-engine
+      imagePullSecrets:
+        - name: gcr-pull-secret-provisioning-engine
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -36,7 +38,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: engine
-          image: provisioning-engine:UNBUILT # TODO: set to the Tekton-built image
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine:0.1.0
           ports:
             - containerPort: 9080
           env:

--- a/provisioning/examples/migrate-job.yaml
+++ b/provisioning/examples/migrate-job.yaml
@@ -19,6 +19,8 @@ spec:
         app.kubernetes.io/name: provisioning-db-migrate
     spec:
       restartPolicy: OnFailure
+      imagePullSecrets:
+        - name: gcr-pull-secret-provisioning-engine
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -26,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: migrate
-          image: provisioning-engine:UNBUILT # ← same image you set in engine.yaml
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine:0.1.0
           command: ["./node_modules/.bin/prisma", "db", "push", "--skip-generate"]
           env:
             - name: DATABASE_URL


### PR DESCRIPTION
Phase 2a activation — the engine now runs (spine executes in Restate).

- **engine.yaml** — image `us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine:0.1.0` (built + pushed), `replicas: 1`, `imagePullSecrets: gcr-pull-secret-provisioning-engine`.
- **ar-token-refresher** — extended to also mint the AR pull secret into the `provisioning` namespace (RBAC Role/RoleBinding + the script), so the engine can pull from the coreyalan-provisioning AR (the puller SA has reader per platform-infra #1069).
- **migrate-job.yaml** — same image + pull secret.

After merge: trigger the refresher once (mint the secret), engine pod pulls + starts, then apply the migrate + register Jobs → `kubectl apply` a Tenant → spine runs in Restate → `phase: Live`. Dry-run validated.