### PR TITLE
feat(provisioning): wire dns island — VO paths, Cloudflare creds, Verdaccio scope

### DIFF
--- a/build-catalog/pipelines/container-build.yaml
+++ b/build-catalog/pipelines/container-build.yaml
@@ -43,6 +43,7 @@ spec:
     - name: source
     - name: gcp-wif      # external_account WIF config → keyless AR push
     - name: github-app   # App key → ~1h clone token; no static git credential
+    - name: npmrc        # Verdaccio-proxy .npmrc → private @scope install, no token
   tasks:
     - name: clone
       workspaces:
@@ -50,11 +51,15 @@ spec:
           workspace: source
         - name: github-app
           workspace: github-app
+        - name: npmrc
+          workspace: npmrc
       taskSpec:
         workspaces:
           - name: output
           - name: github-app
             mountPath: /github-app
+          - name: npmrc
+            mountPath: /npmrc
         steps:
           - name: git-clone
             # Toolchain image (openssl + python3 + curl + git pre-baked) so the
@@ -85,6 +90,11 @@ spec:
               git clone "https://x-access-token:${token}@github.com/${slug}.git" .
               git remote set-url origin "https://github.com/${slug}.git"   # drop the token from .git/config
               [ -n "$(params.git-revision)" ] && git checkout "$(params.git-revision)" || true
+
+              # Drop the Verdaccio .npmrc into the build context so the Dockerfile's
+              # npm install resolves @corey-alan-consulting/* through the proxy (no
+              # token in the image). Optional — absent for public-only builds.
+              cp /npmrc/.npmrc "$(workspaces.output.path)/.npmrc" 2>/dev/null || true
     - name: build
       runAfter: [clone]
       taskRef:

--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -51,6 +51,18 @@ spec:
                   key: uri
             - name: RESTATE_ADMIN
               value: http://restate.restate.svc.cluster.local:9070
+            # Cloudflare (dns island). Read lazily at first reconcile, so the
+            # engine still boots if the secret isn't populated yet.
+            - name: CLOUDFLARE_API_TOKEN
+              valueFrom:
+                secretKeyRef: { name: provisioning-cloudflare, key: api-token }
+            - name: CLOUDFLARE_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef: { name: provisioning-cloudflare, key: account-id }
+            # Optional: when set, the dns island points the app hostname at this
+            # ingress. Unset = ensure the zone only (island handles absence).
+            # - name: PLATFORM_INGRESS_TARGET
+            #   value: staging-k8s.coreyalan.com
           resources:
             requests: { cpu: 25m, memory: 64Mi }
             limits: { cpu: 250m, memory: 256Mi }

--- a/provisioning/externalsecret-cloudflare.yaml
+++ b/provisioning/externalsecret-cloudflare.yaml
@@ -1,0 +1,28 @@
+---
+# Cloudflare API credentials for the provisioning-engine dns island. The island's
+# ensureZone CREATES zones, so this token needs account-level Zone:Create — broader
+# than external-dns's record-edit token, hence its own secret.
+#
+# ⚠️ TODO: create PROVISIONING_CLOUDFLARE_API_TOKEN (Zone:Create + DNS:Edit) and
+#    PROVISIONING_CLOUDFLARE_ACCOUNT_ID in the bitwarden-credentials project and set
+#    their UUIDs below.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: provisioning-cloudflare
+  namespace: provisioning
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-credentials
+    kind: ClusterSecretStore
+  target:
+    name: provisioning-cloudflare
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+  data:
+    - secretKey: api-token
+      remoteRef: { key: REPLACE_WITH_CLOUDFLARE_API_TOKEN_UUID }    # PROVISIONING_CLOUDFLARE_API_TOKEN
+    - secretKey: account-id
+      remoteRef: { key: REPLACE_WITH_CLOUDFLARE_ACCOUNT_ID_UUID }   # PROVISIONING_CLOUDFLARE_ACCOUNT_ID

--- a/provisioning/externalsecret-cloudflare.yaml
+++ b/provisioning/externalsecret-cloudflare.yaml
@@ -3,9 +3,11 @@
 # ensureZone CREATES zones, so this token needs account-level Zone:Create — broader
 # than external-dns's record-edit token, hence its own secret.
 #
-# ⚠️ TODO: create PROVISIONING_CLOUDFLARE_API_TOKEN (Zone:Create + DNS:Edit) and
-#    PROVISIONING_CLOUDFLARE_ACCOUNT_ID in the bitwarden-credentials project and set
-#    their UUIDs below.
+# ⚠️ TODO: create these two secrets by NAME in the bitwarden-secrets-manager
+#    project (2ae99c5f-e9d6-4b1d-8a12-b3d000254de6) — the same project holding
+#    DREAMHOST_TOKEN / GITEA_ADMIN_API_TOKEN:
+#      PROVISIONING_CLOUDFLARE_API_TOKEN   — account-scoped token (Zone:Create + DNS:Edit)
+#      PROVISIONING_CLOUDFLARE_ACCOUNT_ID  — the Cloudflare account id
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -14,7 +16,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-credentials
+    name: bitwarden-secrets-manager
     kind: ClusterSecretStore
   target:
     name: provisioning-cloudflare
