### PR TITLE
fix(build): capturly-android webhook domain + hairpin (android + .click)

### DIFF
--- a/build-targets/capturly/android-trusted.yaml
+++ b/build-targets/capturly/android-trusted.yaml
@@ -15,6 +15,10 @@ githubApp:
 webhook:
   store: bitwarden-build-platform
   secretKey: 06a03bb9-88d3-4076-9302-b48d0154f9b6     # CAPTURLY_TEKTON_TRUSTED_WEBHOOK_SECRET
+  # Public EventListener webhook sink (was unset → fell back to the chart's
+  # tekton-trusted.replace.example placeholder, which cert-manager couldn't issue
+  # a cert for). Mirrors tekton-trusted-provisioning-engine.coreyalan.com.
+  host: tekton-trusted-android.capturly.app
 
 signing:
   store: bitwarden-capturly

--- a/coredns/configmap.yaml
+++ b/coredns/configmap.yaml
@@ -38,6 +38,7 @@ data:
     # Internal DNS overrides - Traefik ClusterIP for homelab domains.
     # Enables split-horizon DNS so cert-manager HTTP-01 self-checks succeed
     # and in-cluster traffic to *.authoritah.com stays inside the cluster.
+    10.43.5.100 authoritah.click
     10.43.5.100 authoritah.com
     10.43.5.100 www.authoritah.com
     10.43.5.100 login.authoritah.com
@@ -82,6 +83,9 @@ data:
     # Tekton trusted-tier EventListener webhook sinks (build platform) — same
     # split-horizon reason as tekton-pac above (HTTP-01 self-check, not hairpin).
     10.43.5.100 tekton-trusted-provisioning-engine.coreyalan.com
+    # capturly Android release EventListener (build platform) — same split-horizon
+    # reason (HTTP-01 self-check reaches Traefik, not the public IP).
+    10.43.5.100 tekton-trusted-android.capturly.app
     # Onboarding seam (provisioning-webhook /onboarding) — split-horizon so the
     # cert-manager HTTP-01 self-check resolves to Traefik, not the public IP.
     10.43.5.100 provisioning.coreyalan.com


### PR DESCRIPTION
Cert/ACME theme, part 2.

## capturly-android-trusted
Its cert requested the placeholder `tekton-trusted.replace.example` because the build-target left `webhook.host` unset (chart default). Set it to **`tekton-trusted-android.capturly.app`** (mirrors `tekton-trusted-provisioning-engine.coreyalan.com`) and add the CoreDNS hairpin so the HTTP-01 self-check reaches Traefik.

## karakeeper (.click)
Add `authoritah.click` to the CoreDNS hairpin so its self-check resolves to Traefik, now that its public DNS is corrected.

## Companion PR
The **public** DNS record for `tekton-trusted-android.capturly.app` (Cloudflare, → homelab origin, DNS-only) is added in platform-infra terraform.

Note: capturly-android also has a separate `ExternalSecret/capturly-android-signing` SecretSyncedError (BWS secret) — not addressed here.