### PR TITLE
fix(build): pass toolchain env to turbo tasks (TURBO_ENV_MODE=loose)

### DIFF
--- a/build-catalog/tasks/web-ci.yaml
+++ b/build-catalog/tasks/web-ci.yaml
@@ -30,6 +30,13 @@ spec:
         # Turbo/CI hints; no secrets.
         - name: CI
           value: "true"
+        # turbo 2.x defaults to strict env mode, which strips the toolchain's
+        # baked offline-build vars (PRISMA_QUERY_ENGINE_LIBRARY, ELECTRON_SKIP_*)
+        # from task processes, so `prisma generate` in a build task can't find the
+        # baked engine and tries to download it (blocked). loose passes the pod env
+        # through to tasks. Safe here: the untrusted tier is zero-secret by design.
+        - name: TURBO_ENV_MODE
+          value: loose
       script: |
         #!/usr/bin/env bash
         set -euo pipefail


### PR DESCRIPTION
Follow-up to #761. With node-linker preserved, the untrusted build now installs offline, lints clean, and clears all type errors — but `@capturly/database:build` (`prisma generate && tsc`) fails: turbo 2.x **strict** env mode strips the toolchain image's baked `PRISMA_QUERY_ENGINE_LIBRARY` from the task, so generate tries to download the engine (blocked). Set `TURBO_ENV_MODE=loose` so build tasks inherit the prepared offline env. Verified turbo honors the var (dry-run: envMode=loose). Safe: untrusted tier is zero-secret.