### PR TITLE
feat(kratix): periodic Tenant drift re-reconcile CronJob

### DIFF
--- a/kratix/config/drift-reconcile.yaml
+++ b/kratix/config/drift-reconcile.yaml
@@ -1,0 +1,84 @@
+---
+# Periodic drift re-reconcile for Tenants — the safety net that replaces the old
+# Metacontroller 300s resync. Kratix reconciles on spec change (the common case);
+# this CronJob every 15 min sets kratix.io/manual-reconciliation on each Tenant so
+# Kratix re-runs the reconcile pipeline, catching external drift (e.g. a deleted
+# Cloudflare zone) that never changes the spec. Kratix clears the label after.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kratix-tenant-drift
+  namespace: kratix-platform-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kratix-tenant-drift
+  namespace: provisioning
+rules:
+  - apiGroups: ["platform.coreyalan.com"]
+    resources: ["tenants"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kratix-tenant-drift
+  namespace: provisioning
+subjects:
+  - kind: ServiceAccount
+    name: kratix-tenant-drift
+    namespace: kratix-platform-system
+roleRef:
+  kind: Role
+  name: kratix-tenant-drift
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kratix-tenant-drift-reconcile
+  namespace: kratix-platform-system
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 300
+      template:
+        spec:
+          serviceAccountName: kratix-tenant-drift
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: trigger
+              image: registry.k8s.io/kubectl:v1.31.1
+              command: ["kubectl"]
+              args:
+                - -n
+                - provisioning
+                - label
+                - tenants
+                - --all
+                - kratix.io/manual-reconciliation=true
+                - --overwrite
+              env:
+                - name: HOME
+                  value: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}


### PR DESCRIPTION
Adds the periodic drift safety net that the L3.3 fold left as a follow-up — the equivalent of Metacontroller old 300s resync.

Kratix reconciles a Tenant on spec change (proven). This CronJob (every 15 min) sets the kratix.io/manual-reconciliation label on every Tenant so Kratix re-runs the reconcile pipeline even when nothing changed — catching external drift (e.g. a deleted Cloudflare zone). Kratix clears the label after each run.

- SA + Role (patch tenants in provisioning) + RoleBinding + CronJob, PSA-restricted (non-root uid 65532, readOnlyRootFilesystem, drop ALL).
- registry.k8s.io/kubectl:v1.31.1, verified runs non-root.
- 15 min is looser than 300s on purpose (reconcile-on-change handles the common case; this is drift-only). Tune the schedule as needed.