### PR TITLE
feat(build): android untrusted lane (unsigned PR/branch builds)

### DIFF
--- a/build-catalog/pipelines/android-pr.yaml
+++ b/build-catalog/pipelines/android-pr.yaml
@@ -1,0 +1,68 @@
+---
+# Channel pipeline: android-pr (UNTRUSTED PR / branch tier). Clone → unsigned
+# assembleDebug (does-this-branch-compile). No keystore, no approval, no Play
+# publish — the signed release flow is android-build.yaml (trusted). PaC provides
+# git auth via the bound basic-auth workspace; the project's .tekton PipelineRun
+# sets runtimeClassName: kata (native/NDK). Shares the capturly untrusted
+# namespace + gradle-cache with the nextjs untrusted lane.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: android-pr
+  labels:
+    app.kubernetes.io/part-of: build-catalog
+spec:
+  params:
+    - name: repo-url
+      type: string
+    - name: revision
+      type: string
+      default: ""
+    - name: toolchain-image
+      type: string
+      default: ghcr.io/nx211/capturly-android-toolchain:0.1.0@sha256:75cd7eb9dee3f7e1c43a7b359950ac49d69a99415067b40db576cbd6fdfc748e
+  workspaces:
+    - name: source
+    - name: npmrc
+    - name: gradle-cache
+      optional: true
+    - name: basic-auth       # PaC-provided git token for the private clone
+      optional: true
+  tasks:
+    - name: clone
+      workspaces:
+        - { name: output, workspace: source }
+        - { name: basic-auth, workspace: basic-auth }
+      taskSpec:
+        workspaces:
+          - name: output
+          - name: basic-auth
+            optional: true
+        steps:
+          - name: git-clone
+            image: alpine/git:2.45.2
+            script: |
+              #!/bin/sh
+              set -eu
+              if [ -f "$(workspaces.basic-auth.path)/.git-credentials" ]; then
+                cp "$(workspaces.basic-auth.path)/.git-credentials" "$HOME/.git-credentials"
+                cp "$(workspaces.basic-auth.path)/.gitconfig" "$HOME/.gitconfig" 2>/dev/null || true
+                git config --global credential.helper store
+              fi
+              cd "$(workspaces.output.path)"
+              git clone "$(params.repo-url)" .
+              [ -n "$(params.revision)" ] && git checkout "$(params.revision)" || true
+    - name: build
+      runAfter: [clone]
+      taskRef:
+        resolver: git
+        params:
+          - { name: url, value: https://github.com/NX211/homelab-infra.git }
+          - { name: revision, value: main }
+          - { name: pathInRepo, value: build-catalog/tasks/build-unsigned-apk.yaml }
+      params:
+        - { name: toolchain-image, value: $(params.toolchain-image) }
+      workspaces:
+        - { name: source, workspace: source }
+        - { name: npmrc, workspace: npmrc }
+        - { name: gradle-cache, workspace: gradle-cache }

--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -1,0 +1,57 @@
+---
+# Reusable catalog Task: build an UNSIGNED Android debug APK for the untrusted
+# PR / branch-check tier. It answers "does this branch compile?" — pnpm workspace
+# deps (via the per-tier Verdaccio proxy, no npm token) → gradle assembleDebug
+# (debug signing config only; NO release keystore, NO Sentry, NO Play publish).
+# The signed release flow is build-signed-aab.yaml (trusted tier). Zero-secret:
+# this Task mounts no keystore/WIF/GitHub-App workspace.
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-unsigned-apk
+  labels:
+    app.kubernetes.io/part-of: build-catalog
+spec:
+  params:
+    - name: toolchain-image
+      description: Node+pnpm+JDK17+Android SDK/NDK image the build runs in.
+      type: string
+    - name: mobile-dir
+      description: Path to the mobile app within the repo.
+      type: string
+      default: apps/mobile
+  workspaces:
+    - name: source        # cloned repo
+    - name: gradle-cache  # persistent ~/.gradle (baked offline deps land here)
+      optional: true
+    - name: npmrc         # configMap: .npmrc pointing at Verdaccio (no token)
+      mountPath: /config/npm
+  steps:
+    - name: pnpm-workspace-deps
+      image: $(params.toolchain-image)
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: HOME
+          value: $(workspaces.source.path)
+        - name: CI
+          value: "true"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        cp /config/npm/.npmrc "$HOME/.npmrc"   # registry = Verdaccio, no auth
+        pnpm install --frozen-lockfile
+        # Metro resolves workspace deps via their built dist/ — compile first.
+        pnpm --filter "@capturly/mobile^..." --if-present build
+    - name: gradle-assemble-debug
+      image: $(params.toolchain-image)
+      workingDir: $(workspaces.source.path)/$(params.mobile-dir)
+      env:
+        - name: HOME
+          value: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # Debug build only — uses the auto-generated debug keystore, no release
+        # signing material. Compiles RN + native/NDK; that's the PR-check signal.
+        ./gradlew assembleDebug --no-daemon
+        ls -la app/build/outputs/apk/debug/ || true

--- a/build-targets/capturly/nextjs-untrusted.yaml
+++ b/build-targets/capturly/nextjs-untrusted.yaml
@@ -1,11 +1,19 @@
-# Inventory entry: capturly web/nextjs PR checks (untrusted tier).
+# Inventory entry: capturly untrusted build namespace (PR / branch checks).
 # Rendered by charts/build-namespace via the build-targets ApplicationSet.
 # namespace -> capturly-builds-untrusted ; pipeline SA -> capturly-nextjs-untrusted.
+# This one target owns the shared capturly-builds-untrusted namespace + the single
+# `capturly` PaC Repository; BOTH the nextjs (.tekton/nextjs-*.yaml, gVisor) and
+# android (.tekton/android-*.yaml, kata) untrusted lanes run here, routed by PaC
+# to the right .tekton PipelineRun. gradleCache serves the android assembleDebug.
 project: capturly
 channel: nextjs
 tier: untrusted
 repo: Corey-Alan-Consulting/capturly.app
 runtimeClass: gvisor
+
+# Persistent ~/.gradle for the android untrusted assembleDebug (shared namespace).
+gradleCache:
+  enabled: true
 
 # No pac.policy: use PaC's default ACL (owner + write-collaborators auto-run;
 # external/fork PRs need a maintainer /ok-to-test). The capturly-maintainers team

--- a/helm-charts/build-namespace/templates/gradle-cache.yaml
+++ b/helm-charts/build-namespace/templates/gradle-cache.yaml
@@ -1,7 +1,8 @@
-{{- if and (eq .Values.tier "trusted") .Values.gradleCache.enabled }}
+{{- if .Values.gradleCache.enabled }}
 ---
-# Persistent Gradle/ccache store for the native build. RWO is fine — releases are
-# serialized (one at a time), so no concurrent-writer conflict.
+# Persistent Gradle/ccache store for native builds. RWO: trusted releases are
+# serialized; untrusted android PR/branch builds also serialize on the cache
+# (RWX via Longhorn for concurrency is a build-platform-reuse hardening item).
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
#18. Stands up the android untrusted build lane in the shared capturly untrusted namespace.

- **build-unsigned-apk task**: pnpm workspace deps (Verdaccio) + `gradlew assembleDebug` — zero-secret, no keystore/approval/Play-publish (the signed release flow stays build-signed-aab).
- **android-pr pipeline**: clone (PaC basic-auth) → unsigned build; consumed from capturly.app `.tekton/android-{pr,incoming}.yaml` (kata runtime).
- **gradle-cache** PVC enabled for the shared `capturly-builds-untrusted` namespace (relaxed the trusted-only gate; RWO, serialized — RWX is a #19 item).

Companions (separate): capturly.app `.tekton/android-{pr,incoming}.yaml` + `build_branch` channel input. ⚠️ First real build will validate/iterate the offline path (gradle deps in the egress-restricted lane likely need android-toolchain baking).