### PR TITLE
chore(provisioning): pin engine to v0.1.6 (onboarding workflow)

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -38,15 +38,11 @@ spec:
           type: RuntimeDefault
       containers:
         - name: engine
-          # Channel-built (Tekton container-build). Live: v0.1.5 (commit f896bcb) —
-          # dns island + reconcile VO. tag v0.1.6 adds the provisionOnboarding
-          # workflow + GitOps Tenant CR commit; the /onboarding seam stays inert
-          # until this points at the v0.1.6 build. digest-pinned.
-          #
-          # TODO(v0.1.6): before this PR goes live, swap the digest below to the
-          # v0.1.6 build output, then re-run the restate-register job:
-          #   image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:<V0.1.6_DIGEST>
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:88d2f758fb2ddae0960c3252144a3287f1a803022f784a98a017fe50456677c1
+          # Channel-built (Tekton container-build, tag v0.1.6) — dns island +
+          # reconcile VO + provisionOnboarding workflow + GitOps Tenant CR commit.
+          # digest-pinned. After this syncs, re-run the restate-register job so
+          # Restate discovers provisionOnboarding.
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:9ede07bdf6ebb198fc721db928f61f31cbedd0e8c75c0154d7c7bdf343e22609
           ports:
             - containerPort: 9080
           env:


### PR DESCRIPTION
## Summary

Pins the provisioning engine to **v0.1.6** — the build that ships the `provisionOnboarding` workflow + GitOps Tenant CR commit, so the `/onboarding` seam merged in #673 becomes functional.

- Image: `engine@sha256:9ede07bdf6ebb198fc721db928f61f31cbedd0e8c75c0154d7c7bdf343e22609` (tag `v0.1.6`, channel-built)
- Was v0.1.5 (dns island + reconcile VO only)

## After merge / sync

Re-run the register job so Restate discovers the new service:

```
kubectl -n provisioning apply -f provisioning/examples/restate-register-job.yaml
```

(Adding `provisionOnboarding` alongside `provisionTenant` is a new service, so no `force:true` re-registration is needed.)
