### PR TITLE
feat(provisioning): run engine v0.1.5 (status settles on Live)

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -38,10 +38,10 @@ spec:
           type: RuntimeDefault
       containers:
         - name: engine
-          # Channel-built (Tekton container-build, tag v0.1.4 = commit 8171b8f) —
+          # Channel-built (Tekton container-build, tag v0.1.5 = commit f896bcb) —
           # dns island + Virtual Object reconcile, cloudflare via Verdaccio.
           # digest-pinned.
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:21f8d8c87598e9db8c3dc8c150459370f5da5909f8a760dc8b89a84c95b66eeb
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:88d2f758fb2ddae0960c3252144a3287f1a803022f784a98a017fe50456677c1
           ports:
             - containerPort: 9080
           env:

--- a/provisioning/examples/migrate-job.yaml
+++ b/provisioning/examples/migrate-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: migrate
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:21f8d8c87598e9db8c3dc8c150459370f5da5909f8a760dc8b89a84c95b66eeb
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:88d2f758fb2ddae0960c3252144a3287f1a803022f784a98a017fe50456677c1
           command: ["./node_modules/.bin/prisma", "db", "push", "--skip-generate"]
           env:
             - name: DATABASE_URL


### PR DESCRIPTION
Pins the deploy at **v0.1.5** (`sha256:88d2f758`, tag `f896bcb`) — the reconcile publishes phase + conditions **once at the end**, so the Tenant settles on `Live` instead of flapping under the per-sync reconcile (engine PR #3).

After merge I roll the engine, confirm `capturly` holds `phase=Live / spine=OK / dns=OK` across resyncs, then tear down the `capturly.dev` test zone + purge the dead `acme` invocation. Closes the dns island.