### PR TITLE
feat(build): kata node-bootstrap installer (unblocks android sandbox)

### DIFF
--- a/docs/runbooks/tekton-build-platform.md
+++ b/docs/runbooks/tekton-build-platform.md
@@ -25,8 +25,12 @@ superseded). Design: [ADR-0017](../../../framework/decisions/0017-tekton-build-p
    needs the runsc binary + a containerd runtime entry. The tracked installer +
    template live in **`node-bootstrap/gvisor/`** (which nodes, exact steps,
    verification, and the optional full-GitOps DaemonSet/SUC path). A rebuilt node
-   silently loses the sandbox until re-run. Kata (for the Android/NDK untrusted
-   channel) is added later via `kata-deploy`.
+   silently loses the sandbox until re-run. Kata (for the Android/NDK channels —
+   trusted release + untrusted branch check) installs the same way: the tracked
+   installer + steps live in **`node-bootstrap/kata/`** (`install-kata.sh`, KVM
+   preflight, per-node run, verification). Run it on every build node before
+   using `runtimeClassName: kata`, or android pods fail with
+   `no runtime for "kata" is configured`.
 2. **Pin/verify release versions** before first sync:
    - operator `tekton/operator/kustomization.yaml` (v0.78.0 LTS)
    - PaC `tekton/pac/kustomization.yaml` (`release.k8s.yaml`, v0.41.1)

--- a/node-bootstrap/kata/README.md
+++ b/node-bootstrap/kata/README.md
@@ -1,0 +1,58 @@
+# Node bootstrap: Kata Containers (kata)
+
+The Tekton build platform uses `runtimeClassName: kata` for **native/NDK**
+channels that gVisor's userspace kernel can't run — the **Android** builds, both
+the trusted release (`android-build`) and the untrusted branch check
+(`android-pr`). k3s does **not** auto-detect kata, so each node that schedules
+those pods needs the kata binaries + a containerd runtime entry. This is
+node-level (**not GitOps**); the script + steps are tracked here so they're
+version-controlled and identical across nodes — mirrors `node-bootstrap/gvisor/`.
+
+> **Why this exists:** the `kata` RuntimeClass
+> (`tekton/runtimeclasses/kata.yaml`) was created before the handler was
+> installed on any node, so kata pods land on nodes without the runtime and fail
+> with `FailedCreatePodSandBox: no runtime for "kata" is configured`. Until this
+> runs on the build nodes, **both** the untrusted android build_branch lane and
+> the trusted android release build cannot schedule.
+
+## Prerequisite
+
+Each target node needs **KVM** (`/dev/kvm`) — kata's QEMU hypervisor. The
+bare-metal homelab nodes have it (kata runs natively, no nested virt). The
+installer preflights this and aborts if missing.
+
+## Which nodes?
+
+Every node a kata (android) build pod can land on. With no build-node taint,
+that's **all worker nodes** (blacktalon, greytalon, redtalon, yellowtalon) — same
+as runsc/gVisor. To dedicate a build node instead, taint+label it and add a
+matching nodeSelector/toleration to the android pipeline podTemplates (ask first —
+it changes the build-catalog + the `.tekton/android-*.yaml`).
+
+## Install (per node, has sudo)
+
+```bash
+# copy install-kata.sh to the node, then:
+sudo KATA_RELEASE=latest ./install-kata.sh
+```
+
+Pin `KATA_RELEASE` to a dated release (e.g. `3.13.0`) for reproducibility. The
+script installs `kata-static` to `/opt/kata`, symlinks `containerd-shim-kata-v2`
+onto containerd's PATH, appends the `runtimes.kata` block to the k3s containerd
+template (preserving the existing `runsc` block), and restarts k3s.
+
+> ⚠️ It restarts k3s. On the **server** node (blacktalon) that's a brief API
+> blip — do it last / during a quiet window. Agent nodes just drain their pods.
+
+## Verify
+
+```bash
+kubectl get runtimeclass kata
+kubectl run katatest --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"runtimeClassName":"kata"}}' --command -- sh -c 'uname -a'
+kubectl logs katatest    # kata reports its guest-VM kernel -> sandbox works
+kubectl delete pod katatest
+```
+
+Then re-run an android build_branch (Port → channel=android) or a trusted android
+release; the pod should schedule and run under kata.

--- a/node-bootstrap/kata/install-kata.sh
+++ b/node-bootstrap/kata/install-kata.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Install Kata Containers (kata-static) and register it as a k3s containerd
+# runtime, so pods with runtimeClassName: kata can schedule on this node — the
+# Tekton untrusted native/NDK channel (Android). Run as a user with sudo on
+# EVERY node that will schedule kata build pods.
+#
+# NOT GitOps: this touches node binaries + /var/lib/rancher/k3s and restarts k3s.
+# Tracked here only so the steps are version-controlled + identical across nodes.
+# Idempotent — safe to re-run (e.g. after a node rebuild). Requires KVM
+# (/dev/kvm) — bare-metal homelab nodes have it (kata runs natively, no nested virt).
+set -euo pipefail
+
+# Pin a dated kata release for reproducibility (https://github.com/kata-containers/kata-containers/releases).
+# "latest" is convenient but unpinned — set e.g. 3.13.0 for prod repeatability.
+KATA_RELEASE="${KATA_RELEASE:-latest}"
+
+echo "== 0/3 preflight: KVM present =="
+[ -e /dev/kvm ] || { echo "ERROR: /dev/kvm missing — kata's QEMU hypervisor needs it"; exit 1; }
+
+echo "== 1/3 install kata-static + shim =="
+case "$(uname -m)" in
+  x86_64)  KARCH=amd64 ;;
+  aarch64) KARCH=arm64 ;;
+  *) echo "unsupported arch $(uname -m)"; exit 1 ;;
+esac
+if [ "$KATA_RELEASE" = latest ]; then
+  KATA_RELEASE="$(curl -sfL https://api.github.com/repos/kata-containers/kata-containers/releases/latest \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["tag_name"])')"
+fi
+url="https://github.com/kata-containers/kata-containers/releases/download/${KATA_RELEASE}/kata-static-${KATA_RELEASE}-${KARCH}.tar.xz"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT; cd "$tmp"
+echo "downloading $url"
+curl -sfL "$url" -o kata-static.tar.xz
+sudo tar -xf kata-static.tar.xz -C /                                      # extracts ./opt/kata/...
+sudo ln -sf /opt/kata/bin/containerd-shim-kata-v2 /usr/local/bin/containerd-shim-kata-v2  # on containerd PATH
+cd /
+
+echo "== 2/3 register the runtime in k3s containerd (detect containerd 1.x vs 2.x) =="
+cdir=/var/lib/rancher/k3s/agent/etc/containerd
+if [ -f "$cdir/config-v3.toml" ]; then
+  tmpl="$cdir/config-v3.toml.tmpl"; plugin='io.containerd.cri.v1.runtime'   # containerd 2.x
+else
+  tmpl="$cdir/config.toml.tmpl";     plugin='io.containerd.grpc.v1.cri'     # containerd 1.x
+fi
+block=$(printf '[plugins."%s".containerd.runtimes.kata]\n  runtime_type = "io.containerd.kata.v2"\n  [plugins."%s".containerd.runtimes.kata.options]\n    ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration.toml"\n' "$plugin" "$plugin")
+if [ -f "$tmpl" ]; then
+  # Preserve existing customizations (e.g. the runsc block); append kata only if missing.
+  if ! sudo grep -q 'runtimes.kata' "$tmpl"; then
+    printf '\n%s\n' "$block" | sudo tee -a "$tmpl" >/dev/null
+  fi
+else
+  # k3s renders config from this tmpl; {{ template "base" . }} keeps k3s's base.
+  printf '{{ template "base" . }}\n\n%s\n' "$block" | sudo tee "$tmpl" >/dev/null
+fi
+echo "wrote/updated: $tmpl (plugin: $plugin)"
+
+echo "== 3/3 restart k3s to re-render containerd config =="
+# Restart whichever unit is active (server runs k3s, agents k3s-agent).
+if systemctl is-active --quiet k3s; then
+  sudo systemctl restart k3s          # server node (blacktalon) — brief API blip
+elif systemctl is-active --quiet k3s-agent; then
+  sudo systemctl restart k3s-agent    # agent node
+else
+  echo "WARN: neither k3s nor k3s-agent is active — restart the k3s unit manually."
+fi
+
+echo "== done. verify: sudo grep -A3 runtimes.kata ${cdir}/config*.toml =="


### PR DESCRIPTION
#18 unblock. The `kata` RuntimeClass exists but the handler was never installed on the nodes, so android pods fail `no runtime for "kata" is configured` — blocking **both** the new untrusted android build_branch lane **and** the existing trusted android release.

Adds the tracked per-node installer `node-bootstrap/kata/install-kata.sh` (+ README), mirroring `node-bootstrap/gvisor/`: kata-static + shim, `runtimes.kata` containerd entry in the k3s config template (preserving runsc), k3s restart, KVM preflight, idempotent. **Node-level (not GitOps)** — the operator runs it on each build node (sudo; restarts k3s). Updates the tekton runbook.

After it's run on the nodes: re-fire an android build_branch (channel=android) — it'll schedule under kata, then the offline-gradle iteration begins.