### PR TITLE
fix(security): label trivy scan-job pods (require-labels parity with prod)

### DIFF
--- a/argocd/applications/trivy-operator.yaml
+++ b/argocd/applications/trivy-operator.yaml
@@ -36,6 +36,10 @@ spec:
           rbacAssessmentScannerEnabled: false
           infraAssessmentScannerEnabled: false
           clusterComplianceEnabled: false
+        trivyOperator:
+          # Parity with prod: kyverno require-labels demands
+          # app.kubernetes.io/name on every Pod (string form, not a map).
+          scanJobPodTemplateLabels: "app.kubernetes.io/name:trivy-scan-job"
         # Controller pod resources (kyverno require-resource-limits parity
         # with prod, where the policy is enforced).
         resources:


### PR DESCRIPTION
Parity with Corey-Alan-Consulting/platform-infra#1098: injects `app.kubernetes.io/name: trivy-scan-job` on scan-job pods via `trivyOperator.scanJobPodTemplateLabels` (string form). Kyverno is audit-mode here so scans weren't blocked, but the same policy exists.