### PR TITLE
feat(build): bake offline native-build inputs into web-toolchain

### DIFF
--- a/.github/workflows/build-web-toolchain.yml
+++ b/.github/workflows/build-web-toolchain.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   IMAGE: ghcr.io/nx211/build-web-toolchain
-  VERSION: "0.1.0"
+  VERSION: "0.2.0"
   TASK: build-catalog/tasks/web-ci.yaml
 
 jobs:

--- a/apps/build-web-toolchain/Dockerfile
+++ b/apps/build-web-toolchain/Dockerfile
@@ -8,6 +8,23 @@
 # so an arbitrary non-root uid can run it.
 FROM node:22-bookworm
 
-RUN npm install -g pnpm@9.15.9 \
+RUN npm install -g pnpm@9.15.9 node-gyp \
     && npm cache clean --force \
     && chmod -R a+rX /usr/local/lib/node_modules
+
+# --- Offline native-build support (untrusted sandbox: egress = Verdaccio only) ---
+# The web-ci `checks` pod can reach ONLY the npm proxy, so any dependency that
+# fetches a binary at install time fails (observed: keytar, electron). Pre-bake
+# those inputs here, where the network IS available, so postinstall/node-gyp
+# resolve entirely offline. Made world-readable for the arbitrary non-root uid.
+
+# node-gyp headers for THIS image's Node version, so native modules (e.g. keytar)
+# build from source offline instead of fetching headers from nodejs.org. python3/
+# make/g++ already ship in node:22-bookworm.
+ENV npm_config_devdir=/opt/node-gyp
+RUN node-gyp install --devdir=/opt/node-gyp \
+    && chmod -R a+rX /opt/node-gyp
+
+# electron ships a large runtime binary the web lint/type-check/build/test never
+# executes, downloaded from a CDN the sandbox can't reach; skip that download.
+ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1


### PR DESCRIPTION
## What

Fixes the untrusted `web-ci` checks failing at `pnpm install` — the root cause behind capturly.app #359/#360 and a blocker for the new `build_branch` action.

The untrusted checks pod's egress NetworkPolicy allows **only** the Verdaccio proxy (by design), but capturly.app deps download binaries at install time:
- **keytar** — `prebuild-install` can't reach GitHub, falls back to node-gyp which can't fetch Node headers from nodejs.org.
- **electron** — downloads a ~100MB runtime binary from a CDN.

### Fix (bake into the image, where network is available)
- Install `node-gyp` globally + `node-gyp install` the headers for the image's Node version into a world-readable `/opt/node-gyp`, and set `npm_config_devdir` → native modules build **from source offline**.
- `ELECTRON_SKIP_BINARY_DOWNLOAD=1` → electron's postinstall skips the download (web checks never run electron).
- Bump image `0.1.0` → `0.2.0`.

On merge, the `build-web-toolchain` workflow builds, cosign-signs (so it passes verify-image-signatures-business), and **auto-pins the new digest** into `build-catalog/tasks/web-ci.yaml`.

## Validation plan
After merge + image build, I'll trigger a real untrusted build to confirm checks pass. Prisma (`@prisma/engines` v5.22.0) also downloads engines at postinstall; the other observed postinstalls (parcel, workerd, sentry-cli) already succeeded. If the empirical run shows prisma still fetching, that's a fast follow-up (bake its engine cache) — fixing the two confirmed failures first.