### PR TITLE
fix(build): stop verdaccio OOM crashloop (1Gi limit + explicit node heap)

### DIFF
--- a/build-registry-proxy/verdaccio.yaml
+++ b/build-registry-proxy/verdaccio.yaml
@@ -58,6 +58,8 @@ spec:
           ports: [{ containerPort: 4873, name: http }]
           env:
             - { name: VERDACCIO_PORT, value: "4873" }
+            # Node caps old-space ~256MB by default; installs OOM'd the pod.
+            - { name: NODE_OPTIONS, value: "--max-old-space-size=768" }
             - name: NPM_TOKEN
               valueFrom: { secretKeyRef: { name: verdaccio-npm-uplink, key: npm-token } }
           volumeMounts:
@@ -65,7 +67,7 @@ spec:
             - { name: storage, mountPath: /verdaccio/storage }
           resources:
             requests: { cpu: 50m, memory: 128Mi }
-            limits: { cpu: "1", memory: 512Mi }
+            limits: { cpu: "1", memory: 1Gi }
           readinessProbe:
             httpGet: { path: /-/ping, port: 4873 }
             initialDelaySeconds: 5
@@ -104,6 +106,8 @@ spec:
           ports: [{ containerPort: 4873, name: http }]
           env:
             - { name: VERDACCIO_PORT, value: "4873" }
+            # Node caps old-space ~256MB by default; installs OOM'd the pod.
+            - { name: NODE_OPTIONS, value: "--max-old-space-size=768" }
             - name: NPM_TOKEN
               valueFrom: { secretKeyRef: { name: verdaccio-npm-uplink, key: npm-token } }
           volumeMounts:
@@ -111,7 +115,7 @@ spec:
             - { name: storage, mountPath: /verdaccio/storage }
           resources:
             requests: { cpu: 50m, memory: 128Mi }
-            limits: { cpu: "1", memory: 512Mi }
+            limits: { cpu: "1", memory: 1Gi }
           readinessProbe:
             httpGet: { path: /-/ping, port: 4873 }
             initialDelaySeconds: 5


### PR DESCRIPTION
`verdaccio-trusted` has been in CrashLoopBackOff for ~2 days (found while trying to install `@corey-alan-consulting/*` locally): Node's default old-space heap (~256MB under the 512Mi limit) OOMs during package installs — `FATAL ERROR: Reached heap limit Allocation failed`. That takes the **trusted build channel** down: provisioning-engine container builds can't npm install right now.

Both instances: memory limit 512Mi → 1Gi and explicit `NODE_OPTIONS=--max-old-space-size=768` so the heap cap is deliberate rather than inferred.