### PR TITLE
security(supply-chain): keyless-sign nx211 build images with cosign

### DIFF
--- a/.github/workflows/build-allowlist-reconciler.yml
+++ b/.github/workflows/build-allowlist-reconciler.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # keyless cosign signing (OIDC)
     steps:
       # Use a GitHub App token so the digest pin-back commit can push to main
       # (and trigger no protected-branch friction), mirroring gitops-staging-update.
@@ -63,6 +64,15 @@ jobs:
             ${{ env.IMAGE }}:${{ env.VERSION }}
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:sha-${{ github.sha }}
+
+      # Keyless cosign signature so verify-image-signatures-business can verify
+      # ghcr.io/nx211/* by this workflow's OIDC identity. Sign by digest.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+      - name: Sign image (keyless)
+        env:
+          IMAGE_DIGEST: ${{ env.IMAGE }}@${{ steps.push.outputs.digest }}
+        run: cosign sign --yes "$IMAGE_DIGEST"
 
       - uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4
 

--- a/.github/workflows/build-capturly-android-toolchain.yml
+++ b/.github/workflows/build-capturly-android-toolchain.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # keyless cosign signing (OIDC)
     steps:
       - name: Mint app token
         id: app-token
@@ -60,6 +61,15 @@ jobs:
             ${{ env.IMAGE }}:${{ env.VERSION }}
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:sha-${{ github.sha }}
+
+      # Keyless cosign signature so verify-image-signatures-business can verify
+      # ghcr.io/nx211/* by this workflow's OIDC identity. Sign by digest.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+      - name: Sign image (keyless)
+        env:
+          IMAGE_DIGEST: ${{ env.IMAGE }}@${{ steps.push.outputs.digest }}
+        run: cosign sign --yes "$IMAGE_DIGEST"
 
       - uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4
 

--- a/.github/workflows/build-synapse-s3.yml
+++ b/.github/workflows/build-synapse-s3.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write # keyless cosign signing (OIDC)
 
 jobs:
   build:
@@ -28,7 +29,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+      - name: Build & push
+        id: push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: helm-charts/matrix/docker/synapse-s3
           build-args: SYNAPSE_VERSION=${{ env.SYNAPSE_VERSION }}
@@ -36,3 +39,12 @@ jobs:
           tags: |
             ${{ env.IMAGE }}:${{ env.SYNAPSE_VERSION }}
             ${{ env.IMAGE }}:latest
+
+      # Keyless cosign signature so verify-image-signatures-business can verify
+      # ghcr.io/nx211/* by this workflow's OIDC identity. Sign by digest.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+      - name: Sign image (keyless)
+        env:
+          IMAGE_DIGEST: ${{ env.IMAGE }}@${{ steps.push.outputs.digest }}
+        run: cosign sign --yes "$IMAGE_DIGEST"

--- a/.github/workflows/build-web-toolchain.yml
+++ b/.github/workflows/build-web-toolchain.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # keyless cosign signing (OIDC)
     steps:
       - name: Mint app token
         id: app-token
@@ -59,6 +60,15 @@ jobs:
             ${{ env.IMAGE }}:${{ env.VERSION }}
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:sha-${{ github.sha }}
+
+      # Keyless cosign signature so verify-image-signatures-business can verify
+      # ghcr.io/nx211/* by this workflow's OIDC identity. Sign by digest.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+      - name: Sign image (keyless)
+        env:
+          IMAGE_DIGEST: ${{ env.IMAGE }}@${{ steps.push.outputs.digest }}
+        run: cosign sign --yes "$IMAGE_DIGEST"
 
       - uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4
 


### PR DESCRIPTION
Phase 6 — add keyless cosign signing to the four nx211 image builds, the prerequisite for enforcing verify-image-signatures-business.

## Change
Each of `build-web-toolchain`, `build-allowlist-reconciler`, `build-synapse-s3`, `build-capturly-android-toolchain` gains:
- `id-token: write` (OIDC for keyless signing)
- Install cosign (pinned) + `cosign sign --yes <image>@<digest>` after the build/push (signs by digest; reuses the existing ghcr login for the `.sig` push).

`build-synapse-s3` also gets an `id: push` on its build step so the digest is referenceable.

## Why
The verify investigation found these images were **unsigned**, so `verify-image-signatures-business` expected signatures that did not exist. The workflow OIDC identity matches that policy's attestor (subject `github.com/NX211/homelab-infra/.github/workflows/*`, issuer `token.actions.githubusercontent.com`).

## Follow-up (not in this PR)
Once each image is **rebuilt and signed** (a push touching each build path, or manual dispatch), flip `verify-image-signatures-business` Audit→Enforce and `mutateDigest: false → true`. Kept out of this PR so the flip only lands after signatures actually exist in the registry.

Validation: actionlint + shellcheck clean; cosign-installer + all actions SHA-pinned.