### PR TITLE
security(kyverno): enforce business-plane registry allowlist

### DIFF
--- a/kyverno-policies-business/restrict-image-registries.yaml
+++ b/kyverno-policies-business/restrict-image-registries.yaml
@@ -1,7 +1,9 @@
 ---
 # Business-plane images may only come from our GHCR namespace or the ARC upstream
 # charts. Mirrors prod's restrict-image-registries, scoped by the `plane: business`
-# namespace label so the personal services are untouched. AUDIT for now.
+# namespace label so the personal services are untouched. ENFORCE: every
+# business-plane image today is ghcr.io/actions/* (allowlisted) with zero
+# PolicyReport failures, so blocking disallowed registries breaks nothing.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -11,7 +13,7 @@ metadata:
     policies.kyverno.io/category: Supply Chain
     policies.kyverno.io/severity: high
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: validate-registries


### PR DESCRIPTION
Phase 6 — flip **restrict-image-registries-business** Audit→Enforce.

Verified on-cluster before flipping: the `plane: business` namespaces (`arc-runners`, `arc-systems`) run **only** `ghcr.io/actions/*` images (the ARC controller/runners), which are in the allowlist (`ghcr.io/nx211/* | ghcr.io/actions/*`). PolicyReports show **4 pass / 0 fail**, so enforcing blocks only *future* disallowed registries — no current workload is affected. ArgoCD syncs this policy directly.

Note: the sibling `verify-image-signatures-business` is intentionally **left in Audit** — the nx211 build workflows do not yet cosign-sign their images, so enforcing it would be a latent trap. A separate PR adds signing first.