### PR TITLE
fix(build): pin source-workspace storageClass (build PVC never bound)

### DIFF
--- a/helm-charts/build-namespace/templates/triggers.yaml
+++ b/helm-charts/build-namespace/templates/triggers.yaml
@@ -51,6 +51,9 @@ spec:
             volumeClaimTemplate:
               spec:
                 accessModes: ["ReadWriteOnce"]
+                # Required: local-path is NOT the cluster default SC, so an unset
+                # class leaves the PVC unbound (Immediate) and the pod never schedules.
+                storageClassName: {{ .Values.triggers.sourceWorkspaceStorageClass }}
                 resources: { requests: { storage: {{ .Values.triggers.sourceWorkspaceSize }} } }
 {{- if .Values.gradleCache.enabled }}
           - name: gradle-cache

--- a/helm-charts/build-namespace/values.yaml
+++ b/helm-charts/build-namespace/values.yaml
@@ -76,6 +76,7 @@ triggers:
   host: ""                    # tekton-trusted.<project>.example (public, webhook sink)
   tagPrefix: ""               # refs/tags/@capturly/mobile@
   sourceWorkspaceSize: 8Gi
+  sourceWorkspaceStorageClass: local-path   # local-path is not the default SC; unset never binds
   pipeline:                   # git-resolved channel pipeline (design §4)
     url: https://github.com/NX211/homelab-infra.git
     revision: main


### PR DESCRIPTION
## Root cause
The trusted `TriggerTemplate`'s `source` workspace `volumeClaimTemplate` specified no `storageClassName`. `local-path` is **not** the cluster's default StorageClass, so the PVC was created with an empty class → `Immediate` binding with no provisioner → **unbound forever**. The clone pod never schedules:

```
FailedScheduling: 0/4 nodes are available: pod has unbound immediate PersistentVolumeClaims
```

Same failure mode the chart's own `gradleCache` comment already warns about.

## Fix
Pin `storageClassName` on the source volumeClaimTemplate (new `triggers.sourceWorkspaceStorageClass`, default `local-path` — which is `WaitForFirstConsumer`, so it binds when the pod schedules). Fixes the trusted build path for provisioning-engine and capturly.

After merge+sync I'll re-trigger; the clone should bind and the kaniko build proceed.