### PR TITLE
fix(kratix): repoint kube-rbac-proxy to quay (gcr.io/kubebuilder sunset)

### DIFF
--- a/kratix/install.yaml
+++ b/kratix/install.yaml
@@ -1562,7 +1562,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
The vendored Kratix v0.125.0 install references `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0`, which Google pruned when it sunset `gcr.io/kubebuilder` — the operator pod's proxy sidecar hits `ErrImagePull: NotFound`. Repoints to the maintained mirror `quay.io/brancz/kube-rbac-proxy:v0.8.0` (same version, confirmed present). The operator image + webhook cert are fine; this is the only blocker to Kratix coming up.