### PR TITLE
fix(build): add libsecret-1-dev to web-toolchain for keytar

### DIFF
--- a/.github/workflows/build-web-toolchain.yml
+++ b/.github/workflows/build-web-toolchain.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   IMAGE: ghcr.io/nx211/build-web-toolchain
-  VERSION: "0.2.0"
+  VERSION: "0.3.0"
   TASK: build-catalog/tasks/web-ci.yaml
 
 jobs:

--- a/apps/build-web-toolchain/Dockerfile
+++ b/apps/build-web-toolchain/Dockerfile
@@ -8,6 +8,13 @@
 # so an arbitrary non-root uid can run it.
 FROM node:22-bookworm
 
+# keytar (native) links against libsecret at build time; node:bookworm ships
+# pkg-config but not the libsecret dev headers, so the offline node-gyp build
+# fails with "Package libsecret-1 was not found". Provide them.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libsecret-1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g pnpm@9.15.9 node-gyp \
     && npm cache clean --force \
     && chmod -R a+rX /usr/local/lib/node_modules


### PR DESCRIPTION
Iteration 2 of the offline-install fix. Baking node-gyp headers (PR #757) let keytar's node-gyp build run offline, but it now fails at `Package libsecret-1 was not found` — a missing system dev library, not a network issue. Add `libsecret-1-dev`; bump image 0.2.0 → 0.3.0 (workflow auto-pins the new signed digest into web-ci).