### PR TITLE
fix(argocd): drop default recurse:false from root-apps self

### DIFF
--- a/argocd/applications/root-apps.yaml
+++ b/argocd/applications/root-apps.yaml
@@ -30,9 +30,9 @@ spec:
     targetRevision: HEAD
     path: argocd/applications
     directory:
-      # Flat directory only. Flip to true if/when apps get nested under
-      # argocd/applications/<group>/.
-      recurse: false
+      # Flat directory (recurse defaults to false — do NOT set it explicitly;
+      # Argo drops the default off the live Application, which reads back as a
+      # perpetual OutOfSync). Flip to recurse: true only if apps get nested.
       # Skip non-YAML files (README.md, etc.) so they don't break sync.
       include: "*.yaml"
   destination:


### PR DESCRIPTION
Last OutOfSync item in staging. After #747 greened the six children, `root-apps` remained OutOfSync on **itself**: git declared `source.directory.recurse: false` (the default), which Argo drops from the live Application (live `directory` is just `{include: "*.yaml"}`), so git read back perpetually ahead.

Drop the default `recurse: false`, keep the meaningful `include: "*.yaml"`. Same fix as #747, applied to root-apps itself → it settles Synced and the staging catalog is sync-clean (only workload-health Degraded/Progressing items remain, which are separate).