### PR TITLE
feat(build): trusted container-build channel for provisioning-engine (ADR-0020)

### DIFF
--- a/build-catalog/images/clone-toolchain/Dockerfile
+++ b/build-catalog/images/clone-toolchain/Dockerfile
@@ -1,0 +1,13 @@
+# Slim clone toolchain for the trusted container-build channel (ADR-0020).
+# Bakes exactly what the App-token clone step needs — git, openssl (JWT signing),
+# python3 (JSON parse), curl (GitHub API), bash — so the step runs non-root under
+# Tekton set-security-context (H1) with no runtime `apk add`. Pin by digest in the
+# pipeline once pushed.
+#
+#   docker build -t ghcr.io/nx211/clone-toolchain:0.1.0 build-catalog/images/clone-toolchain
+#   docker push ghcr.io/nx211/clone-toolchain:0.1.0      # needs ghcr write:packages
+#   # then pin the pushed digest in build-catalog/pipelines/container-build.yaml
+FROM alpine:3.20
+RUN apk add --no-cache git openssl python3 curl bash \
+    && adduser -D -u 1000 build
+USER 1000

--- a/build-catalog/pipelines/container-build.yaml
+++ b/build-catalog/pipelines/container-build.yaml
@@ -1,0 +1,107 @@
+---
+# Channel pipeline: container-build (TRUSTED tier). Clone the app repo with a
+# short-lived GitHub App token → kaniko builds the Dockerfile → pushes to Artifact
+# Registry keyless via WIF. The FIRST in-cluster container-image build channel
+# (ADR-0020), extending ADR-0017 which shipped only web CI-checks + Android AABs.
+# Consumed from the trusted EventListener's TriggerTemplate via the git resolver;
+# the git tag push supplies git-url + git-revision. The image is tagged with the
+# pushed commit SHA (immutable, reproducible). Tekton Chains signs the pushed
+# digest — build-image emits IMAGE_URL/IMAGE_DIGEST as type-hints.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: container-build
+  labels:
+    app.kubernetes.io/part-of: build-catalog
+spec:
+  params:
+    - name: git-url
+      type: string
+    - name: git-revision
+      type: string
+      default: ""
+    - name: image
+      description: AR destination without tag, e.g. us-central1-docker.pkg.dev/<project>/<repo>/<name>.
+      type: string
+      default: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine
+    - name: context
+      description: Build context dir within the cloned source.
+      type: string
+      default: .
+    - name: dockerfile
+      type: string
+      default: Dockerfile
+    - name: toolchain-image
+      description: Clone toolchain (git/openssl/python3/curl, non-root) for the App-token clone.
+      type: string
+      # INTERIM: reuse the public android toolchain (it bakes the same git/openssl/
+      # python3/curl and runs this exact non-root clone). Swap to the slim dedicated
+      # image (build-catalog/images/clone-toolchain/) once ghcr write:packages is
+      # available to push it.
+      default: ghcr.io/nx211/capturly-android-toolchain:0.1.0@sha256:e266bc15b6ad57bb6c913c9a60e666fa0014cf687f97134438bad2b12ecaaabb
+  workspaces:
+    - name: source
+    - name: gcp-wif      # external_account WIF config → keyless AR push
+    - name: github-app   # App key → ~1h clone token; no static git credential
+  tasks:
+    - name: clone
+      workspaces:
+        - name: output
+          workspace: source
+        - name: github-app
+          workspace: github-app
+      taskSpec:
+        workspaces:
+          - name: output
+          - name: github-app
+            mountPath: /github-app
+        steps:
+          - name: git-clone
+            # Toolchain image (openssl + python3 + curl + git pre-baked) so the
+            # step runs non-root under set-security-context — no runtime apk add.
+            image: $(params.toolchain-image)
+            script: |
+              #!/usr/bin/env bash
+              # Clone the private repo with a ~1h GitHub App installation token
+              # minted at build time — nothing long-lived in the pod. set -e but
+              # never -x so the token is never echoed. JSON parsed with python3
+              # (baked) instead of jq.
+              set -euo pipefail
+
+              APP_ID="$(cat /github-app/app-id)"
+              b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+              now=$(date +%s)
+              hdr="$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | b64url)"
+              pld="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$((now-60))" "$((now+540))" "$APP_ID" | b64url)"
+              sig="$(printf '%s' "$hdr.$pld" | openssl dgst -sha256 -sign /github-app/app-private-key -binary | b64url)"
+              jwt="$hdr.$pld.$sig"
+
+              slug="$(printf '%s' "$(params.git-url)" | sed -E 's#https?://github.com/##; s#\.git$##')"
+              gh="https://api.github.com"
+              inst="$(curl -sf -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" "$gh/repos/$slug/installation" | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])')"
+              token="$(curl -sf -X POST -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" "$gh/app/installations/$inst/access_tokens" | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])')"
+
+              cd "$(workspaces.output.path)"
+              git clone "https://x-access-token:${token}@github.com/${slug}.git" .
+              git remote set-url origin "https://github.com/${slug}.git"   # drop the token from .git/config
+              [ -n "$(params.git-revision)" ] && git checkout "$(params.git-revision)" || true
+    - name: build
+      runAfter: [clone]
+      taskRef:
+        resolver: git
+        params:
+          - { name: url, value: 'https://github.com/NX211/homelab-infra.git' }
+          - { name: revision, value: main }
+          - { name: pathInRepo, value: build-catalog/tasks/build-image.yaml }
+      params:
+        - name: image
+          value: $(params.image)
+        - name: tag
+          value: $(params.git-revision)   # immutable: image tag = pushed commit SHA
+        - name: context
+          value: $(params.context)
+        - name: dockerfile
+          value: $(params.dockerfile)
+      workspaces:
+        - { name: source, workspace: source }
+        - { name: gcp-wif, workspace: gcp-wif }

