### PR TITLE
fix(argocd): drop default source.directory.recurse:false from child apps

### DIFF
--- a/argocd/applications/kratix-config.yaml
+++ b/argocd/applications/kratix-config.yaml
@@ -18,8 +18,6 @@ spec:
     repoURL: https://github.com/nx211/homelab-infra.git
     targetRevision: main
     path: kratix/config
-    directory:
-      recurse: false
   destination:
     server: https://kubernetes.default.svc
     namespace: kratix-platform-system

--- a/argocd/applications/kratix.yaml
+++ b/argocd/applications/kratix.yaml
@@ -19,8 +19,6 @@ spec:
     repoURL: https://github.com/nx211/homelab-infra.git
     targetRevision: main
     path: kratix
-    directory:
-      recurse: false
   destination:
     server: https://kubernetes.default.svc
   syncPolicy:

--- a/argocd/applications/port-k8s-exporter-eso.yaml
+++ b/argocd/applications/port-k8s-exporter-eso.yaml
@@ -16,8 +16,6 @@ spec:
     repoURL: https://github.com/NX211/homelab-infra.git
     targetRevision: HEAD
     path: port-k8s-exporter
-    directory:
-      recurse: false
   destination:
     server: https://kubernetes.default.svc
     namespace: port-k8s-exporter

--- a/argocd/applications/port-ocean-argocd-eso.yaml
+++ b/argocd/applications/port-ocean-argocd-eso.yaml
@@ -17,8 +17,6 @@ spec:
     repoURL: https://github.com/NX211/homelab-infra.git
     targetRevision: HEAD
     path: port-ocean-argocd
-    directory:
-      recurse: false
   destination:
     server: https://kubernetes.default.svc
     namespace: port-ocean-argocd

--- a/argocd/applications/provisioning.yaml
+++ b/argocd/applications/provisioning.yaml
@@ -21,8 +21,6 @@ spec:
     repoURL: https://github.com/nx211/homelab-infra.git
     targetRevision: main
     path: provisioning
-    directory:
-      recurse: false
   destination:
     server: https://kubernetes.default.svc
     namespace: provisioning

--- a/argocd/applications/tenants.yaml
+++ b/argocd/applications/tenants.yaml
@@ -24,8 +24,6 @@ spec:
     repoURL: https://github.com/nx211/homelab-infra.git
     targetRevision: main
     path: provisioning/tenants
-    directory:
-      recurse: false
   destination:
     server: https://kubernetes.default.svc
     namespace: provisioning


### PR DESCRIPTION
Greens the last OutOfSync root-apps children (their workloads were already Synced; root-apps saw the **Application CRs** as drifted).

## Cause
Each of `kratix`, `kratix-config`, `port-k8s-exporter-secret`, `port-ocean-argocd-eso`, `provisioning`, `tenants` declared `spec.source.directory.recurse: false`. Thats the **default**, so Argo drops the empty `directory` block from the live Application → git is perpetually ahead → root-apps reports them OutOfSync (verified via a git-vs-live spec diff: the only delta was git-only `source.directory.recurse=false`).

## Fix
Remove the default `directory.recurse: false` block (behavior unchanged — recurse defaults to false) so the Application CRs match live. root-apps settles Synced after this syncs.

`root-apps.yaml` itself keeps its `directory` block (it carries a meaningful `include: "*.yaml"`).