### PR TITLE
fix(staging-track): drop pre-smoke health poll (ran from allowlist-blocked runner)

### DIFF
--- a/.github/workflows/staging-track.yml
+++ b/.github/workflows/staging-track.yml
@@ -210,29 +210,11 @@ jobs:
           echo "skipped=false" >> "$GITHUB_OUTPUT"
           echo "smoke_repo=${REPO}" >> "$GITHUB_OUTPUT"
 
-          # Gate smoke on the NEW pod actually serving 200 via the public
-          # ingress. ArgoCD Healthy+Synced (Stage 1) can be true before the
-          # rolled pod is in the service/ingress routing, so smoking straight
-          # away produced transient false-fails on legit deploys. Poll the same
-          # /api/health the smoke suite checks, up to ~4 min, before dispatching.
-          SMOKE_URL="${SMOKE_URLS[$APP_NAME]}"
-          echo "Waiting for ${SMOKE_URL}/api/health to serve 200 before smoking..."
-          READY=false
-          for i in $(seq 1 24); do
-            CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "${SMOKE_URL}/api/health" || echo "000")
-            if [ "$CODE" = "200" ]; then
-              echo "Staging serving 200 after ${i} attempt(s)"
-              READY=true
-              break
-            fi
-            echo "attempt ${i}/24: ${SMOKE_URL}/api/health -> ${CODE}"
-            sleep 10
-          done
-          if [ "$READY" != "true" ]; then
-            echo "ERROR: ${SMOKE_URL}/api/health never returned 200 — refusing to smoke a non-serving deploy"
-            exit 1
-          fi
-
+          # NB: no pre-smoke health poll here — this job runs on a GitHub-hosted
+          # runner, which the staging IP-allowlist 403s, so any curl to staging
+          # from here always fails. Rollout-timing is handled inside the smoke
+          # suite itself, which now runs on the in-cluster homelab-staging runner
+          # (allowlisted) with Playwright retries.
           echo "Dispatching smoke tests to ${REPO}..."
           gh api "repos/${REPO}/dispatches" \
             -f event_type=staging-smoke-test \


### PR DESCRIPTION
The #725 pre-smoke `/api/health` poll runs on this GitHub-hosted job, which the staging IP-allowlist 403s — so it never returns 200 and fails `staging-track` before smoke is dispatched (no smoke run is created; the check reports failure off the stale prior run).

Re-diagnosis: the original blue-sky 'transient' failure was **also 403** (allowlist), not cold-pod timing — my #725 addressed the wrong cause and introduced this. With smoke now on the in-cluster `homelab-staging` runner (allowlisted) plus Playwright retries, rollout timing is handled correctly. This removes the poll.