### PR TITLE
feat(port): label runtime Argo apps with part-of service ids

### DIFF
--- a/argocd/applications/provisioning.yaml
+++ b/argocd/applications/provisioning.yaml
@@ -8,6 +8,8 @@ kind: Application
 metadata:
   name: provisioning
   namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: provisioning-engine
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
     argocd.argoproj.io/compare-options: ServerSideDiff=true

--- a/argocd/applications/staging-blue-skysolutions-com.yaml
+++ b/argocd/applications/staging-blue-skysolutions-com.yaml
@@ -8,6 +8,8 @@ metadata:
   # line up without per-app special cases.
   name: staging-blue-skysolutions-com
   namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: blue-skysolutions-com
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/applications/staging-capturly-web.yaml
+++ b/argocd/applications/staging-capturly-web.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: staging-capturly-web
   namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: capturly-app
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/applications/staging-coreyalan-com.yaml
+++ b/argocd/applications/staging-coreyalan-com.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: staging-coreyalan-com
   namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: coreyalan-com
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/applications/staging-dispatchr-social.yaml
+++ b/argocd/applications/staging-dispatchr-social.yaml
@@ -9,6 +9,8 @@ metadata:
   # caused staging-promote.yml to poll a non-existent Application forever.
   name: staging-dispatchr-social
   namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: dispatchr-social
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   # Note: the previous `notifications.argoproj.io/subscribe.*` and

--- a/argocd/applications/staging-jlshaw-link.yaml
+++ b/argocd/applications/staging-jlshaw-link.yaml
@@ -8,6 +8,8 @@ metadata:
   # line up without per-app special cases.
   name: staging-jlshaw-link
   namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: jlshaw-link
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
Adds `app.kubernetes.io/part-of: <service-id>` to the 6 runtime Applications on the homelab cluster so the Port Ocean ArgoCD exporter can relate `argocdApplication` → `service`:

| Argo app | service |
|---|---|
| staging-capturly-web | capturly-app |
| staging-coreyalan-com | coreyalan-com |
| staging-dispatchr-social | dispatchr-social |
| staging-blue-skysolutions-com | blue-skysolutions-com |
| staging-jlshaw-link | jlshaw-link |
| provisioning | provisioning-engine |

Excluded: `nightingale` (not a tracked service), Tekton build-namespace apps (covered by the `build` blueprint), and the capturly-live stack (labels land after #616 merges). Companion PR labels the GKE prod apps.