### PR TITLE
fix(eso): repoint capturly android signing store to desktop-signing project

### DIFF
--- a/build-targets/capturly/android-trusted.yaml
+++ b/build-targets/capturly/android-trusted.yaml
@@ -17,7 +17,7 @@ webhook:
   secretKey: 06a03bb9-88d3-4076-9302-b48d0154f9b6     # CAPTURLY_TEKTON_TRUSTED_WEBHOOK_SECRET
 
 signing:
-  store: bitwarden-capturly
+  store: bitwarden-capturly-signing
   keys:
     - { secretKey: upload-keystore.jks.b64, remoteRef: d58e27ce-900d-4ae4-a178-b48100fb27a4, comment: ANDROID_KEYSTORE_BASE64 }
     - { secretKey: store-password,          remoteRef: 3328a7d4-85af-4718-98b9-b48100fb28b3, comment: ANDROID_KEYSTORE_PASSWORD }

--- a/external-secrets-operator/manifests/clustersecretstore-capturly-signing.yaml
+++ b/external-secrets-operator/manifests/clustersecretstore-capturly-signing.yaml
@@ -1,23 +1,23 @@
 ---
-# ClusterSecretStore for the original "Capturly" Bitwarden project — where the
-# Android **signing keystore** + the release-android workflow secrets live (not
-# the newer "Staging - Capturly" project the web app uses). The trusted Android
-# build reads its keystore + sentry token from here.
+# ClusterSecretStore for the "Capturly - Desktop Signing" Bitwarden project —
+# where the Android **signing keystore** + the release sentry auth token live
+# after the Phase 1 isolation split moved them out of the general "Capturly"
+# project. The trusted Android build reads its keystore + sentry token from here.
 #
 # ⚠️ The ESO machine account behind `bitwarden-credentials-build` must have read
-#    access to the "Capturly" project, or reads 404.
+#    access to the "Capturly - Desktop Signing" project, or reads 404.
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
-  name: bitwarden-capturly
+  name: bitwarden-capturly-signing
 spec:
   provider:
     bitwardensecretsmanager:
       auth:
         secretRef:
           credentials:
-            # Build-scoped machine account (reads only Build Platform + Capturly),
-            # separate from the broad web/app account (blast-radius, H8).
+            # Build-scoped machine account (reads only Build Platform + Capturly
+            # signing), separate from the broad web/app account (blast-radius, H8).
             name: bitwarden-credentials-build
             namespace: external-secrets-system
             key: token
@@ -25,7 +25,7 @@ spec:
       identityURL: https://identity.bitwarden.com
       bitwardenServerSDKURL: https://bitwarden-sdk-server.external-secrets-system.svc.cluster.local:9998
       organizationID: "4650c1c8-8d22-4073-8a7d-b3cf011d5ff2"
-      projectID: "63f8918c-424f-419b-b9d8-b3cf012d480c"  # Capturly
+      projectID: "02343bad-9242-4efa-9fa5-b49700024b51"  # Capturly - Desktop Signing
       caProvider:
         type: Secret
         name: bitwarden-tls-certs

--- a/helm-charts/build-namespace/values.yaml
+++ b/helm-charts/build-namespace/values.yaml
@@ -54,7 +54,7 @@ webhook:
 
 # Channel signing material (e.g. Android keystore). Empty list => no signing ES.
 signing:
-  store: bitwarden-capturly
+  store: bitwarden-capturly-signing
   keys: []              # list of { secretKey, remoteRef, comment? }
 
 # Keyless GCP via Workload Identity Federation (external_account, no downloaded key).


### PR DESCRIPTION
## What
The Phase 1 isolation split moved the four Android signing keys into the **Capturly - Desktop Signing** Bitwarden project (`02343bad`), but the `bitwarden-capturly` ClusterSecretStore still read the general **Capturly** project (`63f8918c`). Result: `capturly-android-signing` failed with `SecretSyncedError` and `capturly-android-trusted` stayed Degraded (even after its cert issued).

## Change
- Consolidated all five signing secrets (4 keystore keys + the sentry auth token) into the desktop-signing project. The sentry token was moved in Bitwarden; UUIDs are preserved across a project move, so no `remoteRef` changes.
- Renamed the store `bitwarden-capturly` → `bitwarden-capturly-signing` and repointed its `projectID` to `02343bad`, with comments updated to the post-Phase-1 topology.
- Updated both consumers of the store name (the `build-namespace` chart default and the `android-trusted` build target).

## Required Bitwarden action
The `bitwarden-credentials-build` machine account must have **read** access on the **Capturly - Desktop Signing** project, or the store will 404.

## Verify after merge
`capturly-android-signing` ExternalSecret goes `Ready=True` and `capturly-android-trusted` app becomes Healthy.
