### PR TITLE
fix(tekton): codify gVisor entrypoint policy + whitelist ClusterPolicy in business project

### DIFF
--- a/business-plane/appproject.yaml
+++ b/business-plane/appproject.yaml
@@ -57,6 +57,11 @@ spec:
       kind: RuntimeClass
     - group: operator.tekton.dev
       kind: TektonConfig
+    # The untrusted build tier ships a Kyverno mutating ClusterPolicy
+    # (fix-tekton-entrypoint-perms-untrusted) so gVisor can exec Tekton's
+    # entrypoint — tekton-config manages it.
+    - group: kyverno.io
+      kind: ClusterPolicy
   namespaceResourceWhitelist:
     - group: "*"
       kind: "*"

--- a/tekton/config/fix-tekton-entrypoint-perms-untrusted.yaml
+++ b/tekton/config/fix-tekton-entrypoint-perms-untrusted.yaml
@@ -1,0 +1,68 @@
+---
+# gVisor can't exec Tekton's entrypoint binary (written mode 0311) in the
+# untrusted build tier, so nonroot build pods failed to start (google/gvisor#160,
+# tektoncd/pipeline#4784). This mutating policy inserts a tiny init container
+# that chmods /tekton/bin/entrypoint to 0755 before the real steps run.
+#
+# Codified here from a previously live-only resource (originally applied out of
+# band in the #712 fix) so GitOps owns it — the tekton-config app already tracks
+# it. Requires kyverno.io/ClusterPolicy in the `business` AppProject
+# clusterResourceWhitelist (see business-plane/appproject.yaml).
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: fix-tekton-entrypoint-perms-untrusted
+  annotations:
+    policies.kyverno.io/title: Make Tekton entrypoint readable for gVisor (untrusted build plane)
+    policies.kyverno.io/category: Build Plane
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Inserts a chmod init container into Tekton-managed pods in untrusted
+      (gVisor) build namespaces so nonroot containers can exec
+      /tekton/bin/entrypoint. Remove if Tekton makes the entrypoint mode
+      configurable or the untrusted lane moves to a VM runtime (kata).
+spec:
+  background: false
+  validationFailureAction: Audit
+  rules:
+    - name: insert-entrypoint-chmod-init
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaceSelector:
+                matchLabels:
+                  build.capturly/tier: untrusted
+              selector:
+                matchLabels:
+                  app.kubernetes.io/managed-by: tekton-pipelines
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.initContainers[0].name || '' }}"
+            operator: Equals
+            value: prepare
+          - key: "{{ request.object.spec.initContainers[1].name || '' }}"
+            operator: NotEquals
+            value: fix-entrypoint-perms
+      mutate:
+        patchesJson6902: |-
+          - op: add
+            path: /spec/initContainers/1
+            value:
+              name: fix-entrypoint-perms
+              # Same digest Tekton uses for place-scripts (shell-image).
+              image: cgr.dev/chainguard/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791
+              command: ["sh", "-c", "chmod 0755 /tekton/bin/entrypoint"]
+              securityContext:
+                runAsUser: 0
+                runAsNonRoot: false
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                  add: ["FOWNER"]
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: tekton-internal-bin
+                  mountPath: /tekton/bin


### PR DESCRIPTION
Fixes the `tekton-config` app stuck **OutOfSync** in staging ArgoCD.

## Root cause
`tekton-config` tracks the ClusterPolicy **`fix-tekton-entrypoint-perms-untrusted`** (the #712 gVisor chmod-init fix that makes the untrusted build lane work), but:
1. that policy existed **only on the cluster** — never committed to git, and
2. the `business` AppProject `clusterResourceWhitelist` did **not** permit `kyverno.io/ClusterPolicy`.

So Argo could neither apply nor prune it → `resource kyverno.io:ClusterPolicy is not permitted in project business`.

## Fix (both parts required together)
- **Codify** the policy under `tekton/config/` (recovered from its live `last-applied` spec) so GitOps owns it — the tekton-config app already tracks it, so this is clean adoption, no ownership transfer.
- **Whitelist** `kyverno.io/ClusterPolicy` in `business-plane/appproject.yaml` (exactly what that file's comment anticipated: *"add it here when it does"*).

⚠️ Whitelisting alone would be **dangerous**: `tekton-config` runs `prune: true, selfHeal: true`, so Argo would delete the undeclared live policy and re-break the untrusted lane. Codifying it first prevents that.

## Not caused by the remediation
This drift predates this work (the policy was applied out-of-band during #712). Flagged while investigating the staging ArgoCD health after the Phase 6 merges. `YAML` + embedded JSON6902 validated.