### PR TITLE
fix(build): set android triggers.host (correct field for the EL cert)

### DIFF
--- a/build-targets/capturly/android-trusted.yaml
+++ b/build-targets/capturly/android-trusted.yaml
@@ -15,10 +15,6 @@ githubApp:
 webhook:
   store: bitwarden-build-platform
   secretKey: 06a03bb9-88d3-4076-9302-b48d0154f9b6     # CAPTURLY_TEKTON_TRUSTED_WEBHOOK_SECRET
-  # Public EventListener webhook sink (was unset → fell back to the chart's
-  # tekton-trusted.replace.example placeholder, which cert-manager couldn't issue
-  # a cert for). Mirrors tekton-trusted-provisioning-engine.coreyalan.com.
-  host: tekton-trusted-android.capturly.app
 
 signing:
   store: bitwarden-capturly
@@ -38,9 +34,10 @@ gradleCache:
   size: 10Gi
 
 triggers:
-  # ⚠️ TODO: set the real host; ensure public DNS + Traefik TLS resolve to it, and
-  #    register this URL as the webhook on the capturly.app repo.
-  host: tekton-trusted.REPLACE.example
+  # Public EventListener webhook sink. Its cert (cert-manager HTTP-01), the
+  # Cloudflare A record (platform-infra) and the CoreDNS hairpin all key off this
+  # host. Register this URL as the webhook on the capturly.app repo.
+  host: tekton-trusted-android.capturly.app
   tagPrefix: refs/tags/@capturly/mobile@
   pipeline:
     path: build-catalog/pipelines/android-build.yaml


### PR DESCRIPTION
Correction to #750. The build-namespace chart keys the EventListener Certificate/IngressRoute off **`triggers.host`**, but #750 mistakenly set `webhook.host` — so the cert stayed on the `tekton-trusted.REPLACE.example` placeholder.

Set `triggers.host = tekton-trusted-android.capturly.app` (matching provisioning-engines `triggers.host` pattern) and remove the errant `webhook.host`. The public Cloudflare A record (platform-infra #1124) and the CoreDNS hairpin (#750) already point at this host, so once this syncs the cert can issue.