### PR TITLE
fix(argocd): ignore ESO-defaulted ExternalSecret fields on business-plane

### DIFF
--- a/argocd/applications/business-plane.yaml
+++ b/argocd/applications/business-plane.yaml
@@ -27,3 +27,15 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
+  # The ExternalSecret CRD server-defaults these remoteRef/target fields, which
+  # aren't in git — ignore them so ExternalSecrets don't sit perpetually
+  # OutOfSync (key/secretKey/storeRef/creationPolicy are still compared).
+  ignoreDifferences:
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+        - .spec.data[].remoteRef.metadataPolicy
+        - .spec.data[].remoteRef.nullBytePolicy
+        - .spec.target.deletionPolicy


### PR DESCRIPTION
Folds in the last staging catalog-noise item. `business-plane` sat **OutOfSync** on the `staging-arc-github-config` ExternalSecret (which is `Ready=True` / functional) purely because the ExternalSecret CRD **server-defaults** fields git doesnt specify:
- `spec.data[].remoteRef.{conversionStrategy,decodingStrategy,metadataPolicy,nullBytePolicy}`
- `spec.target.deletionPolicy`

Add a targeted `ignoreDifferences` (jqPathExpressions) for just those on `external-secrets.io/ExternalSecret`, so `business-plane` settles **Synced** while `key`/`secretKey`/`secretStoreRef`/`creationPolicy` are still compared (real drift still caught). Same class of fix as the tekton-config Kyverno ignoreDifferences.