### PR TITLE
chore(provisioning): deploy engine v0.1.11 (sentry error tracking)

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -38,7 +38,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: engine
-          # Channel-built (Tekton container-build, tag v0.1.10) — all five islands
+          # Channel-built (Tekton container-build, tag v0.1.11) — v0.1.10 islands
+          # + sentry error tracking behind SENTRY_DSN. All five islands
           # (spine/dns/email/app/staging) with reverse-order TEARDOWN (Registrar
           # zones retained, teardown retries bounded) + reconcile VO +
           # provisionOnboarding + provisionDecommission + GitOps Tenant CR commit.
@@ -47,7 +48,7 @@ spec:
           # updated provisionTenant are discoverable. The app island also needs a
           # GitHub App (actions:write) + PLATFORM_INFRA_REPO + ONBOARD_WORKFLOW_ID
           # (and ONBOARD_TEARDOWN_WORKFLOW_ID for app teardown) before it dispatches.
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:d57363a15cd06cdc5540df2223eaf96a8b341574a572c94aa472026b35b60c34
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:3d20e8cbd33caa579718db705863cfb96795541b3427abb5b65abed137787d6a
           ports:
             - containerPort: 9080
           env:


### PR DESCRIPTION
Digest-bump to the v0.1.11 trusted-channel build (`sha256:3d20e8cb…`), which adds the conditional sentry init (Corey-Alan-Consulting/provisioning-engine#10). The `SENTRY_DSN`/`SENTRY_ENVIRONMENT` envs from #703 are already on the Deployment, so this rollout activates error tracking.

Registry note: the AR image is tagged with the annotated-tag object SHA (`411d2e98…`) rather than the commit — the digest is what matters and is pinned here; future releases should use lightweight tags so image tags match commit SHAs.

No Restate re-registration needed — handler surface is unchanged (init only).