### PR TITLE
feat(provisioning): run the channel-built engine image (digest-pinned)

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -38,7 +38,9 @@ spec:
           type: RuntimeDefault
       containers:
         - name: engine
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine:0.1.0
+          # Channel-built (Tekton container-build, tag v0.1.1 = commit e5c9bb7),
+          # digest-pinned. Replaces the initial one-off laptop `docker build`.
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:5f9d8aa904faef0062dae0aa94b970ea1896366c0300b71da12da9515e228f08
           ports:
             - containerPort: 9080
           env:

--- a/provisioning/examples/migrate-job.yaml
+++ b/provisioning/examples/migrate-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: migrate
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine:0.1.0
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:5f9d8aa904faef0062dae0aa94b970ea1896366c0300b71da12da9515e228f08
           command: ["./node_modules/.bin/prisma", "db", "push", "--skip-generate"]
           env:
             - name: DATABASE_URL


### PR DESCRIPTION
Graduates the provisioning-engine off the initial one-off **laptop `docker build`** (`engine:0.1.0`) onto the output of the new **Tekton container-build channel** (ADR-0020):

- Built **in-cluster** from tag `v0.1.1` (commit `e5c9bb7`) via kaniko → keyless WIF push to Artifact Registry.
- Digest-pinned: `engine@sha256:5f9d8aa904faef0062dae0aa94b970ea1896366c0300b71da12da9515e228f08`.

The engine's image supply chain is now fully reproducible and in-cluster — a `git tag` push rebuilds it. Updates `engine.yaml` (ArgoCD-synced) and the `migrate-job` example.

Same source as the running `0.1.0`, so functionally a no-op — this is the provenance graduation.