### PR TITLE
fix(build): bake prisma query engine into web-toolchain

### DIFF
--- a/.github/workflows/build-web-toolchain.yml
+++ b/.github/workflows/build-web-toolchain.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   IMAGE: ghcr.io/nx211/build-web-toolchain
-  VERSION: "0.3.0"
+  VERSION: "0.4.0"
   TASK: build-catalog/tasks/web-ci.yaml
 
 jobs:

--- a/apps/build-web-toolchain/Dockerfile
+++ b/apps/build-web-toolchain/Dockerfile
@@ -19,6 +19,20 @@ RUN npm install -g pnpm@9.15.9 node-gyp \
     && npm cache clean --force \
     && chmod -R a+rX /usr/local/lib/node_modules
 
+# `prisma generate` (workspace postinstalls, e.g. packages/database) bundles the
+# query engine, which it fetches from binaries.prisma.sh at generate time —
+# blocked in the sandbox. Bake the engine for the consumers' Prisma version and
+# point generate at it via PRISMA_QUERY_ENGINE_LIBRARY so it runs offline. Keep
+# PRISMA_VERSION in lockstep with capturly's prisma (packages/database).
+ENV PRISMA_VERSION=5.22.0 \
+    PRISMA_CLI_QUERY_ENGINE_TYPE=library
+RUN npm install -g "@prisma/engines@${PRISMA_VERSION}" \
+    && mkdir -p /opt/prisma \
+    && cp "$(find / -name 'libquery_engine-*.so.node' 2>/dev/null | head -1)" /opt/prisma/libquery_engine.so.node \
+    && chmod -R a+rX /opt/prisma \
+    && npm cache clean --force
+ENV PRISMA_QUERY_ENGINE_LIBRARY=/opt/prisma/libquery_engine.so.node
+
 # --- Offline native-build support (untrusted sandbox: egress = Verdaccio only) ---
 # The web-ci `checks` pod can reach ONLY the npm proxy, so any dependency that
 # fetches a binary at install time fails (observed: keytar, electron). Pre-bake


### PR DESCRIPTION
Iteration 3 (final blocker). With node headers (#757) + libsecret (#758), keytar now compiles offline and `pnpm install` reaches its last step: `packages/database` postinstall runs `prisma generate`, which fetches the query engine from binaries.prisma.sh — blocked. Bake the prisma 5.22.0 query engine into the image and point `PRISMA_QUERY_ENGINE_LIBRARY` at it; bump 0.3.0 → 0.4.0. Keep PRISMA_VERSION in lockstep with capturly's prisma version.