### PR TITLE
fix(build): scoped-only npmrc for container-build (fixes @prisma/client ECONNRESET)

### DIFF
--- a/build-catalog/pipelines/container-build.yaml
+++ b/build-catalog/pipelines/container-build.yaml
@@ -91,10 +91,13 @@ spec:
               git remote set-url origin "https://github.com/${slug}.git"   # drop the token from .git/config
               [ -n "$(params.git-revision)" ] && git checkout "$(params.git-revision)" || true
 
-              # Drop the Verdaccio .npmrc into the build context so the Dockerfile's
-              # npm install resolves @corey-alan-consulting/* through the proxy (no
-              # token in the image). Optional — absent for public-only builds.
-              cp /npmrc/.npmrc "$(workspaces.output.path)/.npmrc" 2>/dev/null || true
+              # Drop a SCOPED-ONLY .npmrc into the build context: route only the
+              # private @scope through the Verdaccio proxy (no token in the image),
+              # leaving public deps (prisma, restate-sdk, …) on npmjs direct. The
+              # trusted tier has public egress; proxying large public tarballs
+              # through a cold Verdaccio cache is slow and flaky (ECONNRESET on
+              # @prisma/client). Keeping only the `@scope:registry=` line does that.
+              grep ':registry=' /npmrc/.npmrc > "$(workspaces.output.path)/.npmrc" 2>/dev/null || true
     - name: build
       runAfter: [clone]
       taskRef:


### PR DESCRIPTION
## Root cause
The v0.1.2 engine rebuild failed at `npm install`:
```
npm error ECONNRESET
npm error network request to http://verdaccio-trusted…/@prisma%2fclient failed, reason: socket hang up
```
The shared `.npmrc` sets a **global** `registry=<verdaccio>`, so *every* package — including large public ones like `@prisma/client` — is proxied through Verdaccio. That's required for the **untrusted** tier (no public egress), but for the **trusted** kaniko build it means pulling big public tarballs through a cold proxy cache, which is slow and reset-prone.

## Fix
In the container-build clone step, keep only the `@scope:registry=` line (`grep ':registry='`), dropping the global registry. Public deps then install **direct from npmjs** (the trusted tier has public egress — the way the v0.1.1 build worked), while the private `@corey-alan-consulting` scope still resolves through Verdaccio with **no token in the pod**.

Git-resolved pipeline — merge and I re-tag `v0.1.3` to rebuild.