### PR TITLE
feat(port): homelab ArgoCD integration (monitor homelab apps)

### DIFF
--- a/argocd/applications/port-ocean-argocd-eso.yaml
+++ b/argocd/applications/port-ocean-argocd-eso.yaml
@@ -1,0 +1,30 @@
+---
+# Creds ExternalSecret for the homelab Ocean ArgoCD integration. Split from the
+# Helm app so the Secret lands before the exporter pod. (Named -eso, not
+# -secret, because the repo .gitignore blocks *-secret.yaml.)
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: port-ocean-argocd-eso
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: HEAD
+    path: port-ocean-argocd
+    directory:
+      recurse: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: port-ocean-argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/applications/port-ocean-argocd.yaml
+++ b/argocd/applications/port-ocean-argocd.yaml
@@ -1,0 +1,66 @@
+---
+# Homelab Ocean ArgoCD integration — catalogs THIS cluster's ArgoCD Applications
+# (sync status / health / deploy history) into Port. Clone of the GKE one
+# (Corey-Alan-Consulting/platform-infra), pointed at the homelab argocd-server.
+# Distinct integration identifier (argocd-homelab) and UID-based entity ids mean
+# no collision with the GKE argocdApplication entities (e.g. cert-manager exists
+# on both clusters).
+#
+# In-cluster over the internal service; argocd-server runs --insecure so it's
+# plain HTTP and bypasses SSO (token auth straight to the API). Read-only token
+# (port-ocean-user) + Port creds via ESO (Workbench). Probes disabled (the chart
+# hardcodes /health/live which the image 404s -> CrashLoopBackOff otherwise).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: port-ocean-argocd
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://port-labs.github.io/helm-charts
+    chart: port-ocean
+    targetRevision: "0.22.0"
+    helm:
+      releaseName: port-ocean-argocd
+      valuesObject:
+        port:
+          baseUrl: https://api.port.io
+        secret:
+          create: false
+          name: port-ocean-argocd-creds
+        initializePortResources: true
+        sendRawDataExamples: true
+        scheduledResyncInterval: 360
+        livenessProbe:
+          enabled: false
+        readinessProbe:
+          enabled: false
+        integration:
+          type: argocd
+          identifier: argocd-homelab
+          version: "0.1.96" # pin (Kyverno disallow-latest-tag)
+          eventListener:
+            type: POLLING
+          config:
+            serverUrl: http://argocd-server.argocd.svc.cluster.local
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 300m
+            memory: 512Mi
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: port-ocean-argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -19,6 +19,9 @@ argo-cd:
       timeout.reconciliation: 180s
       # Enable API key generation for admin account
       accounts.admin: apiKey, login
+      # Read-only account for the Port Ocean ArgoCD integration (token minted for
+      # it, stored via ESO). Granted role:readonly below — never admin.
+      accounts.port-ocean-user: apiKey
       # Argo ships no built-in health assessment for the CloudNativePG Cluster
       # CR, so the `postgresql` app perpetually reported "Unknown" health even
       # while the database was up. This Lua check reads the CR's `Ready`
@@ -100,6 +103,12 @@ argo-cd:
         jqPathExpressions:
           - .spec.selector
           - .spec.template.metadata.labels
+
+    rbac:
+      # Grant the Port integration account read-only access (admin stays admin;
+      # no policy.default change so other accounts are unaffected).
+      policy.csv: |
+        g, port-ocean-user, role:readonly
 
     params:
       # Run server without TLS (Traefik handles TLS termination)

--- a/port-ocean-argocd/externalsecret.yaml
+++ b/port-ocean-argocd/externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# Creds for the homelab Ocean ArgoCD integration, from the "Workbench" BWS
+# project. Port API creds are the same org-level pair the k8s exporter uses; the
+# ArgoCD API token is a read-only homelab port-ocean-user token. Keys are the
+# exact env-var names the exporter reads (mounted via envFrom; secret.create=false).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: port-ocean-argocd-creds
+  namespace: port-ocean-argocd
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: port-ocean-argocd-creds
+    creationPolicy: Owner
+  data:
+    - secretKey: OCEAN__PORT__CLIENT_ID
+      remoteRef: { key: 43007afc-7e58-49b0-9b16-b4950127753c } # PORT_CLIENT_ID (Workbench)
+    - secretKey: OCEAN__PORT__CLIENT_SECRET
+      remoteRef: { key: b4effd61-ae6d-4928-9911-b49501279406 } # PORT_CLIENT_SECRET (Workbench)
+    # TODO(user): after this PR merges, generate a token for the read-only
+    # port-ocean-user on the homelab ArgoCD, store it in the Workbench BWS project
+    # (e.g. HOMELAB_ARGOCD_TOKEN), and replace this placeholder UUID.
+    - secretKey: OCEAN__INTEGRATION__CONFIG__TOKEN
+      remoteRef: { key: REPLACE-WITH-HOMELAB-ARGOCD-TOKEN-UUID } # HOMELAB_ARGOCD_TOKEN (Workbench)


### PR DESCRIPTION
Monitors the homelab cluster's ArgoCD Applications (your ~50-app list) in Port — sync status, health, deploy history. A clone of the GKE ArgoCD integration, pointed at the homelab `argocd-server`.

## Why this (not the k8s exporter)
Your list is ArgoCD Applications; the ArgoCD integration is the right tool for their sync/health. Homelab `argocdApplication` entities key on **UID**, so they don't collide with the GKE entities even where the same app runs on both clusters (`cert-manager`, `external-secrets-operator`, …). Distinct integration identifier `argocd-homelab`.

## How it authenticates
- In-cluster → `http://argocd-server.argocd.svc` (homelab argocd-server runs `--insecure`, so plain HTTP, bypassing SSO).
- **Read-only account** added to the argocd values: `accounts.port-ocean-user: apiKey` + `g, port-ocean-user, role:readonly` (admin stays admin; no `policy.default` change).
- Token + Port creds via ESO from the **Workbench** BWS project. Probes disabled (chart 404s `/health/live`); image pinned `0.1.96`.

## Your two steps to finish it
1. **Merge this PR** → the read-only `port-ocean-user` account is created on the homelab ArgoCD.
2. **Generate a token for it** and store it in Workbench, then give me the secret UUID:
   ```
   argocd account generate-token --account port-ocean-user   # against the homelab ArgoCD
   ```
   Put it in the Workbench BWS project (e.g. `HOMELAB_ARGOCD_TOKEN`) and I'll replace the `REPLACE-WITH-HOMELAB-ARGOCD-TOKEN-UUID` placeholder in the ExternalSecret. Until then the integration deploys but 401s (harmless).
