### PR TITLE
feat(provisioning): expose the decommission seam + dry-run CRD field

### DIFF
--- a/kratix/promises/managed-hosting/promise.yaml
+++ b/kratix/promises/managed-hosting/promise.yaml
@@ -102,6 +102,10 @@ spec:
                       type: boolean
                       description: Set true to run the teardown/compensation saga (GDPR-erasure path).
                       default: false
+                    decommissionDryRun:
+                      type: boolean
+                      description: With decommissioned, reconcile only reports what it would delete (no external delete or DB mutation); phase settles on DecommissionPlanned.
+                      default: false
                 status:
                   # Permissive: Kratix owns status.conditions (standard k8s
                   # conditions like PipelineCompleted); the adapter writes island

--- a/provisioning/ingressroute.yaml
+++ b/provisioning/ingressroute.yaml
@@ -17,10 +17,11 @@ spec:
   dnsNames:
     - provisioning.coreyalan.com
 ---
-# The ONE public inbound path to the control plane: PathPrefix(/onboarding) only,
-# so the unauthenticated /sync hook (Metacontroller, in-cluster) is never exposed.
-# Guarded by the constant-time bearer check in the webhook — coreyalan.com's
-# producers + wizard present the shared token. Raw Restate ingress stays private.
+# The only public inbound paths to the control plane: PathPrefix(/onboarding) and
+# PathPrefix(/decommission), so the unauthenticated /sync hook (Metacontroller,
+# in-cluster) is never exposed. Both are guarded by the constant-time bearer check
+# in the webhook — coreyalan.com's producers + wizard present the shared token.
+# Raw Restate ingress stays private.
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
@@ -30,7 +31,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`provisioning.coreyalan.com`) && PathPrefix(`/onboarding`)
+    - match: Host(`provisioning.coreyalan.com`) && (PathPrefix(`/onboarding`) || PathPrefix(`/decommission`))
       kind: Rule
       services:
         - name: provisioning-webhook

--- a/provisioning/tenant-crd.yaml
+++ b/provisioning/tenant-crd.yaml
@@ -91,6 +91,10 @@ spec:
                   type: boolean
                   description: Set true to run the teardown/compensation saga (GDPR-erasure path).
                   default: false
+                decommissionDryRun:
+                  type: boolean
+                  description: With decommissioned, reconcile only reports what it would delete (no external delete or DB mutation); phase settles on DecommissionPlanned.
+                  default: false
             status:
               # Permissive: Kratix (the L3 driver) owns status.conditions (standard
               # k8s conditions); the Promise adapter writes island state to
@@ -103,6 +107,6 @@ spec:
                   description: Opaque, stable id — the Restate saga key. Never the email.
                 phase:
                   type: string
-                  enum: [Pending, Provisioning, Live, Partial, Failed, Decommissioned]
+                  enum: [Pending, Provisioning, Live, Partial, Failed, DecommissionPlanned, Decommissioned]
                 observedGeneration:
                   type: integer

--- a/provisioning/webhook.yaml
+++ b/provisioning/webhook.yaml
@@ -20,6 +20,7 @@ data:
     const RESTATE = process.env.RESTATE_INGRESS ?? 'http://restate.restate.svc.cluster.local:8080';
     const RECONCILE = 'provisionTenant';
     const ONBOARDING = 'provisionOnboarding';
+    const DECOMMISSION = 'provisionDecommission';
     const SEAM_TOKEN = process.env.ONBOARDING_BEARER_TOKEN ?? '';
 
     async function driveRestate(id, spec) {
@@ -58,9 +59,10 @@ data:
       };
     }
 
-    // Onboarding seam — the ONE public inbound path (PathPrefix(/onboarding) in the
-    // IngressRoute; /sync stays cluster-internal). coreyalan.com's producers +
-    // wizard call these; the engine's Restate ingress stays private behind them.
+    // Onboarding + decommission seams — the public inbound paths (PathPrefix
+    // /onboarding + /decommission in the IngressRoute; /sync stays cluster-internal).
+    // coreyalan.com's producers + wizard call these; the engine's Restate ingress
+    // stays private behind them.
 
     // Constant-time bearer check. Closed-by-default: no token configured => reject,
     // so the seam is shut until the shared secret is mounted.
@@ -97,7 +99,18 @@ data:
       }
     }
 
+    // Teardown seam — commit a decommissioned Tenant CR via the engine's git
+    // handoff (ArgoCD -> Metacontroller -> reconcile teardown). Synchronous so
+    // the caller gets { ok, tenant, dryRun, commitUrl } back. Business plane owns
+    // the spec (same one it onboarded with); dryRun defaults off.
+    async function decommissionRoute(payload) {
+      const spec = payload.spec ?? {};
+      if (!spec.email) return { status: 400, text: JSON.stringify({ error: 'missing spec.email' }) };
+      return restateCall(DECOMMISSION, 'decommission', { spec, dryRun: Boolean(payload.dryRun) });
+    }
+
     const ONBOARDING_ROUTES = new Set(['/onboarding/start', '/onboarding/state', '/onboarding/submit']);
+    const GUARDED_ROUTES = new Set([...ONBOARDING_ROUTES, '/decommission']);
 
     function readJsonBody(req, res, handler) {
       let body = '';
@@ -115,9 +128,11 @@ data:
     const server = createServer((req, res) => {
       if (req.method === 'GET' && req.url === '/healthz') { res.writeHead(200).end('ok'); return; }
 
-      if (req.method === 'POST' && ONBOARDING_ROUTES.has(req.url)) {
+      if (req.method === 'POST' && GUARDED_ROUTES.has(req.url)) {
         if (!authorized(req)) { res.writeHead(401, { 'content-type': 'application/json' }).end(JSON.stringify({ error: 'unauthorized' })); return; }
-        readJsonBody(req, res, (payload) => onboardingRoute(req.url, payload));
+        readJsonBody(req, res, (payload) =>
+          req.url === '/decommission' ? decommissionRoute(payload) : onboardingRoute(req.url, payload),
+        );
         return;
       }
 


### PR DESCRIPTION
## What

The k8s-native surface + public seam for tenant teardown. Companion to the engine's `provisionDecommission` service (provisioning-engine #8).

## Changes

- **Tenant CRD + Kratix Promise embedded CRD** — add `spec.decommissionDryRun` (plan-only teardown: reconcile reports what it *would* delete and mutates nothing) and add `DecommissionPlanned` to the `status.phase` enum so the dry-run phase validates. Both copies kept in lockstep.
- **`webhook.yaml`** — new bearer-guarded `/decommission` route → forwards `{ spec, dryRun }` to `provisionDecommission` (synchronous; returns `{ ok, tenant, dryRun, commitUrl }`). Same constant-time bearer check as the onboarding seam; **closed by default** until the shared token is mounted.
- **`ingressroute.yaml`** — expose `PathPrefix(/decommission)` alongside `/onboarding` on the one public host; the unauthenticated `/sync` hook stays cluster-internal.

## Flow

`/decommission` (bearer) → `provisionDecommission` commits a `decommissioned: true` CR → ArgoCD `tenants` app syncs → Metacontroller drives the reconcile VO → islands tear down in reverse order. A human removes the CR file as the final `prune:false` step.

## Sequencing

Merge after provisioning-engine #8 is deployed so the `provisionDecommission` service the route targets actually exists (the route degrades to a Restate 404 until then — same graceful pattern as the onboarding seam before the engine was live). Then W4 proves it on the capturly fixture.
