### PR TITLE
feat(provisioning): wire email island (engine v0.1.7 + Mailgun ESO)

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -38,11 +38,11 @@ spec:
           type: RuntimeDefault
       containers:
         - name: engine
-          # Channel-built (Tekton container-build, tag v0.1.6) — dns island +
-          # reconcile VO + provisionOnboarding workflow + GitOps Tenant CR commit.
-          # digest-pinned. After this syncs, re-run the restate-register job so
-          # Restate discovers provisionOnboarding.
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:9ede07bdf6ebb198fc721db928f61f31cbedd0e8c75c0154d7c7bdf343e22609
+          # Channel-built (Tekton container-build, tag v0.1.7) — dns + email
+          # islands + reconcile VO + provisionOnboarding workflow + GitOps Tenant
+          # CR commit. digest-pinned. Re-run the migrate job (db push) after this
+          # syncs so the EmailDomain table lands.
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:77fd8170ea315457c786d539f24b92017c68109c7b6345e2a7adddff43d2e3bf
           ports:
             - containerPort: 9080
           env:
@@ -61,6 +61,18 @@ spec:
             - name: CLOUDFLARE_ACCOUNT_ID
               valueFrom:
                 secretKeyRef: { name: provisioning-cloudflare, key: account-id }
+            # Mailgun + field cipher (email island). optional:true so the engine
+            # boots before the secrets land; the island only needs them when a
+            # tenant with provisionEmail reconciles.
+            - name: MAILGUN_API_KEY
+              valueFrom:
+                secretKeyRef: { name: provisioning-mailgun, key: api-key, optional: true }
+            - name: MAILGUN_ADMIN_KEY
+              valueFrom:
+                secretKeyRef: { name: provisioning-mailgun, key: admin-key, optional: true }
+            - name: STAGING_ACCESS_SECRET
+              valueFrom:
+                secretKeyRef: { name: provisioning-mailgun, key: cipher-secret, optional: true }
             # Optional: when set, the dns island points the app hostname at this
             # ingress. Unset = ensure the zone only (island handles absence).
             # - name: PLATFORM_INGRESS_TARGET

--- a/provisioning/externalsecret-mailgun.yaml
+++ b/provisioning/externalsecret-mailgun.yaml
@@ -1,0 +1,33 @@
+---
+# Mailgun account credentials + the field-cipher secret for the email island.
+# createMailgunOps ensures a per-tenant Mailgun sending domain and encrypts the
+# per-domain sending key at rest with STAGING_ACCESS_SECRET.
+#
+# Created as PLACEHOLDERS in the bitwarden-secrets-manager "Workbench" project
+# (2ae99c5f) — set the real values in Bitwarden:
+#   MAILGUN_API_KEY / MAILGUN_ADMIN_KEY — copy from the app account's Mailgun secrets
+#   STAGING_ACCESS_SECRET — a strong random (openssl rand -hex 32). A fresh key is
+#     fine (engine has its own DB); match coreyalan's secret-box only if you later
+#     migrate existing EmailDomain ciphertext.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: provisioning-mailgun
+  namespace: provisioning
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: provisioning-mailgun
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+  data:
+    - secretKey: api-key
+      remoteRef: { key: 7a641504-a74e-4855-9fa5-b495002790c2 }   # MAILGUN_API_KEY
+    - secretKey: admin-key
+      remoteRef: { key: 3fe836b2-a3d4-4a78-93c1-b49500279104 }   # MAILGUN_ADMIN_KEY
+    - secretKey: cipher-secret
+      remoteRef: { key: c9e30e33-c063-40ea-86f7-b49500279156 }   # STAGING_ACCESS_SECRET


### PR DESCRIPTION
## Summary

Wires the **email island** (provisioning-engine #5) into the running control plane: pins the engine to **v0.1.7**, adds the Mailgun + field-cipher env, and the ESO that backs it.

- **Image:** `engine@sha256:77fd8170…43d2e3bf` (tag `v0.1.7`) — was v0.1.6. Adds the `email` island to the reconcile VO.
- **Engine env** (optional refs, so the engine boots before secrets land): `MAILGUN_API_KEY`, `MAILGUN_ADMIN_KEY`, `STAGING_ACCESS_SECRET`.
- **ESO** `provisioning-mailgun` → three Bitwarden "Workbench" secrets (created as **placeholders** — set the real values in Bitwarden before an email tenant reconciles).

The island only fires for tenants with `provisionEmail` + a domain, so this is non-breaking for everything else.

## Before it works end-to-end

1. **Set the real values in Bitwarden** (Workbench project): `MAILGUN_API_KEY` / `MAILGUN_ADMIN_KEY` (copy from the app account) and `STAGING_ACCESS_SECRET` (`openssl rand -hex 32`).
2. Merge → ArgoCD syncs (hard-refresh if needed) → engine rolls to v0.1.7.
3. **Re-run the migrate job** (`db push`) so the `EmailDomain` table + enums + `Provisioning.emailDomainId` land:
   `kubectl -n provisioning apply -f provisioning/examples/migrate-job.yaml`
4. No Restate re-register — the email island is part of `provisionTenant`, not a new service.
