### PR TITLE
feat(arc): staging self-hosted runner scale set (homelab-staging)

### DIFF
--- a/argocd/applications/arc-controller.yaml
+++ b/argocd/applications/arc-controller.yaml
@@ -1,0 +1,42 @@
+---
+# Actions Runner Controller (ARC) — the operator that reconciles
+# AutoscalingRunnerSets into ephemeral self-hosted GitHub Actions runners.
+# CRDs (autoscalingrunnersets/ephemeralrunners/etc.) already exist on the
+# cluster; ServerSideApply lets ArgoCD adopt them without ownership conflicts.
+# Release name is pinned to `arc` so the controller ServiceAccount is
+# `arc-gha-rs-controller` (referenced by the scale set below).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-controller
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: ghcr.io/actions/actions-runner-controller-charts
+    chart: gha-runner-scale-set-controller
+    targetRevision: 0.14.2
+    helm:
+      releaseName: arc
+      valuesObject:
+        replicaCount: 1
+        resources:
+          requests:
+            cpu: 20m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-systems
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/argocd/applications/arc-scaleset-staging.yaml
+++ b/argocd/applications/arc-scaleset-staging.yaml
@@ -1,0 +1,47 @@
+---
+# ARC runner scale set "homelab-staging" — ephemeral GitHub Actions runners
+# that live in-cluster (arc-runners ns). They run the staging smoke suite so
+# it hits staging from an allowlisted in-cluster network instead of a
+# GitHub-hosted runner (which the staging Traefik IP-allowlist 403s).
+#
+# `runnerScaleSetName: homelab-staging` IS the `runs-on:` label in the app
+# repos' staging-smoke.yml. githubConfigSecret is created by ESO from the
+# staging-arc-runners GitHub App creds (Workbench BWS project).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-scaleset-staging
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: ghcr.io/actions/actions-runner-controller-charts
+    chart: gha-runner-scale-set
+    targetRevision: 0.14.2
+    helm:
+      releaseName: homelab-staging
+      valuesObject:
+        githubConfigUrl: https://github.com/Corey-Alan-Consulting
+        # Pre-created by ESO (business-plane/arc-github-config-externalsecret.yaml)
+        githubConfigSecret: staging-arc-github-config
+        runnerScaleSetName: homelab-staging
+        minRunners: 0
+        maxRunners: 2
+        # Point the scale set at the controller installed above so its
+        # listener RBAC is granted to the right ServiceAccount.
+        controllerServiceAccount:
+          namespace: arc-systems
+          name: arc-gha-rs-controller
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-runners
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/business-plane/arc-github-config-externalsecret.yaml
+++ b/business-plane/arc-github-config-externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# GitHub App creds for the ARC "homelab-staging" scale set, synced from the
+# Workbench BWS project into the k8s secret the scale set consumes
+# (githubConfigSecret). Keys are the exact names gha-runner-scale-set expects.
+# App: staging-arc-runners (org Corey-Alan-Consulting, Self-hosted runners: RW).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: staging-arc-github-config
+  namespace: arc-runners
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: staging-arc-github-config
+    creationPolicy: Owner
+  data:
+    - secretKey: github_app_id
+      remoteRef:
+        key: 0a72b2aa-a8a8-4222-87ed-b49700f61a2a
+    - secretKey: github_app_installation_id
+      remoteRef:
+        key: 2c2bd488-8aaf-45e2-952c-b49700f61a67
+    - secretKey: github_app_private_key
+      remoteRef:
+        key: 5fee4b79-0c19-4178-a2a5-b49700f667db


### PR DESCRIPTION
Stands up ARC + a `homelab-staging` runner scale set so the staging smoke suite runs **in-cluster** (allowlisted) instead of on GitHub-hosted runners — which the staging Traefik IP-allowlist returns 403 to. This is the prerequisite for enforcing the rebuilt `staging/ok` gate.

- **arc-controller** — `gha-runner-scale-set-controller` 0.14.2 in `arc-systems`. CRDs already exist on the cluster; `ServerSideApply` adopts them. Release name `arc` → controller SA `arc-gha-rs-controller`.
- **arc-scaleset-staging** — `gha-runner-scale-set` 0.14.2 in `arc-runners`, org `Corey-Alan-Consulting`, `runnerScaleSetName: homelab-staging` (this is the `runs-on:` label), scale-to-zero (min 0 / max 2).
- **ESO** — `staging-arc-github-config` synced from the `staging-arc-runners` GitHub App creds (App ID 4436664 / install 150107083; key in Workbench BWS), keyed as the chart expects.

Next: point `coreyalan.com` + `blue-skysolutions.com` `staging-smoke.yml` `runs-on` at `homelab-staging`, re-test via a blue-sky deploy (smoke should now reach staging → `staging/ok` green), then make `staging/ok` a required check.