### PR TITLE
fix(security): clear the provisioning namespace's 46 critical CVEs

### DIFF
--- a/kratix/config/kratix-config.yaml
+++ b/kratix/config/kratix-config.yaml
@@ -1,0 +1,16 @@
+---
+# KratixConfig (read from kratix-platform-system/kratix key "config" at
+# controller startup — restart the controller-manager after changing).
+# numberOfJobsToKeep: 1 keeps a single completed workflow job per resource
+# instead of the default 5 — the drift-reconcile CronJob spawns a pipeline
+# pod every 15 min, and each retained completed pod drags the pipeline
+# adapter image's CVEs into the provisioning namespace's trivy reports
+# (5 pods x 6 criticals gated provisioning-engine's Gold).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kratix
+  namespace: kratix-platform-system
+data:
+  config: |
+    numberOfJobsToKeep: 1

--- a/provisioning/control-db.yaml
+++ b/provisioning/control-db.yaml
@@ -11,7 +11,10 @@ metadata:
   namespace: provisioning
 spec:
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  # Pinned minor on the current "system" image line (legacy-compatible layout,
+  # Debian trixie packages). The floating :16 tag had frozen on an ancient
+  # bullseye digest whose 15 criticals were all fix:NONE in-distro.
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.11-system-trixie
   storage:
     size: 2Gi
     storageClass: local-path

--- a/provisioning/webhook.yaml
+++ b/provisioning/webhook.yaml
@@ -178,7 +178,9 @@ spec:
           type: RuntimeDefault
       containers:
         - name: webhook
-          image: node:22-alpine
+          # Digest-pinned: the floating tag had frozen on a digest whose bundled npm
+          # vendored a critically-vulnerable tar (CVE-2026-59873).
+          image: node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32
           command: ["node", "/app/server.mjs"]
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Breakdown of the 46 criticals gating `provisioning-engine`'s Gold (the engine image itself is clean — these are namespace neighbors):

| source | criticals | fix |
|---|---|---|
| 5 retained completed Kratix pipeline pods × adapter v0.125.0 | 30 | `numberOfJobsToKeep: 1` in a new KratixConfig (kratix-platform-system/kratix) — the drift CronJob spawns a pipeline every 15 min, so the keep-5 default permanently parks 5 CVE-laden pods |
| `postgresql:16` floating tag frozen on an old bullseye digest | 15 (all `fix: NONE` in-distro) | pin `16.11-system-trixie` (system = legacy-compatible layout; CNPG rolling-updates the cluster) |
| `node:22-alpine` floating tag — bundled npm vendors vulnerable `tar` (CVE-2026-59873) | 1 | digest-pin current 22-alpine |

Post-merge: the Kratix controller-manager needs a restart to load the ConfigMap (it reads config at startup); remaining adapter CVEs (6, in the single kept pod) go away with the next Kratix version bump — noted as follow-up.

Expected end state: provisioning-engine's `critical_vulnerabilities` drops 46 → ~6 on the next trivy rescan, and to 0 after a Kratix upgrade.