### PR TITLE
fix(arc): baseline PodSecurity on arc namespaces

### DIFF
--- a/business-plane/namespaces.yaml
+++ b/business-plane/namespaces.yaml
@@ -13,8 +13,14 @@ metadata:
   name: arc-systems
   labels:
     plane: business
-    pod-security.kubernetes.io/audit: restricted
-    pod-security.kubernetes.io/warn: restricted
+    # ARC-managed pods can't satisfy 'restricted': the ephemeral runners
+    # apt-install at job time (playwright install --with-deps) and the ARC
+    # listener pod sets no securityContext. Baseline is the level ARC documents
+    # for its namespaces. These are TRUSTED first-party smoke runners; the
+    # untrusted build lane keeps gVisor + restricted separately via Tekton.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline
 ---
 apiVersion: v1
 kind: Namespace
@@ -22,5 +28,11 @@ metadata:
   name: arc-runners
   labels:
     plane: business
-    pod-security.kubernetes.io/audit: restricted
-    pod-security.kubernetes.io/warn: restricted
+    # ARC-managed pods can't satisfy 'restricted': the ephemeral runners
+    # apt-install at job time (playwright install --with-deps) and the ARC
+    # listener pod sets no securityContext. Baseline is the level ARC documents
+    # for its namespaces. These are TRUSTED first-party smoke runners; the
+    # untrusted build lane keeps gVisor + restricted separately via Tekton.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline


### PR DESCRIPTION
The `homelab-staging` ARC listener is crash-looping because `arc-systems`/`arc-runners` get `restricted` PSA (cluster default) but ARC pods can't satisfy it — the listener sets no securityContext, and the ephemeral runners apt-install at job time (`playwright install --with-deps chromium`). Controller log: `would violate PodSecurity "restricted:latest"` → listener pod denied → the `ephemeralrunnersets ... not found` cascade.

Sets `enforce/audit/warn=baseline` on both arc namespaces — the level ARC documents for its namespaces. These run **trusted first-party** staging smoke tests; the untrusted build lane keeps its gVisor + restricted hardening via Tekton, unaffected. Auth + registration already work (App creds valid, scale set registered); this is the last thing between the listener and Running.