### PR TITLE
fix(capturly-live): enforce non-root securityContext on web

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -16,10 +16,3 @@ misconfigurations:
   - id: KSV-0113
     paths:
       - "ar-token-refresher/rbac.yaml"
-  # capturly-live web is stock nginx:alpine (root master, pid + cache under
-  # /var/run + /var/cache) so it can't drop to non-root without an image rebuild.
-  # Follow-up: rebuild live-capturly-app on nginxinc/nginx-unprivileged, then
-  # drop this. The signaling deployment IS hardened (runs as the node user).
-  - id: KSV-0118
-    paths:
-      - "helm-charts/capturly-live/templates/web.yaml"

--- a/helm-charts/capturly-live/templates/web.yaml
+++ b/helm-charts/capturly-live/templates/web.yaml
@@ -19,6 +19,14 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       enableServiceLinks: false
+      # The image is nginx-unprivileged, running as the non-root nginx user (uid 101).
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
       {{- if .Values.imagePullSecret }}
       imagePullSecrets:
         - name: {{ .Values.imagePullSecret }}
@@ -27,6 +35,10 @@ spec:
       - name: web
         image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
         imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         ports:
         - name: http
           containerPort: {{ .Values.web.service.port }}


### PR DESCRIPTION
Completes the web hardening follow-up from #753.

## Change
- `web.yaml`: add a non-root `securityContext` (runAsNonRoot, uid/gid 101, drop ALL caps, RuntimeDefault seccomp) matching the signaling deployment.
- `.trivyignore.yaml`: drop the `KSV-0118` entry for `web.yaml` — no longer needed.

## Depends on
**live.capturly.app#3** (rebuilds the web image on `nginxinc/nginx-unprivileged`). Merge that first and let its publish workflow push to AR. Applying `runAsNonRoot` before the new image is live would CrashLoop the old root-based nginx.

## Notes
Only coturn still carries KSV-0118 (root, hostNetwork TURN relay) — out of scope here and not in this diff, so the code-scanning check is unaffected.

## Verify after both merge
`capturly-live-web` rolls to the unprivileged image and stays Running as uid 101; app remains Healthy.