### PR TITLE
fix(argocd): ignore Kyverno-defaulted fields so tekton-config settles Synced

### DIFF
--- a/argocd/applications/tekton-config.yaml
+++ b/argocd/applications/tekton-config.yaml
@@ -34,3 +34,11 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  # Kyverno server-defaults ClusterPolicy fields (admission, emitWarning, autogen,
+  # …) that aren't in git; ignore its field-manager so the entrypoint policy
+  # doesn't sit perpetually OutOfSync (mirrors the kyverno-policies-business app).
+  ignoreDifferences:
+    - group: kyverno.io
+      kind: ClusterPolicy
+      managedFieldsManagers:
+        - kyverno


### PR DESCRIPTION
Follow-up to #741. With the policy codified and the AppProject whitelisting ClusterPolicy, `tekton-config` could finally manage `fix-tekton-entrypoint-perms-untrusted` — but it stayed **OutOfSync** because Kyverno server-defaults fields (`admission`, `emitWarning`, `autogen`, …) that arent in git, and tekton-config lacked an `ignoreDifferences` for them.

Add the **same** `ignoreDifferences` block the already-Synced `kyverno-policies-business` app uses:
```
ignoreDifferences:
  - group: kyverno.io
    kind: ClusterPolicy
    managedFieldsManagers: [kyverno]
```
After this, tekton-config settles Synced/Healthy (verified the AppProject whitelist already applied live).