### PR TITLE
feat(port): ingest Tekton PipelineRuns into the build blueprint

### DIFF
--- a/argocd/applications/port-k8s-exporter.yaml
+++ b/argocd/applications/port-k8s-exporter.yaml
@@ -37,6 +37,10 @@ spec:
         configMap:
           create: true
           config: |
+            # Dangling build->repository relations create a stub githubRepository
+            # (identifier = repo name) that the GitHub integration later merges,
+            # so a build never fails to ingest for an un-cataloged repo.
+            createMissingRelatedEntities: true
             resources:
               # tenant — the spine root (identifier = opaque provisioningId)
               - kind: platform.coreyalan.com/v1alpha1/tenants
@@ -104,6 +108,32 @@ spec:
                         relations:
                           github_repository: .spec.githubRepo
                           argocd_application: .spec.appName
+              # build — Tekton PipelineRuns across the *-builds-{trusted,untrusted}
+              # namespaces. Handles both trusted (Tekton Triggers: git-url/git-revision
+              # spec params) and untrusted (PaC: sha/url annotations) runs.
+              - kind: tekton.dev/v1/pipelineruns
+                selector:
+                  query: "true"
+                port:
+                  entity:
+                    mappings:
+                      - identifier: .metadata.uid
+                        title: .metadata.name
+                        blueprint: '"build"'
+                        properties:
+                          status: .status.conditions[0].reason
+                          succeeded: (.status.conditions[0].status == "True")
+                          pipeline: .metadata.labels["tekton.dev/pipeline"]
+                          namespace: .metadata.namespace
+                          commit: ((.spec.params // [] | map(select(.name == "git-revision")) | .[0].value) // .metadata.annotations["pipelinesascode.tekton.dev/sha"])
+                          git_url: ((.spec.params // [] | map(select(.name == "git-url")) | .[0].value) // .metadata.annotations["pipelinesascode.tekton.dev/repo-url"])
+                          triggered_by: (.metadata.labels["triggers.tekton.dev/eventlistener"] // .metadata.labels["pipelinesascode.tekton.dev/repository"] // "manual")
+                          started_at: .status.startTime
+                          completed_at: .status.completionTime
+                        relations:
+                          # PaC exposes the repo name directly (url-repository label);
+                          # Tekton Triggers runs derive it from the git-url param.
+                          repository: (.metadata.labels["pipelinesascode.tekton.dev/url-repository"] // (((.spec.params // [] | map(select(.name == "git-url")) | .[0].value) // "") | sub("\\.git$"; "") | split("/") | last))
   destination:
     server: https://kubernetes.default.svc
     namespace: port-k8s-exporter


### PR DESCRIPTION
Adds a `tekton.dev/v1/pipelineruns` mapping to the homelab `port-k8s-exporter`, populating the `build` blueprint (platform-infra #1091) — so your Tekton builds (container / nextjs / android channels, trusted + untrusted) finally show in Port.

**Per build:** status, succeeded (bool), pipeline/channel, commit, git_url, namespace, triggered_by, start/complete times → related to its `githubRepository`.

Handles both trigger types: **Tekton Triggers** (trusted — `git-url`/`git-revision` params) and **PaC** (untrusted — `repo-url`/`sha` annotations, `url-repository` label). `createMissingRelatedEntities` so a build for an un-cataloged repo stubs+merges rather than failing to ingest. jq validated against real trusted (`provisioning-engine`) and PaC (`capturly.app`) runs.

**Merge platform-infra #1091 first** (the blueprint must exist before the exporter upserts into it).