### PR TITLE
feat(port): k8s exporter for the spine (Tenant CRs -> Port)

### DIFF
--- a/argocd/applications/port-k8s-exporter-eso.yaml
+++ b/argocd/applications/port-k8s-exporter-eso.yaml
@@ -1,0 +1,29 @@
+---
+# Port creds ExternalSecret for the k8s exporter (from the Workbench BWS project).
+# Split from the Helm app so the credential Secret lands before the exporter pod.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: port-k8s-exporter-secret
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: HEAD
+    path: port-k8s-exporter
+    directory:
+      recurse: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: port-k8s-exporter
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/applications/port-k8s-exporter.yaml
+++ b/argocd/applications/port-k8s-exporter.yaml
@@ -1,0 +1,111 @@
+---
+# Port Kubernetes exporter (L4 spine ingest) — reads the Tenant CRs on this
+# homelab cluster and maps them into the platform-spine blueprints in Port
+# (tenant/domain/emailDomain/appOnboarding, defined as code in platform-infra).
+# Keyed on the opaque provisioningId, never the client email.
+#
+# createDefaultResources=false: the spine blueprints already exist (managed by
+# the Port TF provider); this exporter only populates them from the Tenant CRs.
+# General k8s workload cataloging + the homelab app list are separate follow-ups
+# (extend this mapping / a homelab ArgoCD integration).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: port-k8s-exporter
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://port-labs.github.io/helm-charts
+    chart: port-k8s-exporter
+    targetRevision: "0.3.28"
+    helm:
+      valuesObject:
+        image:
+          tag: "0.7.5" # pin (Kyverno disallow-latest-tag)
+        # Port API host for this account (default is api.getport.io).
+        portBaseUrl: https://api.port.io
+        stateKey: homelab-k8s
+        createDefaultResources: false
+        secret:
+          useExistingSecret: true
+          name: port-k8s-exporter # ESO-managed (Workbench Port creds)
+        configMap:
+          create: true
+          config: |
+            resources:
+              # tenant — the spine root (identifier = opaque provisioningId)
+              - kind: platform.coreyalan.com/v1alpha1/tenants
+                selector:
+                  query: "true"
+                port:
+                  entity:
+                    mappings:
+                      - identifier: .status.provisioningId // .metadata.uid
+                        title: .spec.appName // .spec.domain // .metadata.name
+                        blueprint: '"tenant"'
+                        properties:
+                          phase: .status.phase
+                          blueprint_version: .spec.blueprint
+                          provision_email: .spec.provisionEmail
+                        relations:
+                          domain: .spec.domain
+                          email_domain: .spec.emailDomainName
+                          app_onboarding: .status.provisioningId // .metadata.uid
+              # domain — only tenants that provision one
+              - kind: platform.coreyalan.com/v1alpha1/tenants
+                selector:
+                  query: .spec.domain != null
+                port:
+                  entity:
+                    mappings:
+                      - identifier: .spec.domain
+                        title: .spec.domain
+                        blueprint: '"domain"'
+                        properties:
+                          registrar: .spec.registrar
+                          status: .status.phase
+              # emailDomain — only tenants with email provisioning
+              - kind: platform.coreyalan.com/v1alpha1/tenants
+                selector:
+                  query: .spec.emailDomainName != null
+                port:
+                  entity:
+                    mappings:
+                      - identifier: .spec.emailDomainName
+                        title: .spec.emailDomainName
+                        blueprint: '"emailDomain"'
+                        properties:
+                          region: .spec.emailRegion
+                          provider: '"mailgun"'
+              # appOnboarding — only tenants with an app (relations to the
+              # GitHub/ArgoCD ingests; best-effort identifier match)
+              - kind: platform.coreyalan.com/v1alpha1/tenants
+                selector:
+                  query: .spec.appName != null
+                port:
+                  entity:
+                    mappings:
+                      - identifier: .status.provisioningId // .metadata.uid
+                        title: .spec.appName
+                        blueprint: '"appOnboarding"'
+                        properties:
+                          github_repo: .spec.githubRepo
+                          hostname: .spec.appHostname
+                          staging_url: .spec.stagingBaseUrl
+                        relations:
+                          github_repository: .spec.githubRepo
+                          argocd_application: .spec.appName
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: port-k8s-exporter
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/port-k8s-exporter/externalsecret.yaml
+++ b/port-k8s-exporter/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# Port API creds for the k8s exporter, from the "Workbench" BWS project (the
+# same org-level Port pair the GKE-side integrations use). Key names match what
+# the port-k8s-exporter chart's useExistingSecret expects (PORT_CLIENT_ID /
+# PORT_CLIENT_SECRET). Secret name = the Helm release name so the chart finds it.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: port-k8s-exporter
+  namespace: port-k8s-exporter
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: port-k8s-exporter
+    creationPolicy: Owner
+  data:
+    - secretKey: PORT_CLIENT_ID
+      remoteRef: { key: 43007afc-7e58-49b0-9b16-b4950127753c } # PORT_CLIENT_ID (Workbench)
+    - secretKey: PORT_CLIENT_SECRET
+      remoteRef: { key: b4effd61-ae6d-4928-9911-b49501279406 } # PORT_CLIENT_SECRET (Workbench)


### PR DESCRIPTION
Spine ingest for L4 — the Port Kubernetes exporter that reads the `Tenant` CRs on this homelab cluster and populates the platform-spine blueprints (`tenant`/`domain`/`emailDomain`/`appOnboarding`, defined as code in platform-infra).

## What it does
`port-k8s-exporter` v0.7.5 (chart 0.3.28), self-hosted on homelab where the `Tenant` CRs live. One `Tenant` CR maps into up to four spine entities via JQ, keyed on the opaque **provisioningId** (never the client email):

- `tenant` → phase, blueprint, provisionEmail; relations to domain / emailDomain / appOnboarding
- `domain` (if `spec.domain`) → registrar, status
- `emailDomain` (if `spec.emailDomainName`) → region, provider
- `appOnboarding` (if `spec.appName`) → githubRepo, hostname, stagingUrl; relations to `githubRepository` / `argocdApplication`

## Notes
- Creds via ESO from the **Workbench** BWS project (the new `PORT_CLIENT_ID`/`PORT_CLIENT_SECRET`); secret name = release name for the chart's `useExistingSecret`.
- `createDefaultResources: false` — the spine blueprints already exist (Port TF); this only fills them. `portBaseUrl: api.port.io`. Image pinned `0.7.5` (Kyverno).
- The mapping lives inline in the exporter's ConfigMap (GitOps here), so no separate Port-TF part.

## Verify on first sync
- The chart's `useExistingSecret` resolves the secret name to `port-k8s-exporter` (release name).
- Multiple `resources` entries for the same `kind` (one per spine blueprint) are honored.
- The live `capturly` Tenant produces a `tenant` + `domain` entity in Port.
- Homelab Kyverno (registry allowlist / probes) doesn't block the GHCR image.

General k8s workload cataloging and the homelab app-list monitoring (via a homelab ArgoCD integration) are separate follow-ups.
