### PR TITLE
chore(provisioning): pin engine to v0.1.8 (app + staging islands)

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -38,11 +38,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: engine
-          # Channel-built (Tekton container-build, tag v0.1.7) — dns + email
-          # islands + reconcile VO + provisionOnboarding workflow + GitOps Tenant
-          # CR commit. digest-pinned. Re-run the migrate job (db push) after this
-          # syncs so the EmailDomain table lands.
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:77fd8170ea315457c786d539f24b92017c68109c7b6345e2a7adddff43d2e3bf
+          # Channel-built (Tekton container-build, tag v0.1.8) — all five islands
+          # (spine/dns/email/app/staging) + reconcile VO + provisionOnboarding
+          # workflow + GitOps Tenant CR commit. digest-pinned. Re-run the migrate
+          # job (db push) after this syncs so AppOnboarding + StagingSite land. The
+          # app island also needs a GitHub App (actions:write) + PLATFORM_INFRA_REPO
+          # + ONBOARD_WORKFLOW_ID env before it can dispatch (see follow-up).
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:491ab4232bbd655e41b99fdff7062bb732c2b849fc57a722c4051a6fcd94da00
           ports:
             - containerPort: 9080
           env:


### PR DESCRIPTION
## Summary

Pins the engine to **v0.1.8** — all five reconcile islands (`spine`/`dns`/`email`/`app`/`staging`).

- Image: `engine@sha256:491ab423…da00` (tag `v0.1.8`, commit `eafe664`)
- Was v0.1.7 (spine/dns/email)

## After merge / sync

1. Re-run the migrate job (`db push`) so `AppOnboarding` + `StagingSite` + `Provisioning.appOnboardingId` land. **Override the stale digest** in `provisioning/examples/migrate-job.yaml` to the v0.1.8 image at apply time (the file still pins v0.1.5).
2. **Staging island** goes fully live (pure DB). **App island** is present but **inert** until wired: it needs a GitHub App with `actions: write` on the platform-infra repo + `PLATFORM_INFRA_REPO` (`owner/repo`) + `ONBOARD_WORKFLOW_ID` env (separate follow-up PR + ESO).
3. No Restate re-register — both are islands within `provisionTenant`.
