### PR TITLE
fix(build): preserve repo .npmrc in web-ci (node-linker=hoisted)

### DIFF
--- a/build-catalog/tasks/web-ci.yaml
+++ b/build-catalog/tasks/web-ci.yaml
@@ -34,7 +34,12 @@ spec:
         #!/usr/bin/env bash
         set -euo pipefail
         # pnpm is baked into the image (non-root); no corepack enable needed.
-        cp /config/npm/.npmrc "$HOME/.npmrc"   # registry = Verdaccio, no auth
+        # APPEND the Verdaccio registry — do NOT overwrite. HOME is the repo root,
+        # so `cp` would clobber the repo's committed .npmrc, which sets
+        # node-linker=hoisted. That setting is required: it hoists @types/node into
+        # the root node_modules where every package's tsc finds Node globals
+        # (Buffer/setTimeout). Overwriting it broke every package's build offline.
+        cat /config/npm/.npmrc >> "$HOME/.npmrc"   # registry = Verdaccio, no auth
         pnpm install --frozen-lockfile
         # apps/web type-checks against the compiled dist/ of its workspace deps.
         pnpm --filter "@capturly/web^..." --if-present build


### PR DESCRIPTION
## Root cause (the real one behind #359)

The untrusted nextjs build failed with `Cannot find name 'Buffer'/'setTimeout'` across packages. After baking the offline toolchain (install now runs), the true cause surfaced:

- The repo's committed `.npmrc` sets **`node-linker=hoisted`** (for RN/CocoaPods). That hoists `@types/node` into the **root** `node_modules`, where every package's `tsc` auto-includes it → Node globals resolve.
- `web-ci` sets `HOME=$(workspaces.source.path)` (**the repo root**) and did `cp /config/npm/.npmrc "$HOME/.npmrc"` — **overwriting the repo's `.npmrc`**, dropping `node-linker=hoisted`. The install fell back to pnpm's isolated layout, `@types/node` was no longer at the root, and every package's build failed to resolve Node globals.

## Fix
Append the Verdaccio registry instead of overwriting, preserving `node-linker=hoisted`.

## Evidence
Locally (hoisted): `turbo run type-check` 24/24 pass, `build` (web dep closure) 8/8 pass — **zero** real code errors. Hiding `@types/node` from tsc reproduces the exact CI error `LiveBackupSession.ts(31,35): Cannot find name 'setTimeout'`. So this one-line fix resolves all packages; no app-code changes needed.