### PR TITLE
fix(tekton): declare Kyverno default fields so the entrypoint policy syncs Synced

### DIFF
--- a/tekton/config/fix-tekton-entrypoint-perms-untrusted.yaml
+++ b/tekton/config/fix-tekton-entrypoint-perms-untrusted.yaml
@@ -22,10 +22,16 @@ metadata:
       /tekton/bin/entrypoint. Remove if Tekton makes the entrypoint mode
       configurable or the untrusted lane moves to a VM runtime (kata).
 spec:
+  # These match Kyverno's server-side defaults. Declared explicitly so the live
+  # policy (where Argo's field-manager ends up owning them) doesn't sit
+  # perpetually OutOfSync against a git spec that omitted them.
+  admission: true
   background: false
+  emitWarning: false
   validationFailureAction: Audit
   rules:
     - name: insert-entrypoint-chmod-init
+      skipBackgroundRequests: true
       match:
         any:
           - resources:


### PR DESCRIPTION
Root-cause fix for `tekton-config` sitting OutOfSync (from the root-apps investigation).

## What was actually happening
root-apps propagates child specs **fine** (the earlier theory was wrong). The real cause: Kyverno server-defaults `spec.admission=true`, `spec.emitWarning=false`, and `rules[].skipBackgroundRequests=true` **during Argos apply**, and Argos field-manager ends up **owning** them — but git omitted them, so Argo perpetually diffed (wants to remove fields Kyverno immediately re-adds).

The global `resource.customizations.ignoreDifferences.kyverno.io_ClusterPolicy` uses `managedFieldsManagers: [kyverno]`, which does **not** help here because `kyverno` owns no `spec` fields on this policy (verified via managedFields).

## Fix
Declare the three defaulted fields explicitly (they equal Kyvernos defaults → no behavior change) so **git == live**. Verified **zero spec delta** against the live policy, so once synced it settles Synced/Healthy.

The per-app `ignoreDifferences` added in #742 is a manager-based no-op here (kyverno owns no spec) — harmless, can be removed later.