### PR TITLE
feat(provisioning): run engine v0.1.3 (dns island + Virtual Object)

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -38,9 +38,10 @@ spec:
           type: RuntimeDefault
       containers:
         - name: engine
-          # Channel-built (Tekton container-build, tag v0.1.1 = commit e5c9bb7),
-          # digest-pinned. Replaces the initial one-off laptop `docker build`.
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:5f9d8aa904faef0062dae0aa94b970ea1896366c0300b71da12da9515e228f08
+          # Channel-built (Tekton container-build, tag v0.1.3 = commit 9e9907b) —
+          # dns island + Virtual Object reconcile, cloudflare via Verdaccio.
+          # digest-pinned.
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:4f1fe21ba1d01a6ef8f2e51023bc758878abba85f1a563e87e53e1aa769ef1e1
           ports:
             - containerPort: 9080
           env:

--- a/provisioning/examples/migrate-job.yaml
+++ b/provisioning/examples/migrate-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: migrate
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:5f9d8aa904faef0062dae0aa94b970ea1896366c0300b71da12da9515e228f08
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:4f1fe21ba1d01a6ef8f2e51023bc758878abba85f1a563e87e53e1aa769ef1e1
           command: ["./node_modules/.bin/prisma", "db", "push", "--skip-generate"]
           env:
             - name: DATABASE_URL


### PR DESCRIPTION
Points `engine.yaml` + the migrate Job at the channel-built **v0.1.3** image (`sha256:4f1fe21b`, tag `9e9907b`) — the first build carrying:
- the **dns island** (Cloudflare zone ensure via `@corey-alan-consulting/cloudflare`, installed through Verdaccio)
- the **Virtual Object** reconcile (`reconcile`/`getStatus`, level-triggered drift convergence)
- the `Domain`/`DnsRecord` schema

## After merge I drive
1. Run the **migrate Job** → creates `Domain`/`DnsRecord` (+ `Provisioning.domainId`)
2. **Re-register** the deployment with Restate (service is now a Virtual Object, not a workflow)
3. Apply a `Tenant` with a `domain` → the dns island ensures the Cloudflare zone; the 300s resync keeps it converged

Companion to engine tag v0.1.3; #665 (webhook→reconcile/getStatus, CF env) already merged.