### PR TITLE
fix(staging-track): wait for new pod to serve before smoking

### DIFF
--- a/.github/workflows/staging-track.yml
+++ b/.github/workflows/staging-track.yml
@@ -210,6 +210,29 @@ jobs:
           echo "skipped=false" >> "$GITHUB_OUTPUT"
           echo "smoke_repo=${REPO}" >> "$GITHUB_OUTPUT"
 
+          # Gate smoke on the NEW pod actually serving 200 via the public
+          # ingress. ArgoCD Healthy+Synced (Stage 1) can be true before the
+          # rolled pod is in the service/ingress routing, so smoking straight
+          # away produced transient false-fails on legit deploys. Poll the same
+          # /api/health the smoke suite checks, up to ~4 min, before dispatching.
+          SMOKE_URL="${SMOKE_URLS[$APP_NAME]}"
+          echo "Waiting for ${SMOKE_URL}/api/health to serve 200 before smoking..."
+          READY=false
+          for i in $(seq 1 24); do
+            CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "${SMOKE_URL}/api/health" || echo "000")
+            if [ "$CODE" = "200" ]; then
+              echo "Staging serving 200 after ${i} attempt(s)"
+              READY=true
+              break
+            fi
+            echo "attempt ${i}/24: ${SMOKE_URL}/api/health -> ${CODE}"
+            sleep 10
+          done
+          if [ "$READY" != "true" ]; then
+            echo "ERROR: ${SMOKE_URL}/api/health never returned 200 — refusing to smoke a non-serving deploy"
+            exit 1
+          fi
+
           echo "Dispatching smoke tests to ${REPO}..."
           gh api "repos/${REPO}/dispatches" \
             -f event_type=staging-smoke-test \


### PR DESCRIPTION
Hardens the staging/ok gate so it stops transiently false-failing legit deploys.

**Problem:** `staging-track` treats ArgoCD `Healthy+Synced` as the cue to smoke, but that can be true before the newly-rolled pod is in the service/ingress routing. Smoke then hits the public URL ~2 min post-deploy, gets a non-200, and fails `staging/ok` — a false negative (observed on blue-sky; `/api/health` was 200 both in-cluster and externally once settled).

**Fix:** before dispatching smoke, poll the app's public `/api/health` (same endpoint the smoke suite checks, from the existing per-app `SMOKE_URLS` map) until 200, up to ~4 min; fail only if it never serves. Makes `staging/ok` fail on real problems, not rollout timing — prerequisite for making it a required check.