### PR TITLE
fix(security): trivy-operator controller limits + vuln-only scanning

### DIFF
--- a/argocd/applications/trivy-operator.yaml
+++ b/argocd/applications/trivy-operator.yaml
@@ -30,6 +30,21 @@ spec:
           scanJobsConcurrentLimit: 1
           # Rescan weekly, not the 24h default.
           scannerReportTTL: "168h"
+          # Vulnerability reports are the only signal we consume; policy
+          # compliance is kyverno's job.
+          configAuditScannerEnabled: false
+          rbacAssessmentScannerEnabled: false
+          infraAssessmentScannerEnabled: false
+          clusterComplianceEnabled: false
+        # Controller pod resources (kyverno require-resource-limits parity
+        # with prod, where the policy is enforced).
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
         trivy:
           resources:
             requests:


### PR DESCRIPTION
Parity with the prod fix (Corey-Alan-Consulting/platform-infra#1095): controller pod requests/limits (kyverno `require-resource-limits` parity — enforced on prod, audit here) and config-audit/RBAC/infra/compliance scanners disabled, leaving only vulnerability scanning — the one signal the Port scorecard consumes.