--- a/build-targets/provisioning-engine/container-trusted.yaml
+++ b/build-targets/provisioning-engine/container-trusted.yaml
@@ -20,7 +20,7 @@ githubApp:
 # bitwarden-build-platform store and put its UUID here (see the activation runbook).
 webhook:
   store: bitwarden-build-platform
-  secretKey: REPLACE_WITH_WEBHOOK_SECRET_UUID       # PROVISIONING_ENGINE_TEKTON_WEBHOOK_SECRET
+  secretKey: 642b4aba-60b0-430c-a1f3-b494012cfd39   # PROVISIONING_ENGINE_TEKTON_WEBHOOK_SECRET
 
 # No signing block: container images are signed by Tekton Chains (cluster-side),
 # not by a channel keystore.

--- a/build-targets/provisioning-engine/container-trusted.yaml
+++ b/build-targets/provisioning-engine/container-trusted.yaml
@@ -1,0 +1,40 @@
+# Inventory entry: provisioning-engine control-plane container image (trusted tier).
+# Rendered by helm-charts/build-namespace via the build-targets ApplicationSet.
+# namespace -> provisioning-engine-builds-trusted ; pipeline SA ->
+# provisioning-engine-container-trusted (matches the WIF subject bound in
+# platform-infra #1069). The FIRST container-build channel (ADR-0020).
+project: provisioning-engine
+channel: container
+tier: trusted
+repo: Corey-Alan-Consulting/provisioning-engine
+runtimeClass: kata          # kaniko assembles layers as root; Kata microVM is the boundary
+
+# Shared org build App (Contents:read-only, H4) — same App as capturly; it must be
+# INSTALLED on the provisioning-engine repo. The clone step mints a ~1h token.
+githubApp:
+  store: bitwarden-build-platform
+  appIdKey: 98c21209-8551-447f-8897-b48d0154e6f7      # BUILD_APP_ID
+  privateKeyKey: f331c75a-a7fb-4631-8c6d-b48d0154e73b # BUILD_APP_PRIVATE_KEY
+
+# NEW per-repo HMAC the GitHub tag webhook signs with. Create this in the
+# bitwarden-build-platform store and put its UUID here (see the activation runbook).
+webhook:
+  store: bitwarden-build-platform
+  secretKey: REPLACE_WITH_WEBHOOK_SECRET_UUID       # PROVISIONING_ENGINE_TEKTON_WEBHOOK_SECRET
+
+# No signing block: container images are signed by Tekton Chains (cluster-side),
+# not by a channel keystore.
+
+# Keyless AR push: the pipeline SA impersonates provisioning-engine-push via the
+# homelab-staging WIF pool (platform-infra #1069).
+wif:
+  audience: //iam.googleapis.com/projects/861533890029/locations/global/workloadIdentityPools/homelab-staging/providers/k3s-oidc
+  impersonationUrl: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/provisioning-engine-push@coreyalan-provisioning.iam.gserviceaccount.com:generateAccessToken
+
+triggers:
+  # Public webhook sink: cert-manager LE/HTTP-01 (see the chart), DNS-only A record
+  # in platform-infra (coreyalan-dns.tf). Register this URL as the webhook on the repo.
+  host: tekton-trusted-provisioning-engine.coreyalan.com
+  tagPrefix: refs/tags/v          # git tag vX.Y.Z triggers a build of that commit
+  pipeline:
+    path: build-catalog/pipelines/container-build.yaml

