### PR TITLE
feat(security): enforce business-plane image signature verification

### DIFF
--- a/kyverno-policies-business/verify-image-signatures.yaml
+++ b/kyverno-policies-business/verify-image-signatures.yaml
@@ -1,10 +1,11 @@
 ---
 # Verify keyless Cosign signatures on our own (ghcr.io/nx211/*) images in the
 # business plane. Signed by the homelab-infra build workflows via Sigstore/OIDC
-# (no key). Mirrors prod's verify-image-signature. AUDIT for now — graduate to
-# Enforce per namespace once policy-reporter is clean. Third-party ARC images
-# (ghcr.io/actions/*) are allowlisted by registry, not required to be re-signed
-# by us.
+# (no key). Mirrors prod's verify-image-signature. ENFORCE: unsigned ghcr.io/nx211/*
+# images are rejected at admission. Third-party ARC images (ghcr.io/actions/*,
+# incl. the runner pods) are allowlisted by registry and not matched here, so
+# they are unaffected. failurePolicy: Ignore keeps deploys unblocked if the
+# Sigstore/registry path has a transient error.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -14,7 +15,7 @@ metadata:
     policies.kyverno.io/category: Supply Chain
     policies.kyverno.io/severity: high
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
   background: false
   # Fail-open on webhook error so a Sigstore/registry blip never wedges deploys.
   failurePolicy: Ignore
@@ -32,10 +33,8 @@ spec:
       verifyImages:
         - imageReferences:
             - "ghcr.io/nx211/*"
-          # Audit mode can't rewrite the image to its digest, so mutation must be
-          # off (Kyverno rejects mutateDigest: true with Audit). Flip to true when
-          # this policy graduates to Enforce.
-          mutateDigest: false
+          # Enforce mode pins each verified image to its digest at admission.
+          mutateDigest: true
           attestors:
             - entries:
                 - keyless:


### PR DESCRIPTION
Graduates `verify-image-signatures-business` from **Audit → Enforce** and enables `mutateDigest` (digest pinning), completing the supply-chain follow-up from the expert-review remediation.

## Effect
Unsigned `ghcr.io/nx211/*` images in `plane: business` namespaces are rejected at admission and verified images are pinned to their digest.

## Pre-flight (verified on-cluster)
- Business-plane namespaces: `arc-runners`, `arc-systems`.
- **No `ghcr.io/nx211/*` images** run there — checked every pod and every Deployment/StatefulSet/DaemonSet/CronJob/Job template. The only image present is the third-party ARC controller (`ghcr.io/actions/gha-runner-scale-set-controller`).
- ARC **runner** pods use `ghcr.io/actions/actions-runner:latest` — `ghcr.io/actions/*`, registry-allowlisted and **not** matched by the `ghcr.io/nx211/*` rule, so CI runners are unaffected.
- The nx211 signed images (build-web-toolchain, synapse-s3, capturly-android-toolchain, allowlist-reconciler) all run in **non**-business namespaces and are out of this policy’s scope.

So Enforce blocks nothing that exists today; it is a guardrail for any future `ghcr.io/nx211/*` image deployed to the business plane. `failurePolicy: Ignore` keeps deploys unblocked on transient Sigstore/registry errors.