### PR TITLE
fix(tekton): make entrypoint executable under gVisor on the untrusted lane

### DIFF
--- a/tekton/config/kyverno-fix-entrypoint-perms.yaml
+++ b/tekton/config/kyverno-fix-entrypoint-perms.yaml
@@ -43,6 +43,11 @@ spec:
           - key: "{{ request.object.spec.initContainers[0].name || '' }}"
             operator: Equals
             value: prepare
+          # JSON 6902 inserts aren't idempotent; webhook reinvocation would
+          # insert a duplicate without this guard.
+          - key: "{{ request.object.spec.initContainers[1].name || '' }}"
+            operator: NotEquals
+            value: fix-entrypoint-perms
       mutate:
         patchesJson6902: |-
           - op: add

--- a/tekton/config/kyverno-fix-entrypoint-perms.yaml
+++ b/tekton/config/kyverno-fix-entrypoint-perms.yaml
@@ -1,0 +1,66 @@
+# gVisor cannot exec the exec-only (0311) /tekton/bin/entrypoint that Tekton's
+# `prepare` init writes: the sentry loads the ELF with the task's credentials and
+# therefore needs READ (google/gvisor#160), so every nonroot container in a Tekton
+# pod — place-scripts and all step containers — dies with exit 126 / "Permission
+# denied" (tektoncd/pipeline#4784; the 0311 mode is hardcoded). Trusted (runc)
+# lanes are unaffected: the Linux kernel execs exec-only binaries fine.
+#
+# Fix: insert a root-in-sandbox init container right after `prepare` that chmods
+# the binary 0755. Root here is contained by gVisor — the same boundary the lane
+# already relies on — and the binary is a public OSS artifact, so losing the
+# exec-only mode protects nothing. Scoped to untrusted (gVisor) build namespaces
+# via the build.capturly/tier label.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: fix-tekton-entrypoint-perms-untrusted
+  annotations:
+    policies.kyverno.io/title: Make Tekton entrypoint readable for gVisor (untrusted build plane)
+    policies.kyverno.io/category: Build Plane
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Inserts a chmod init container into Tekton-managed pods in untrusted
+      (gVisor) build namespaces so nonroot containers can exec
+      /tekton/bin/entrypoint. Remove if Tekton makes the entrypoint mode
+      configurable or the untrusted lane moves to a VM runtime (kata).
+spec:
+  background: false
+  rules:
+    - name: insert-entrypoint-chmod-init
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchLabels:
+                  app.kubernetes.io/managed-by: tekton-pipelines
+              namespaceSelector:
+                matchLabels:
+                  build.capturly/tier: untrusted
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.initContainers[0].name || '' }}"
+            operator: Equals
+            value: prepare
+      mutate:
+        patchesJson6902: |-
+          - op: add
+            path: /spec/initContainers/1
+            value:
+              name: fix-entrypoint-perms
+              # Same digest Tekton uses for place-scripts (shell-image).
+              image: cgr.dev/chainguard/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791
+              command: ["sh", "-c", "chmod 0755 /tekton/bin/entrypoint"]
+              securityContext:
+                runAsUser: 0
+                runAsNonRoot: false
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                  add: ["FOWNER"]
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: tekton-internal-bin
+                  mountPath: /tekton/bin


### PR DESCRIPTION
The untrusted (gVisor) build lane has failed every PipelineRun since it landed on 2026-07-20 — `place-scripts` exits 126 with `sh: /tekton/bin/entrypoint: Permission denied`.

**Root cause** (reproduced empirically on the cluster): Tekton's `prepare` init writes the entrypoint binary exec-only (0311, hardcoded — tektoncd/pipeline#4784), and gVisor's sentry loads ELFs with the task's credentials, which requires READ (google/gvisor#160). Every nonroot container fails — and the chainguard shell image is nonroot by default, so this breaks regardless of `set-security-context`. The trusted runc lane is unaffected (kernel exec doesn't need read).

**Ruled out:** reverting `set-security-context` (image is nonroot anyway), `DAC_READ_SEARCH` (K8s caps aren't effective for non-root UIDs), kata (RuntimeClass exists but containerd has no kata runtime configured on the nodes).

**Fix:** Kyverno inserts one init container after `prepare` — chainguard busybox (same digest Tekton uses), `chmod 0755 /tekton/bin/entrypoint`, runAsUser 0 with ALL caps dropped except FOWNER, seccomp RuntimeDefault, mounts only `tekton-internal-bin`. Root here is contained by gVisor — the boundary the lane is built on. Scoped to `build.capturly/tier: untrusted` namespaces.

Verified: minimal repro pod EXEC-OK, and a `/retest` of capturly.app#355 is running against the live policy now. **Note:** the policy is already hand-applied to the cluster for that verification; Argo adopts it on sync after merge.