### PR TITLE
fix(dns): hairpin capturly-live domains for cert-manager HTTP-01 self-check

### DIFF
--- a/coredns/configmap.yaml
+++ b/coredns/configmap.yaml
@@ -62,6 +62,12 @@ data:
     10.43.5.100 staging.dispatchr.social
     10.43.5.100 staging.capturly.app
     10.43.5.100 staging.blue-skysolutions.com
+    # capturly-live (WebRTC) — split-horizon so the cert-manager HTTP-01
+    # self-check reaches Traefik instead of hairpinning to the public IP (the
+    # certs were stuck "failed to perform self check … context deadline exceeded").
+    10.43.5.100 live.capturly.app
+    10.43.5.100 wss.live.capturly.app
+    10.43.5.100 turn.live.capturly.app
     # Matrix stack (server_name coreyalan.com; apex served by prod cluster).
     10.43.5.100 matrix.coreyalan.com
     10.43.5.100 auth.coreyalan.com


### PR DESCRIPTION
First fix in the cert/ACME theme.

## Diagnosis
capturly-lives three certs (`live.capturly.app`, `wss.live.capturly.app`, `turn.live.capturly.app`) were stuck `pending`:
```
Waiting for HTTP-01 challenge propagation: failed to perform self check … context deadline exceeded
```
cert-managers in-cluster self-check couldnt reach the challenge URL because those domains werent in the CoreDNS `NodeHosts` hairpin list — so they resolved to the public IP and timed out (exactly the hairpin issue).

## Fix
Add the three domains to the split-horizon `NodeHosts` (→ Traefik `10.43.5.100`), same pattern the file already uses for `staging.*` and the tekton webhook domains (comments there call out the identical self-check reason).

After CoreDNS reloads, the self-check passes and cert-manager proceeds to Lets Encrypt validation.

## Separate (not this PR)
- **karakeeper** (`authoritah.click`) fails at LEs **public** validation ("Timeout during connect — likely firewall") — a public DNS/firewall issue, not hairpin.
- **capturly-android-trusted** cert requests the placeholder domain `tekton-trusted.replace.example` (needs the real domain).
- capturly-live also has a **separate** ImagePullBackOff (missing ghcr pull secret) — not fixed here.