### PR TITLE
fix(security): scan-job label string uses key=value, not key:value

### DIFF
--- a/argocd/applications/trivy-operator.yaml
+++ b/argocd/applications/trivy-operator.yaml
@@ -39,7 +39,7 @@ spec:
         trivyOperator:
           # Parity with prod: kyverno require-labels demands
           # app.kubernetes.io/name on every Pod (string form, not a map).
-          scanJobPodTemplateLabels: "app.kubernetes.io/name:trivy-scan-job"
+          scanJobPodTemplateLabels: "app.kubernetes.io/name=trivy-scan-job"
         # Controller pod resources (kyverno require-resource-limits parity
         # with prod, where the policy is enforced).
         resources:


### PR DESCRIPTION
Parity with Corey-Alan-Consulting/platform-infra#1101 (or current number): the operator parses `scanJob.podTemplateLabels` as `key=value` pairs; the colon form made every workload reconcile error.