### PR TITLE
fix(build): bake prisma schema-engine into web-toolchain

### DIFF
--- a/.github/workflows/build-web-toolchain.yml
+++ b/.github/workflows/build-web-toolchain.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   IMAGE: ghcr.io/nx211/build-web-toolchain
-  VERSION: "0.4.0"
+  VERSION: "0.5.0"
   TASK: build-catalog/tasks/web-ci.yaml
 
 jobs:

--- a/apps/build-web-toolchain/Dockerfile
+++ b/apps/build-web-toolchain/Dockerfile
@@ -29,9 +29,14 @@ ENV PRISMA_VERSION=5.22.0 \
 RUN npm install -g "@prisma/engines@${PRISMA_VERSION}" \
     && mkdir -p /opt/prisma \
     && cp "$(find / -name 'libquery_engine-*.so.node' 2>/dev/null | head -1)" /opt/prisma/libquery_engine.so.node \
+    && cp "$(find / -name 'schema-engine-*' -type f 2>/dev/null | head -1)" /opt/prisma/schema-engine \
     && chmod -R a+rX /opt/prisma \
     && npm cache clean --force
-ENV PRISMA_QUERY_ENGINE_LIBRARY=/opt/prisma/libquery_engine.so.node
+# generate pulls BOTH the query-engine library and the schema-engine; point prisma
+# at each baked binary. Set the legacy migration-engine var too for safety.
+ENV PRISMA_QUERY_ENGINE_LIBRARY=/opt/prisma/libquery_engine.so.node \
+    PRISMA_SCHEMA_ENGINE_BINARY=/opt/prisma/schema-engine \
+    PRISMA_MIGRATION_ENGINE_BINARY=/opt/prisma/schema-engine
 
 # --- Offline native-build support (untrusted sandbox: egress = Verdaccio only) ---
 # The web-ci `checks` pod can reach ONLY the npm proxy, so any dependency that


### PR DESCRIPTION
Iteration 4. With the query engine baked (#759), `prisma generate` now fails fetching the **schema-engine** (`schema-engine.gz.sha256` from binaries.prisma.sh). `@prisma/engines` ships both engines; bake the schema-engine too and set `PRISMA_SCHEMA_ENGINE_BINARY` (+ legacy migration var). Bump 0.4.0 → 0.5.0.