### PR TITLE
feat(build): PaC incoming webhook for on-demand branch builds

### DIFF
--- a/build-targets/capturly/nextjs-untrusted.yaml
+++ b/build-targets/capturly/nextjs-untrusted.yaml
@@ -12,3 +12,10 @@ runtimeClass: gvisor
 # does not exist in the Corey-Alan-Consulting org, and naming a missing team makes
 # the policy check 404 and deny everyone. Add a real team slug here only if one is
 # created.
+
+# On-demand branch builds via the Port build_branch action: an authorized POST to
+# the PaC /incoming endpoint runs .tekton/nextjs-incoming.yaml for the requested
+# branch (any branch, per targets glob).
+incoming:
+  secretKey: 6e103eb4-23ad-409b-8f73-b49800d3826f   # CAPTURLY_PAC_INCOMING_SECRET
+  targets: ["**"]

--- a/helm-charts/build-namespace/templates/externalsecrets.yaml
+++ b/helm-charts/build-namespace/templates/externalsecrets.yaml
@@ -73,3 +73,26 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if and (eq .Values.tier "untrusted") .Values.incoming.secretKey }}
+---
+# PaC incoming shared secret (untrusted). The Port build_branch action holds the
+# same value and POSTs it to the PaC /incoming endpoint to trigger a branch build.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.project }}-pac-incoming
+  namespace: {{ include "bn.namespace" . }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.incoming.store }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.project }}-pac-incoming
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+  data:
+    - secretKey: secret
+      remoteRef: { key: {{ .Values.incoming.secretKey }} }
+{{- end }}

--- a/helm-charts/build-namespace/templates/repository.yaml
+++ b/helm-charts/build-namespace/templates/repository.yaml
@@ -27,4 +27,15 @@ spec:
       ok_to_test: {{ .Values.pac.policy.ok_to_test | toJson }}
 {{- end }}
 {{- end }}
+{{- if .Values.incoming.secretKey }}
+  # On-demand branch builds: an authorized POST to the PaC /incoming endpoint with
+  # this shared secret runs the matching .tekton/ incoming PipelineRun for the
+  # requested branch. Backs the Port build_branch action.
+  incoming:
+    - type: webhook-url
+      secret:
+        name: {{ .Values.project }}-pac-incoming
+        key: secret
+      targets: {{ .Values.incoming.targets | toJson }}
+{{- end }}
 {{- end }}

--- a/helm-charts/build-namespace/values.yaml
+++ b/helm-charts/build-namespace/values.yaml
@@ -39,6 +39,16 @@ pac:
     pull_request: []
     ok_to_test: []
 
+# PaC incoming webhook (untrusted): lets an authorized caller (e.g. the Port
+# build_branch self-service action) POST to the PaC /incoming endpoint to build
+# an arbitrary branch on demand, reusing the .tekton/ incoming PipelineRun — no
+# PR required. The shared secret is synced from Bitwarden into <project>-pac-incoming;
+# the caller must present the same value. Empty secretKey => no incoming block.
+incoming:
+  store: bitwarden-build-platform
+  secretKey: ""              # Bitwarden UUID of the shared incoming secret
+  targets: ["**"]           # glob branches the incoming webhook may build
+
 # ---------------- trusted tier ------------------
 # Dedicated Contents:read build App (H4). The clone step mints a ~1h installation
 # token from these at build time — no static git credential.


### PR DESCRIPTION
## What

Adds a Pipelines-as-Code **incoming-webhook** lane to the `build-namespace` chart so an authorized caller (the Port `build_branch` action) can build **any branch on demand** — no PR required — reusing the existing untrusted PaC pipeline.

- `values.yaml`: new `incoming` block (store/secretKey/targets; empty secretKey = off).
- `repository.yaml`: renders `Repository.spec.incoming` (webhook-url + secret ref + `targets` glob) when enabled.
- `externalsecrets.yaml`: syncs the shared secret into `<project>-pac-incoming` (untrusted only).
- `build-targets/capturly/nextjs-untrusted.yaml`: enabled with `targets: ["**"]` (any branch), secret `CAPTURLY_PAC_INCOMING_SECRET`.

## Companion changes
- capturly.app: `.tekton/nextjs-incoming.yaml` (`on-event:[incoming]`, `on-target-branch:[**]`) — separate PR.
- platform-infra: the `build_branch` Port action that POSTs to the PaC `/incoming` endpoint — separate PR.

## Validation
- `helm template` renders the ExternalSecret + `Repository.spec.incoming` correctly (secret `6e103eb4…`, targets `["**"]`).
- Trusted target (android) renders **zero** incoming objects (defaults off) — no regression.
- `helm lint` clean.