### PR TITLE
fix(build-registry-proxy): raise verdaccio memory for cold-cache installs

### DIFF
--- a/build-registry-proxy/verdaccio.yaml
+++ b/build-registry-proxy/verdaccio.yaml
@@ -66,8 +66,8 @@ spec:
             - { name: config, mountPath: /verdaccio/conf }
             - { name: storage, mountPath: /verdaccio/storage }
           resources:
-            requests: { cpu: 50m, memory: 128Mi }
-            limits: { cpu: "1", memory: 1Gi }
+            requests: { cpu: 50m, memory: 256Mi }
+            limits: { cpu: "1", memory: 2Gi }
           readinessProbe:
             httpGet: { path: /-/ping, port: 4873 }
             initialDelaySeconds: 5
@@ -114,8 +114,8 @@ spec:
             - { name: config, mountPath: /verdaccio/conf }
             - { name: storage, mountPath: /verdaccio/storage }
           resources:
-            requests: { cpu: 50m, memory: 128Mi }
-            limits: { cpu: "1", memory: 1Gi }
+            requests: { cpu: 50m, memory: 256Mi }
+            limits: { cpu: "1", memory: 2Gi }
           readinessProbe:
             httpGet: { path: /-/ping, port: 4873 }
             initialDelaySeconds: 5


### PR DESCRIPTION
verdaccio-untrusted OOMKilled (exit 137, 1Gi limit) during the first real untrusted-lane install after #712 unbroke the entrypoint — clients saw ECONNRESET/socket-timeout and `capturly-nextjs-pr` failed at the `checks` task. Bumps limits to 2Gi (requests 256Mi) on both verdaccio tiers. Next capturly PR run validates the lane end-to-end.