### PR TITLE
fix(port): wire the homelab ArgoCD read-only token

### DIFF
--- a/port-ocean-argocd/externalsecret.yaml
+++ b/port-ocean-argocd/externalsecret.yaml
@@ -21,8 +21,6 @@ spec:
       remoteRef: { key: 43007afc-7e58-49b0-9b16-b4950127753c } # PORT_CLIENT_ID (Workbench)
     - secretKey: OCEAN__PORT__CLIENT_SECRET
       remoteRef: { key: b4effd61-ae6d-4928-9911-b49501279406 } # PORT_CLIENT_SECRET (Workbench)
-    # TODO(user): after this PR merges, generate a token for the read-only
-    # port-ocean-user on the homelab ArgoCD, store it in the Workbench BWS project
-    # (e.g. HOMELAB_ARGOCD_TOKEN), and replace this placeholder UUID.
+    # Read-only port-ocean-user token for the homelab ArgoCD.
     - secretKey: OCEAN__INTEGRATION__CONFIG__TOKEN
-      remoteRef: { key: REPLACE-WITH-HOMELAB-ARGOCD-TOKEN-UUID } # HOMELAB_ARGOCD_TOKEN (Workbench)
+      remoteRef: { key: b9a99882-d4ba-4f1b-bb40-b4950136236e } # HOMELAB_ARGOCD_TOKEN (Workbench)


### PR DESCRIPTION
Replaces the placeholder with the real Workbench `HOMELAB_ARGOCD_TOKEN` UUID (read-only `port-ocean-user` token generated after #690). After merge, the homelab ArgoCD integration authenticates and starts cataloging your homelab apps into Port (as `argocd-homelab`, UID-keyed so no collision with the GKE entities). I'll verify + set their `environment: staging` via the port_integration mapping.