### PR TITLE
chore(argocd): drop no-op ignoreDifferences from tekton-config

### DIFF
--- a/argocd/applications/tekton-config.yaml
+++ b/argocd/applications/tekton-config.yaml
@@ -34,11 +34,3 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
-  # Kyverno server-defaults ClusterPolicy fields (admission, emitWarning, autogen,
-  # …) that aren't in git; ignore its field-manager so the entrypoint policy
-  # doesn't sit perpetually OutOfSync (mirrors the kyverno-policies-business app).
-  ignoreDifferences:
-    - group: kyverno.io
-      kind: ClusterPolicy
-      managedFieldsManagers:
-        - kyverno


### PR DESCRIPTION
Cleanup. The per-app `ignoreDifferences` (managedFieldsManagers: kyverno) I added to `tekton-config` while chasing its OutOfSync was a **no-op** — `kyverno` owns no spec fields on the policy, so it ignored nothing. The real cause was a duplicate resource (fixed in #745), and the policy is now Synced/Healthy with a zero-delta git spec. Remove the dead config; the cluster-wide `argocd-cm` kyverno customization stays.