### PR TITLE
feat(provisioning): sentry DSN env for the engine

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -58,6 +58,13 @@ spec:
                   key: uri
             - name: RESTATE_ADMIN
               value: http://restate.restate.svc.cluster.local:9070
+            # Error tracking (Port operational_readiness Gold signal). DSN is a
+            # public client key; inert until an engine image with the sentry
+            # init ships (provisioning-engine#10).
+            - name: SENTRY_DSN
+              value: https://3fc73fa33407a09fee6fbd768b5cd773@o4511020580995072.ingest.us.sentry.io/4511819698995200
+            - name: SENTRY_ENVIRONMENT
+              value: production
             # Cloudflare (dns island). Read lazily at first reconcile, so the
             # engine still boots if the secret isn't populated yet.
             - name: CLOUDFLARE_API_TOKEN


### PR DESCRIPTION
Wires `SENTRY_DSN` + `SENTRY_ENVIRONMENT=production` into the engine Deployment. The DSN is a public client key (safe in git); the env is inert until an engine image containing the sentry init (Corey-Alan-Consulting/provisioning-engine#10) is tagged, built, and digest-bumped here.

Once that image ships and sends its first event, Port mints `provisioning-engine-production` and the service's last Gold guard (`sentry_project_environments > 0`) is satisfiable.