### PR TITLE
feat(provisioning): run engine v0.1.4 (deterministic reconcile)

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -38,10 +38,10 @@ spec:
           type: RuntimeDefault
       containers:
         - name: engine
-          # Channel-built (Tekton container-build, tag v0.1.3 = commit 9e9907b) —
+          # Channel-built (Tekton container-build, tag v0.1.4 = commit 8171b8f) —
           # dns island + Virtual Object reconcile, cloudflare via Verdaccio.
           # digest-pinned.
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:4f1fe21ba1d01a6ef8f2e51023bc758878abba85f1a563e87e53e1aa769ef1e1
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:21f8d8c87598e9db8c3dc8c150459370f5da5909f8a760dc8b89a84c95b66eeb
           ports:
             - containerPort: 9080
           env:

--- a/provisioning/examples/migrate-job.yaml
+++ b/provisioning/examples/migrate-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: migrate
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:4f1fe21ba1d01a6ef8f2e51023bc758878abba85f1a563e87e53e1aa769ef1e1
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:21f8d8c87598e9db8c3dc8c150459370f5da5909f8a760dc8b89a84c95b66eeb
           command: ["./node_modules/.bin/prisma", "db", "push", "--skip-generate"]
           env:
             - name: DATABASE_URL


### PR DESCRIPTION
Pins `engine.yaml` + migrate Job at **v0.1.4** (`sha256:21f8d8c8`, tag `8171b8f`).

Fixes the Restate determinism error (RestateError 570) that stalled `reconcile` at `phase=Provisioning` — the VO now journals its timestamp via `ctx.run` so replays match (engine PR #2).

After merge I redeploy, then apply a `Tenant` with `domain: capturly.dev` to prove the dns island ensures the Cloudflare zone.