--- a/helm-charts/build-namespace/templates/ingressroute.yaml
+++ b/helm-charts/build-namespace/templates/ingressroute.yaml
@@ -1,5 +1,25 @@
 {{- if and (eq .Values.tier "trusted") .Values.triggers.host }}
 ---
+# Public TLS cert for the webhook sink, issued by cert-manager via the
+# letsencrypt-prod ClusterIssuer (HTTP-01 through Traefik) — same pattern as the
+# PaC controller (tekton/pac/certificate.yaml) and authelia. GitHub verifies TLS
+# on delivery, so the default Traefik cert won't do. HTTP-01 works for any host
+# that resolves to the homelab public IP on :80, so no DNS-01 solver is needed;
+# it requires the {{ .Values.triggers.host }} A record (platform-infra Cloudflare,
+# DNS-only) to exist first.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.project }}-{{ .Values.channel }}-{{ .Values.tier }}-el-tls
+  namespace: {{ include "bn.namespace" . }}
+spec:
+  secretName: {{ .Values.project }}-{{ .Values.channel }}-{{ .Values.tier }}-el-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ .Values.triggers.host }}
+---
 # Exposes the EventListener sink so GitHub can POST the tag-push webhook. This is
 # the ONE inbound path to the build platform (the Dashboard is not deployed, §10)
 # and must be internet-reachable for GitHub. Guarded by the webhook HMAC (github
@@ -19,5 +39,6 @@ spec:
       services:
         - name: el-{{ .Values.project }}-{{ .Values.channel }}-{{ .Values.tier }}
           port: 8080
-  tls: {}
+  tls:
+    secretName: {{ .Values.project }}-{{ .Values.channel }}-{{ .Values.tier }}-el-tls
 {{- end }}


### PR DESCRIPTION
First in-cluster **container-image build channel**, extending the Tekton build platform (ADR-0017: web CI-checks + Android AABs only) to Dockerfile → Artifact Registry, keyless via WIF.

## What
- **`build-catalog/pipelines/container-build.yaml`** — App-token clone → `build-image` (kaniko, WIF push) → image tagged with the pushed commit SHA. Tekton Chains signs the digest.
- **`build-targets/provisioning-engine/container-trusted.yaml`** — inventory entry. Renders ns `provisioning-engine-builds-trusted` + SA `provisioning-engine-container-trusted` (exactly the WIF push subject bound in platform-infra #1069), EventListener, ExternalSecrets, trusted-egress netpol.
- **`helm-charts/build-namespace/templates/ingressroute.yaml`** — adds a cert-manager LE/HTTP-01 `Certificate` on the webhook sink so GitHub's TLS delivery succeeds (the default Traefik cert would be rejected). Mirrors the PaC controller pattern. Benefits capturly's trusted trigger too.
- **`build-catalog/images/clone-toolchain/Dockerfile`** — slim dedicated clone toolchain for later; the pipeline interim-pins the public android toolchain (same baked tools) until ghcr `write:packages` is available to push the slim one.

Renders clean via `helm template`; pipeline validated with `yq`.

## ⚠️ Draft — blocked on two inputs before merge
1. **Webhook secret UUID** — `container-trusted.yaml` has `REPLACE_WITH_WEBHOOK_SECRET_UUID`; create the per-repo HMAC in the `bitwarden-build-platform` store and fill its UUID.
2. **GitHub App install** — the shared build App must be installed on `Corey-Alan-Consulting/provisioning-engine` (new repo).

Paired with the platform-infra DNS record for `tekton-trusted-provisioning-engine.coreyalan.com`.