### PR TITLE
fix(port): make tenant->appOnboarding relation conditional on appName

### DIFF
--- a/argocd/applications/port-k8s-exporter.yaml
+++ b/argocd/applications/port-k8s-exporter.yaml
@@ -55,7 +55,11 @@ spec:
                         relations:
                           domain: .spec.domain
                           email_domain: .spec.emailDomainName
-                          app_onboarding: .status.provisioningId // .metadata.uid
+                          # Only relate when the tenant actually has an app —
+                          # else it points at a non-existent appOnboarding entity
+                          # (that entity is created only when .spec.appName is set)
+                          # and Port rejects the tenant upsert (404 dangling relation).
+                          app_onboarding: (if .spec.appName then (.status.provisioningId // .metadata.uid) else null end)
               # domain — only tenants that provision one
               - kind: platform.coreyalan.com/v1alpha1/tenants
                 selector:


### PR DESCRIPTION
First sync of the k8s exporter worked — pod healthy, ESO synced, `domain: capturly.dev` created — but the **tenant** entity failed:

```
Entity "38cb9062…" does not exist in the blueprint "appOnboarding"
```

The tenant mapping always set `app_onboarding` to the provisioningId, but the `appOnboarding` entity is only created when `.spec.appName` is set. Appless tenants (like capturly) dangled the relation → Port 404'd the tenant upsert.

Fix: gate the relation — `(if .spec.appName then (.status.provisioningId // .metadata.uid) else null end)`. After merge, the tenant entity upserts cleanly.