### PR TITLE
fix(build): restore kaniko CA bundle in SSL_CERT_DIR (TLS to AR)

### DIFF
--- a/build-catalog/tasks/build-image.yaml
+++ b/build-catalog/tasks/build-image.yaml
@@ -79,6 +79,13 @@ spec:
       env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /gcp/credential-config.json
+        # Tekton overrides the image's SSL_CERT_DIR (/kaniko/ssl/certs, where the
+        # kaniko CA bundle lives) with /tekton-custom-certs:/etc/ssl/certs:/etc/pki/
+        # tls/certs — none of which exist in the kaniko image — so Go loads zero CA
+        # roots and every registry TLS handshake fails "x509: unknown authority".
+        # Prepend kaniko's bundle dir back (keeping Tekton's custom-certs path).
+        - name: SSL_CERT_DIR
+          value: /kaniko/ssl/certs:/tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs
       script: |
         #!/busybox/sh
         set -eu


### PR DESCRIPTION
## Root cause
The kaniko build failed at the push permission check:
```
Get "https://us-central1-docker.pkg.dev/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority
```
Not a network or image-CA problem — **Tekton overrides the image's `SSL_CERT_DIR`**. The kaniko image sets `SSL_CERT_DIR=/kaniko/ssl/certs` (where its 200 KB CA bundle lives), but the build container gets `SSL_CERT_DIR=/tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs` — **none of those paths exist in the kaniko image**, so Go's cert loader finds zero roots and rejects every registry TLS cert.

That's why plain test pods (which keep the image's `SSL_CERT_DIR`) reached AR fine (`DENIED: Unauthenticated` = TLS OK) while the Tekton build pod failed.

## Fix
Prepend `/kaniko/ssl/certs` to `SSL_CERT_DIR` in the `build-image` step (keeping Tekton's `/tekton-custom-certs` for any org CA).

**Verified in a throwaway pod:** broken value → `unknown authority`; fixed value → `DENIED` (TLS verifies). Git-resolved Task — merge and I re-trigger.