### PR TITLE
fix(build): kaniko -debug image (step script needs a shell)

### DIFF
--- a/build-catalog/tasks/build-image.yaml
+++ b/build-catalog/tasks/build-image.yaml
@@ -40,7 +40,10 @@ spec:
       default: .
     - name: kaniko-image
       type: string
-      default: gcr.io/kaniko-project/executor:v1.23.2 # digest-pin in the inventory
+      # -debug: bundles /busybox/sh, which the step's `script` shebang needs. The
+      # non-debug executor image has no shell, so the script can't exec at all
+      # (fork/exec ...: no such file or directory). digest-pin in the inventory.
+      default: gcr.io/kaniko-project/executor:v1.23.2-debug
   workspaces:
     - name: source
     - name: gcp-wif # configmap: credential-config.json (external_account)


### PR DESCRIPTION
## Root cause
`build-image`'s step uses a `script:` with `#!/busybox/sh`, but the default image was the **non-debug** `gcr.io/kaniko-project/executor:v1.23.2`, which contains only the executor binary — **no shell**. Tekton writes the step script to `/tekton/scripts/script-0-*` and execs it; with no `/busybox/sh` interpreter the kernel can't exec it:

```
Error executing command: fork/exec /tekton/scripts/script-0-lrmg9: no such file or directory
```

## Fix
Default to the `-debug` variant, which bundles `/busybox/sh`.

## Where we are
The first real container build reached this step: **clone succeeded** (GitHub App-token clone of the private repo worked), and the root kaniko pod **was admitted and started** without kata — so the runtimeClass gap isn't a functional blocker. This shell fix should let kaniko actually build+push.

Task is git-resolved from `main`, so no ArgoCD sync — just merge and I re-trigger.