### PR TITLE
fix(build): trusted netpol — allow EventListener → Tekton interceptors :8443

### DIFF
--- a/helm-charts/build-namespace/templates/networkpolicy.yaml
+++ b/helm-charts/build-namespace/templates/networkpolicy.yaml
@@ -89,6 +89,15 @@ spec:
         - ipBlock: { cidr: {{ .Values.cluster.serviceCidr }} }
       ports:
         - { protocol: TCP, port: 443 }
+    # Tekton Triggers core interceptors (github HMAC + CEL) live in tekton-pipelines
+    # on :8443. The EventListener sink runs in this namespace under the blanket
+    # podSelector, so without this its interceptor call is dropped and no trigger
+    # ever fires (the PipelineRun is never created).
+    - to:
+        - namespaceSelector:
+            matchLabels: { kubernetes.io/metadata.name: tekton-pipelines }
+      ports:
+        - { protocol: TCP, port: 8443 }
     # Verdaccio npm registry proxy (in-cluster) — private-dep install, no token.
     - to:
         - namespaceSelector:


### PR DESCRIPTION
## Root cause
The trusted-tier egress `NetworkPolicy` (`podSelector: {}`) covers **every** pod in the build namespace — including the **EventListener sink** — but only allowed DNS, the kube-apiserver, the in-cluster serviceCidr:443, Verdaccio, and public :443. It did **not** allow the `tekton-pipelines` **core-interceptors** service on `:8443`, which the `github` (HMAC) and `cel` interceptors call. So every webhook that reached the sink was dropped at the interceptor step (`connection refused`) and **no PipelineRun was ever created**.

## Proof
A pod in the namespace connects to the interceptor ClusterIP:8443 at **t=0** (before k3s programs its netpol rules) but is **REFUSED** once the policy settles (~50s) — while the long-lived EL pod is always refused. That timing is why ephemeral `nc` probes looked reachable.

## Fix
Add an egress rule allowing the namespace to reach `tekton-pipelines` on `:8443`. This is the last gap in the trusted trigger path — it fixes `provisioning-engine` and `capturly`'s trusted EventListeners alike.

After merge+sync I'll redeliver the tag webhook and the first container build should fire.