### PR TITLE
chore(provisioning): deploy engine v0.1.9 (island teardowns + decommission)

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -38,13 +38,15 @@ spec:
           type: RuntimeDefault
       containers:
         - name: engine
-          # Channel-built (Tekton container-build, tag v0.1.8) — all five islands
-          # (spine/dns/email/app/staging) + reconcile VO + provisionOnboarding
-          # workflow + GitOps Tenant CR commit. digest-pinned. Re-run the migrate
-          # job (db push) after this syncs so AppOnboarding + StagingSite land. The
-          # app island also needs a GitHub App (actions:write) + PLATFORM_INFRA_REPO
-          # + ONBOARD_WORKFLOW_ID env before it can dispatch (see follow-up).
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:491ab4232bbd655e41b99fdff7062bb732c2b849fc57a722c4051a6fcd94da00
+          # Channel-built (Tekton container-build, tag v0.1.9) — all five islands
+          # (spine/dns/email/app/staging) with reverse-order TEARDOWN + reconcile
+          # VO + provisionOnboarding + provisionDecommission + GitOps Tenant CR
+          # commit. digest-pinned. RE-REGISTER Restate after this syncs (apply
+          # examples/restate-register-job.yaml) so provisionDecommission + the
+          # updated provisionTenant are discoverable. The app island also needs a
+          # GitHub App (actions:write) + PLATFORM_INFRA_REPO + ONBOARD_WORKFLOW_ID
+          # (and ONBOARD_TEARDOWN_WORKFLOW_ID for app teardown) before it dispatches.
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:60ec3f698e9ee3cb79290decda296453639d9fba377b280b1667d9b720c2d174
           ports:
             - containerPort: 9080
           env:


### PR DESCRIPTION
## What

Deploys the tenant-teardown engine. Bumps the digest-pinned `provisioning-engine` image to the **v0.1.9** build (`sha256:60ec3f69…`, main `614601146`), which contains:

- **W2** — reverse-order `TEARDOWN` across all five islands (spine deleted last, phase gating, dry-run) + the repo's first test suite (28 tests).
- **W3** — the `provisionDecommission` service + `decommissioned`/`decommissionDryRun` CR flags.

## Post-sync (manual, required)

The engine image built via `v0.1.9` (Tekton tag trigger). After ArgoCD rolls the new pod:

```
kubectl -n provisioning apply -f provisioning/examples/restate-register-job.yaml
```

Re-registers the endpoint with Restate so `provisionDecommission` + the updated `provisionTenant` handlers are discoverable (Restate updates the deployment on re-register; re-runnable).

## Next

Once deployed + registered, W4 proves teardown on the capturly fixture (dry-run → `DecommissionPlanned`, then real → `capturly.dev` zone + rows gone).
