### PR TITLE
fix(kratix): resolve status.conditions clash (Kratix vs island data)

### DIFF
--- a/kratix/promises/managed-hosting/promise.yaml
+++ b/kratix/promises/managed-hosting/promise.yaml
@@ -103,7 +103,12 @@ spec:
                       description: Set true to run the teardown/compensation saga (GDPR-erasure path).
                       default: false
                 status:
+                  # Permissive: Kratix owns status.conditions (standard k8s
+                  # conditions like PipelineCompleted); the adapter writes island
+                  # state to status.islands. preserve-unknown-fields lets both
+                  # coexist — our old strict conditions schema clashed with Kratix.
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                   properties:
                     provisioningId:
                       type: string
@@ -113,28 +118,6 @@ spec:
                       enum: [Pending, Provisioning, Live, Partial, Failed, Decommissioned]
                     observedGeneration:
                       type: integer
-                    conditions:
-                      type: array
-                      description: One entry per island (spine/dns/email/app/staging).
-                      items:
-                        type: object
-                        required: [island, status]
-                        properties:
-                          island:
-                            type: string
-                            enum: [spine, dns, email, app, staging]
-                          status:
-                            type: string
-                            enum: [Pending, Running, OK, Skipped, Failed]
-                          attempt:
-                            type: integer
-                          detail:
-                            type: string
-                          lastError:
-                            type: string
-                          lastTransitionTime:
-                            type: string
-                            format: date-time
   workflows:
     resource:
       configure:
@@ -169,6 +152,6 @@ spec:
                       "$RESTATE/provisionTenant/$KEY/getStatus" || echo '{}')
                     mkdir -p /kratix/metadata
                     printf '%s' "$STATUS" | KEY="$KEY" GEN="$GEN" yq -P \
-                      '{"provisioningId": env(KEY), "observedGeneration": (env(GEN)|tonumber), "phase": (.phase // "Pending"), "conditions": (.conditions // [])}' \
+                      '{"provisioningId": env(KEY), "observedGeneration": (env(GEN)|tonumber), "phase": (.phase // "Pending"), "islands": (.conditions // [])}' \
                       > /kratix/metadata/status.yaml
                     echo "tenant/$KEY: reconcile dispatched + status published"

--- a/provisioning/tenant-crd.yaml
+++ b/provisioning/tenant-crd.yaml
@@ -92,7 +92,11 @@ spec:
                   description: Set true to run the teardown/compensation saga (GDPR-erasure path).
                   default: false
             status:
+              # Permissive: Kratix (the L3 driver) owns status.conditions (standard
+              # k8s conditions); the Promise adapter writes island state to
+              # status.islands. preserve-unknown-fields lets both coexist.
               type: object
+              x-kubernetes-preserve-unknown-fields: true
               properties:
                 provisioningId:
                   type: string
@@ -102,25 +106,3 @@ spec:
                   enum: [Pending, Provisioning, Live, Partial, Failed, Decommissioned]
                 observedGeneration:
                   type: integer
-                conditions:
-                  type: array
-                  description: One entry per island (spine/dns/email/app/staging).
-                  items:
-                    type: object
-                    required: [island, status]
-                    properties:
-                      island:
-                        type: string
-                        enum: [spine, dns, email, app, staging]
-                      status:
-                        type: string
-                        enum: [Pending, Running, OK, Skipped, Failed]
-                      attempt:
-                        type: integer
-                      detail:
-                        type: string
-                      lastError:
-                        type: string
-                      lastTransitionTime:
-                        type: string
-                        format: date-time


### PR DESCRIPTION
The drift test surfaced a real bug from the L3.3 fold. Kratix writes standard k8s conditions (PipelineCompleted, status=False) into **status.conditions**, but our Tenant CRD repurposed status.conditions for **island** conditions (required island + OK/Skipped/... enum). Kratix status write fails validation every reconcile -> hot error loop. capturly stayed Live (Restate does the real work), but the status-write errored ~every 40s.

## Fix
- Give Kratix status.conditions; the adapter now writes island state to **status.islands**.
- status made permissive (x-kubernetes-preserve-unknown-fields) so Kratix conditions + our islands coexist.
- Applied to both the Promise embedded CRD and provisioning/tenant-crd.yaml (they co-manage the CRD, kept exact-match).

Safe: nothing reads status.conditions now that Metacontroller is retired. **Merge to stop the loop** — then Kratix status writes succeed, capturly gets status.islands + Kratix conditions.