@@ -23,6 +25,6 @@ spec:
       engineVersion: v2
   data:
     - secretKey: api-token
-      remoteRef: { key: REPLACE_WITH_CLOUDFLARE_API_TOKEN_UUID }    # PROVISIONING_CLOUDFLARE_API_TOKEN
+      remoteRef: { key: PROVISIONING_CLOUDFLARE_API_TOKEN }   # exact name in Bitwarden SM
     - secretKey: account-id
-      remoteRef: { key: REPLACE_WITH_CLOUDFLARE_ACCOUNT_ID_UUID }   # PROVISIONING_CLOUDFLARE_ACCOUNT_ID
+      remoteRef: { key: PROVISIONING_CLOUDFLARE_ACCOUNT_ID }  # exact name in Bitwarden SM

--- a/provisioning/externalsecret-cloudflare.yaml
+++ b/provisioning/externalsecret-cloudflare.yaml
@@ -25,6 +25,6 @@ spec:
       engineVersion: v2
   data:
     - secretKey: api-token
-      remoteRef: { key: PROVISIONING_CLOUDFLARE_API_TOKEN }   # exact name in Bitwarden SM
+      remoteRef: { key: 408adccc-5e4d-4a8d-9a26-b494015d7799 }   # PROVISIONING_CLOUDFLARE_API_TOKEN
     - secretKey: account-id
-      remoteRef: { key: PROVISIONING_CLOUDFLARE_ACCOUNT_ID }  # exact name in Bitwarden SM
+      remoteRef: { key: 97116b5e-a818-46ad-8469-b494015d86ca }   # PROVISIONING_CLOUDFLARE_ACCOUNT_ID

--- a/provisioning/webhook.yaml
+++ b/provisioning/webhook.yaml
@@ -1,6 +1,8 @@
 ---
-# Provisioning sync webhook — Phase 2a: submits the Tenant to the Restate engine
-# and mirrors the workflow's state into Tenant.status. Still ConfigMap-mounted /
+# Provisioning sync webhook — submits the Tenant to the Restate engine's
+# provisionTenant Virtual Object (reconcile) and mirrors its state (getStatus)
+# into Tenant.status. The 300s Metacontroller resync re-drives reconcile → drift
+# converges. Still ConfigMap-mounted /
 # zero-dependency (Node 22 global fetch). Graceful fallback: while the engine is
 # unbuilt/unregistered, Restate calls fail and the webhook reports phase Pending —
 # so this is safe to ship before the engine is live.
@@ -18,17 +20,19 @@ data:
     const WF = 'provisionTenant';
 
     async function driveRestate(id, spec) {
-      // Fire-and-forget submit (idempotent: re-submits to an existing workflow key
-      // are ignored by Restate). Then read the workflow's published state.
+      // Fire-and-forget reconcile on the Virtual Object keyed by id. Restate
+      // serializes calls per key, so the periodic drift resync and a spec-change
+      // sync never race; the reconcile is level-triggered (re-runs each call).
+      // Then read the object's published state via the shared getStatus handler.
       try {
-        await fetch(`${RESTATE}/${WF}/${encodeURIComponent(id)}/run/send`, {
+        await fetch(`${RESTATE}/${WF}/${encodeURIComponent(id)}/reconcile/send`, {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify(spec),
         });
       } catch { /* engine not up yet */ }
       try {
-        const r = await fetch(`${RESTATE}/${WF}/${encodeURIComponent(id)}/status`, { method: 'POST' });
+        const r = await fetch(`${RESTATE}/${WF}/${encodeURIComponent(id)}/getStatus`, { method: 'POST' });
         if (r.ok) return await r.json();
       } catch { /* fall through to Pending */ }
       return null;


### PR DESCRIPTION
Companion to **provisioning-engine#1** (dns island + Virtual Object).

- **webhook** → the `provisionTenant` **Virtual Object**: `reconcile/send` + `getStatus` (was workflow `run`/`status`). The 300s resync now re-drives `reconcile`, so drift converges.
- **engine env**: `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` from a new ESO `provisioning-cloudflare` (store `bitwarden-credentials`); read lazily so the engine still boots before the secret is populated. `PLATFORM_INGRESS_TARGET` left commented (island ensures the zone without it).
- **container-build**: mount the `npmrc` workspace and copy the Verdaccio `.npmrc` into the build context, so the engine image installs the restricted `@corey-alan-consulting/cloudflare` **through the trusted proxy** — no token in the build pod.

## ⚠️ Needs before it works end-to-end
1. Create **`PROVISIONING_CLOUDFLARE_API_TOKEN`** (Zone:Create + DNS:Edit) and **`PROVISIONING_CLOUDFLARE_ACCOUNT_ID`** in the `bitwarden-credentials` project → fill the two UUIDs in `provisioning/cloudflare-secret.yaml`.
2. Confirm the **`VERDACCIO_NPM_TOKEN`** uplink is populated (it powers `@corey-alan-consulting` proxying — same token the GH workflows use).
3. Merge engine#1 → tag a new `v*` → the channel rebuilds the engine with the cloudflare dep.

Then: apply a Tenant with a `domain` → the dns island ensures the Cloudflare zone and the drift resync keeps it converged.