### PR TITLE
fix(ci): rebase+retry pin-back push to survive concurrent builds

### DIFF
--- a/.github/workflows/build-allowlist-reconciler.yml
+++ b/.github/workflows/build-allowlist-reconciler.yml
@@ -95,4 +95,12 @@ jobs:
           fi
           git add "$MANIFEST"
           git commit -m "chore(allowlist-reconciler): pin image ${{ steps.push.outputs.digest }}"
-          git push
+          # Concurrent image builds each push a pin-back to main; rebase + retry
+          # so a non-fast-forward rejection self-heals (each build pins a
+          # different file, so the rebase never conflicts).
+          for attempt in 1 2 3 4 5; do
+            if git push; then exit 0; fi
+            echo "push rejected (attempt ${attempt}); rebasing onto origin/main"
+            git pull --rebase origin main
+          done
+          echo "::error::pin-back push failed after 5 attempts"; exit 1

--- a/.github/workflows/build-capturly-android-toolchain.yml
+++ b/.github/workflows/build-capturly-android-toolchain.yml
@@ -89,4 +89,12 @@ jobs:
           fi
           git add "$PIPELINE"
           git commit -m "chore(android-toolchain): pin image ${{ steps.push.outputs.digest }}"
-          git push
+          # Concurrent image builds each push a pin-back to main; rebase + retry
+          # so a non-fast-forward rejection self-heals (each build pins a
+          # different file, so the rebase never conflicts).
+          for attempt in 1 2 3 4 5; do
+            if git push; then exit 0; fi
+            echo "push rejected (attempt ${attempt}); rebasing onto origin/main"
+            git pull --rebase origin main
+          done
+          echo "::error::pin-back push failed after 5 attempts"; exit 1

--- a/.github/workflows/build-web-toolchain.yml
+++ b/.github/workflows/build-web-toolchain.yml
@@ -88,4 +88,12 @@ jobs:
           fi
           git add "$TASK"
           git commit -m "chore(web-toolchain): pin image ${{ steps.push.outputs.digest }}"
-          git push
+          # Concurrent image builds each push a pin-back to main; rebase + retry
+          # so a non-fast-forward rejection self-heals (each build pins a
+          # different file, so the rebase never conflicts).
+          for attempt in 1 2 3 4 5; do
+            if git push; then exit 0; fi
+            echo "push rejected (attempt ${attempt}); rebasing onto origin/main"
+            git pull --rebase origin main
+          done
+          echo "::error::pin-back push failed after 5 attempts"; exit 1


### PR DESCRIPTION
When several image builds run concurrently (as happened when a change touched all four build workflows at once), their pin-back commits race to push to `main` and all but the first are rejected `! [rejected] main -> main (fetch first)`, failing the build.

Make the pin-back push **rebase + retry** (5 attempts) on rejection. Each build pins a *different* file (web-ci task / android-build pipeline / allowlist manifest), so the rebase never conflicts. Fixes the two builds that lost the race after the cosign-signing PR merged.

actionlint + shellcheck clean.