### PR TITLE
feat(provisioning): wire app island GitHub App (dispatch env + ESO)

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -95,6 +95,26 @@ spec:
               value: provisioning/tenants
             - name: TENANTS_BRANCH
               value: main
+            # App island — dispatches the GitHub Actions onboarding workflow.
+            # Needs a GitHub App with actions:write on PLATFORM_INFRA_REPO
+            # (distinct from the onboarding commit App). optional:true so the
+            # engine boots before the secrets land; the island only needs them
+            # when a tenant with appName+githubRepo reconciles.
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef: { name: provisioning-app, key: github-app-id, optional: true }
+            - name: GITHUB_APP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef: { name: provisioning-app, key: github-app-private-key, optional: true }
+            - name: GITHUB_APP_INSTALLATION_ID
+              valueFrom:
+                secretKeyRef: { name: provisioning-app, key: github-app-installation-id, optional: true }
+            - name: PLATFORM_INFRA_REPO
+              valueFrom:
+                secretKeyRef: { name: provisioning-app, key: platform-infra-repo, optional: true }
+            - name: ONBOARD_WORKFLOW_ID
+              valueFrom:
+                secretKeyRef: { name: provisioning-app, key: onboard-workflow-id, optional: true }
           resources:
             requests: { cpu: 25m, memory: 64Mi }
             limits: { cpu: 250m, memory: 256Mi }

--- a/provisioning/externalsecret-app.yaml
+++ b/provisioning/externalsecret-app.yaml
@@ -1,0 +1,37 @@
+---
+# App island credentials: a GitHub App (actions:write on PLATFORM_INFRA_REPO) the
+# island uses to dispatch the onboarding Actions workflow, plus the repo + workflow
+# id it targets. Distinct from the onboarding COMMIT App (contents:write) — this
+# one needs actions:write.
+#
+# Created as PLACEHOLDERS in the bitwarden-secrets-manager "Workbench" project
+# (2ae99c5f) — set the real values in Bitwarden:
+#   APP_ISLAND_GITHUB_APP_ID / _PRIVATE_KEY / _INSTALLATION_ID — the App's creds
+#   APP_ISLAND_PLATFORM_INFRA_REPO — "owner/repo" holding the onboarding workflow
+#   APP_ISLAND_ONBOARD_WORKFLOW_ID — the workflow file name or id (e.g. onboard.yml)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: provisioning-app
+  namespace: provisioning
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: provisioning-app
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+  data:
+    - secretKey: github-app-id
+      remoteRef: { key: a65882da-207d-42a8-ade3-b495002f79a3 }   # APP_ISLAND_GITHUB_APP_ID
+    - secretKey: github-app-private-key
+      remoteRef: { key: 03fb2723-4f1f-43ee-a3d6-b495002f7a4a }   # APP_ISLAND_GITHUB_APP_PRIVATE_KEY
+    - secretKey: github-app-installation-id
+      remoteRef: { key: cd7c71da-8544-40e8-b2ae-b495002f7a90 }   # APP_ISLAND_GITHUB_APP_INSTALLATION_ID
+    - secretKey: platform-infra-repo
+      remoteRef: { key: 62967f92-d33a-4e3e-8eda-b495002f7ad3 }   # APP_ISLAND_PLATFORM_INFRA_REPO
+    - secretKey: onboard-workflow-id
+      remoteRef: { key: 25f46fbe-297a-466c-99dd-b495002f7b15 }   # APP_ISLAND_ONBOARD_WORKFLOW_ID


### PR DESCRIPTION
## Summary

Activates the **app island** — the GitHub App it uses to dispatch the onboarding Actions workflow, plus the repo + workflow it targets.

- **Engine env** (optional refs, so the engine still boots before secrets land): `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_INSTALLATION_ID`, `PLATFORM_INFRA_REPO`, `ONBOARD_WORKFLOW_ID`.
- **ESO** `provisioning-app` → five Bitwarden "Workbench" secrets (created as **placeholders** — set the real values before an app tenant reconciles).

The GitHub App here needs **`actions: write`** on the platform-infra repo — distinct from the onboarding *commit* App (`contents: write`). It can be the same App with the extra permission, or a dedicated one.

## Before it works end-to-end

1. **Set the real values in Bitwarden** (Workbench): the App's `APP_ISLAND_GITHUB_APP_ID` / `_PRIVATE_KEY` / `_INSTALLATION_ID`, plus `APP_ISLAND_PLATFORM_INFRA_REPO` (`owner/repo`) and `APP_ISLAND_ONBOARD_WORKFLOW_ID` (e.g. `onboard.yml`).
2. Merge → ArgoCD syncs; the engine restarts with the env (no image change).

Non-breaking: the app island only fires for tenants with `appName` + `githubRepo`, and the refs are optional.
