### PR TITLE
fix(coredns): split-horizon the trusted webhook sink (finishes cert issuance)

### DIFF
--- a/coredns/configmap.yaml
+++ b/coredns/configmap.yaml
@@ -73,6 +73,9 @@ data:
     # cert-manager HTTP-01 self-check reaches Traefik instead of hairpinning to
     # the public IP; GitHub's external webhook still hits the public IP:443.
     10.43.5.100 tekton-pac.coreyalan.com
+    # Tekton trusted-tier EventListener webhook sinks (build platform) — same
+    # split-horizon reason as tekton-pac above (HTTP-01 self-check, not hairpin).
+    10.43.5.100 tekton-trusted-provisioning-engine.coreyalan.com
     10.43.5.100 sabnzbd.authoritah.tv
     10.43.5.100 jellyfin.authoritah.tv
     10.43.5.100 docs.authoritah.com


### PR DESCRIPTION
Second half of unblocking the sink cert (after #658 fixed the :80 redirect priority).

## Why
cert-manager's HTTP-01 **self-check** does `GET http://<host>/.well-known/acme-challenge/<token>` using the public FQDN. From inside the cluster that resolves to the homelab **public IP** and **hairpins** — NAT loopback is broken, so it times out (`context deadline exceeded`) and the challenge never completes.

`tekton-pac` already documents+works around exactly this with a split-horizon `hosts` entry → Traefik's ClusterIP `10.43.5.100`. Confirmed live: `tekton-pac.coreyalan.com` → `10.43.5.100` (internal), but `tekton-trusted-provisioning-engine.coreyalan.com` → `206.225.142.166` (public) → hairpin timeout.

## Fix
Add `10.43.5.100 tekton-trusted-provisioning-engine.coreyalan.com` to the CoreDNS hosts block. The self-check now reaches Traefik internally (where #658 lets it serve the token); GitHub's external webhook still hits the public IP:443 unchanged.

After merge+sync I'll reload CoreDNS, force-retry the challenge, and the cert should go Ready.