### PR TITLE
feat(kratix): move state store to Corey-Alan-Consulting + keyless generator cred

### DIFF
--- a/kratix/config/externalsecret-app-key.yaml
+++ b/kratix/config/externalsecret-app-key.yaml
@@ -1,0 +1,20 @@
+---
+# The dedicated App's PEM for the GithubAccessToken generator.
+# TODO: set KRATIX_STATE_APP_PRIVATE_KEY (placeholder) in the Workbench project to
+# the App's private key (dedicated App on Corey-Alan-Consulting/kratix-state).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kratix-state-app-key
+  namespace: kratix-platform-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: kratix-state-app-key
+    creationPolicy: Owner
+  data:
+    - secretKey: privateKey
+      remoteRef: { key: 4fd187bc-4ffb-4d64-ba92-b495003d502a }  # KRATIX_STATE_APP_PRIVATE_KEY

--- a/kratix/config/externalsecret-git.yaml
+++ b/kratix/config/externalsecret-git.yaml
@@ -21,7 +21,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        username: "nx211"
+        username: "x-access-token"
         password: "{{ .token }}"
   data:
     - secretKey: token

--- a/kratix/config/externalsecret-git.yaml
+++ b/kratix/config/externalsecret-git.yaml
@@ -1,20 +1,15 @@
 ---
-# Git credentials for the Kratix state store (NX211/kratix-state). username is the
-# repo owner (literal); password is a fine-grained PAT with contents:write on that
-# repo.
-#
-# TODO: set KRATIX_STATE_GIT_TOKEN (placeholder) in the bitwarden-secrets-manager
-# "Workbench" project to a fine-grained PAT (contents:write on NX211/kratix-state).
+# Kratix state-store git credential — KEYLESS. Consumes the GithubAccessToken
+# generator (kratix-state-token): a scoped 1h App installation token, refreshed
+# every 40m (before the 1h expiry). username is x-access-token (GitHub App token
+# auth over HTTPS); password is the minted token. No long-lived secret.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: kratix-state-git
   namespace: kratix-platform-system
 spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: bitwarden-secrets-manager
-    kind: ClusterSecretStore
+  refreshInterval: 40m
   target:
     name: kratix-state-git
     creationPolicy: Owner
@@ -23,6 +18,9 @@ spec:
       data:
         username: "x-access-token"
         password: "{{ .token }}"
-  data:
-    - secretKey: token
-      remoteRef: { key: f2859e46-0bc5-4926-94f1-b49500364c0f }  # KRATIX_STATE_GIT_TOKEN
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: GithubAccessToken
+          name: kratix-state-token

--- a/kratix/config/generator-github.yaml
+++ b/kratix/config/generator-github.yaml
@@ -1,0 +1,21 @@
+---
+# Keyless state-store credential: mints a 1h GitHub App installation token scoped
+# to kratix-state (contents:write), refreshed before expiry — no static PAT.
+# TODO: after creating the dedicated App, fill appID + installID below.
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: GithubAccessToken
+metadata:
+  name: kratix-state-token
+  namespace: kratix-platform-system
+spec:
+  appID: "REPLACE_WITH_APP_ID"
+  installID: "REPLACE_WITH_INSTALL_ID"
+  repositories:
+    - kratix-state
+  permissions:
+    contents: write
+  auth:
+    privateKey:
+      secretRef:
+        name: kratix-state-app-key
+        key: privateKey

--- a/kratix/config/generator-github.yaml
+++ b/kratix/config/generator-github.yaml
@@ -8,8 +8,8 @@ metadata:
   name: kratix-state-token
   namespace: kratix-platform-system
 spec:
-  appID: "REPLACE_WITH_APP_ID"
-  installID: "REPLACE_WITH_INSTALL_ID"
+  appID: "4415431"
+  installID: "149595521"
   repositories:
     - kratix-state
   permissions:

--- a/kratix/config/gitstatestore.yaml
+++ b/kratix/config/gitstatestore.yaml
@@ -7,7 +7,7 @@ kind: GitStateStore
 metadata:
   name: default
 spec:
-  url: https://github.com/NX211/kratix-state
+  url: https://github.com/Corey-Alan-Consulting/kratix-state
   branch: main
   secretRef:
     name: kratix-state-git


### PR DESCRIPTION
## Summary

Two related changes to the Kratix state store:

1. **Move to `Corey-Alan-Consulting/kratix-state`** — it is platform/control-plane state (spans homelab + prod-GKE destinations) and belongs with `provisioning-engine` / `platform-infra`, not the homelab-cluster repo. Empty repo, nothing migrates.
2. **Keyless credential** — replaces the static PAT with an ESO **`GithubAccessToken` generator** (already installed on the cluster; no ESO upgrade needed). It mints a **1h GitHub App installation token scoped to `kratix-state` + `contents:write`**, refreshed every 40m. No long-lived secret.

- `generator-github.yaml` — the `GithubAccessToken` generator (appID/installID to fill).
- `externalsecret-app-key.yaml` — the App PEM via ESO (Bitwarden placeholder `KRATIX_STATE_APP_PRIVATE_KEY`).
- `externalsecret-git.yaml` — now consumes the generator (`username: x-access-token`, `password` = the minted token).

## Before it works (your part)

1. Create a **dedicated GitHub App** under Corey-Alan-Consulting: `contents: write`, installed on **only** `kratix-state`. Generate a private key.
2. Set **`KRATIX_STATE_APP_PRIVATE_KEY`** in the Workbench project to that PEM.
3. Give me the App **appID + installID** and I will fill them into `generator-github.yaml`.

(The old `KRATIX_STATE_GIT_TOKEN` PAT placeholder is now unused — safe to delete in Bitwarden.)
