### PR TITLE
fix(traefik): let ACME HTTP-01 beat the :80 redirect (unblocks cert issuance)

### DIFF
--- a/argocd/applications/traefik.yaml
+++ b/argocd/applications/traefik.yaml
@@ -55,6 +55,13 @@ spec:
                 entryPoint:
                   to: websecure
                   scheme: https
+                  # Low priority so cert-manager's HTTP-01 solver Ingress (a
+                  # Host()+Path() router whose length-based priority is far higher)
+                  # wins for /.well-known/acme-challenge/* on :80. Without this the
+                  # catch-all redirect out-prioritizes the solver and every LE
+                  # HTTP-01 challenge 301s — breaking all cert issuance/renewal
+                  # (build-platform webhook sinks, and tekton-pac at its Sep renewal).
+                  priority: 10
           websecure:
             port: 8443
             hostPort: 443


### PR DESCRIPTION
## Root cause
The `web` (:80) entrypoint's catch-all HTTP→HTTPS redirect **out-prioritizes cert-manager's HTTP-01 solver Ingress**, so every Let's Encrypt HTTP-01 challenge on :80 gets `301`'d and no certificate can complete issuance or renewal.

**Proof:** curling Traefik's `web` entrypoint *directly* (no hairpin) on the exact `/.well-known/acme-challenge/<token>` path returns `301 Moved Permanently` instead of the solver token. The solver Ingress is otherwise correct (class `traefik`, Exact path, healthy endpoints).

This is why `provisioning-engine`'s and `capturly`'s trusted webhook-sink certs never issue (both `…-el-tls` secrets missing → Traefik logs repeated *"secret does not exist"*). `tekton-pac` is a survivor from before the redirect and will hit the same wall at its ~September renewal.

## Fix
Set the redirect `priority: 10`. cert-manager's solver router — `Host() && Path(/.well-known/acme-challenge/…)` — has a far higher length-based priority and now wins for the challenge path; all other :80 traffic still redirects to :443 unchanged. The only routers on :80 are this redirect and the transient ACME solvers, so blast radius is limited to letting HTTP-01 through.

Alternative considered: switch the `letsencrypt-prod` issuer to Cloudflare **DNS-01** (the zone now lives on Cloudflare). More robust long-term but a broader change to the shared issuer; this surgical priority fix keeps the platform's existing HTTP-01 standard.

After merge + sync I'll force-retry the pending challenges and the sink cert should go Ready.