### PR TITLE
feat(build): prisma-engines mirror (de-couple toolchain from prisma version)

### DIFF
--- a/.github/workflows/build-web-toolchain.yml
+++ b/.github/workflows/build-web-toolchain.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   IMAGE: ghcr.io/nx211/build-web-toolchain
-  VERSION: "0.5.0"
+  VERSION: "0.6.0"
   TASK: build-catalog/tasks/web-ci.yaml
 
 jobs:

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -16,3 +16,9 @@ misconfigurations:
   - id: KSV-0113
     paths:
       - "ar-token-refresher/rbac.yaml"
+  # prisma-engines mirror pulls the upstream nginx-unprivileged image from
+  # docker.io (same as the sibling verdaccio proxy). No ghcr re-mirror yet;
+  # accepted, path-scoped. All other KSV findings on this file are hardened.
+  - id: KSV-0125
+    paths:
+      - "build-registry-proxy/prisma-mirror.yaml"

--- a/apps/build-web-toolchain/Dockerfile
+++ b/apps/build-web-toolchain/Dockerfile
@@ -19,26 +19,13 @@ RUN npm install -g pnpm@9.15.9 node-gyp \
     && npm cache clean --force \
     && chmod -R a+rX /usr/local/lib/node_modules
 
-# `prisma generate` (workspace postinstalls, e.g. packages/database) bundles the
-# query engine, which it fetches from binaries.prisma.sh at generate time —
-# blocked in the sandbox. Bake the engine for the consumers' Prisma version and
-# point generate at it via PRISMA_QUERY_ENGINE_LIBRARY so it runs offline. Keep
-# PRISMA_VERSION in lockstep with capturly's prisma (packages/database).
-ENV PRISMA_VERSION=5.22.0 \
-    PRISMA_CLI_QUERY_ENGINE_TYPE=library
-RUN npm install -g "@prisma/engines@${PRISMA_VERSION}" \
-    && mkdir -p /opt/prisma \
-    && cp "$(find / -name 'libquery_engine-*.so.node' 2>/dev/null | head -1)" /opt/prisma/libquery_engine.so.node \
-    && cp "$(find / -name 'schema-engine-*' -type f 2>/dev/null | head -1)" /opt/prisma/schema-engine \
-    && chmod -R a+rX /opt/prisma \
-    && npm cache clean --force
-# generate pulls BOTH the query-engine library and the schema-engine; point prisma
-# at each baked binary. Set the legacy migration-engine var too for safety.
-ENV PRISMA_QUERY_ENGINE_LIBRARY=/opt/prisma/libquery_engine.so.node \
-    PRISMA_SCHEMA_ENGINE_BINARY=/opt/prisma/schema-engine \
-    PRISMA_MIGRATION_ENGINE_BINARY=/opt/prisma/schema-engine
+# NOTE: prisma engines are NO LONGER baked here (that pinned the image to one
+# prisma version). `prisma generate` now fetches them offline from the per-tier
+# prisma-engines mirror (build-registry-proxy/prisma-mirror.yaml) via
+# PRISMA_ENGINES_MIRROR, set on the web-ci `checks` step — so any prisma version
+# resolves without a toolchain rebuild. See build-catalog/tasks/web-ci.yaml.
 
-# --- Offline native-build support (untrusted sandbox: egress = Verdaccio only) ---
+# --- Offline native-build support (untrusted sandbox: egress = proxies only) ---
 # The web-ci `checks` pod can reach ONLY the npm proxy, so any dependency that
 # fetches a binary at install time fails (observed: keytar, electron). Pre-bake
 # those inputs here, where the network IS available, so postinstall/node-gyp

--- a/build-catalog/tasks/web-ci.yaml
+++ b/build-catalog/tasks/web-ci.yaml
@@ -37,6 +37,12 @@ spec:
         # through to tasks. Safe here: the untrusted tier is zero-secret by design.
         - name: TURBO_ENV_MODE
           value: loose
+        # prisma generate fetches engines from the per-tier prisma-engines mirror
+        # (a caching reverse-proxy to binaries.prisma.sh) instead of a version-
+        # pinned bake in the toolchain image — so any prisma version resolves
+        # offline. loose env-mode passes this through to the build tasks.
+        - name: PRISMA_ENGINES_MIRROR
+          value: http://prisma-mirror-untrusted.build-registry-proxy.svc.cluster.local:8080
       script: |
         #!/usr/bin/env bash
         set -euo pipefail

--- a/build-registry-proxy/kustomization.yaml
+++ b/build-registry-proxy/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - networkpolicy-and-namespace.yaml
   - externalsecret-npm-uplink.yaml
   - verdaccio.yaml
+  - prisma-mirror.yaml

--- a/build-registry-proxy/prisma-mirror.yaml
+++ b/build-registry-proxy/prisma-mirror.yaml
@@ -1,0 +1,113 @@
+---
+# Prisma engines caching mirror (UNTRUSTED tier). An nginx reverse-proxy to
+# binaries.prisma.sh so untrusted build pods fetch prisma engines offline-from-
+# mirror via PRISMA_ENGINES_MIRROR — instead of a version-pinned bake in the
+# build-web-toolchain image (which couples the toolchain to one prisma version).
+# Any prisma version now resolves through the mirror. Same per-tier isolation as
+# verdaccio (H3): untrusted-only ingress; its own egress to the public CDN.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prisma-mirror-config
+  namespace: build-registry-proxy
+data:
+  nginx.conf: |
+    worker_processes 1;
+    error_log /dev/stderr warn;
+    pid /tmp/nginx.pid;
+    events { worker_connections 1024; }
+    http {
+      access_log off;
+      proxy_temp_path  /tmp/proxy_temp;
+      client_body_temp_path /tmp/client_temp;
+      proxy_cache_path /tmp/cache levels=1:2 keys_zone=prisma:10m max_size=2g inactive=90d use_temp_path=off;
+      server {
+        listen 8080;
+        # Engine artifacts are immutable (content-addressed by commit hash) → cache hard.
+        location / {
+          proxy_pass https://binaries.prisma.sh;
+          proxy_set_header Host binaries.prisma.sh;
+          proxy_ssl_server_name on;
+          proxy_cache prisma;
+          proxy_cache_valid 200 206 90d;
+          proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+          proxy_cache_lock on;
+        }
+        location = /healthz { return 200 'ok'; add_header Content-Type text/plain; }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prisma-mirror-untrusted
+  namespace: build-registry-proxy
+  labels: { app: prisma-mirror-untrusted, app.kubernetes.io/name: prisma-mirror }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: prisma-mirror-untrusted }
+  template:
+    metadata:
+      labels: { app: prisma-mirror-untrusted, app.kubernetes.io/name: prisma-mirror }
+    spec:
+      enableServiceLinks: false
+      securityContext: { runAsNonRoot: true, runAsUser: 101, fsGroup: 101 }
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          ports: [{ containerPort: 8080, name: http }]
+          volumeMounts:
+            - { name: config, mountPath: /etc/nginx/nginx.conf, subPath: nginx.conf, readOnly: true }
+            - { name: tmp, mountPath: /tmp }
+          resources:
+            requests: { cpu: 25m, memory: 64Mi }
+            limits: { cpu: "1", memory: 512Mi }
+          readinessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+            initialDelaySeconds: 3
+      volumes:
+        - { name: config, configMap: { name: prisma-mirror-config } }
+        - { name: tmp, emptyDir: {} }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prisma-mirror-untrusted
+  namespace: build-registry-proxy
+spec:
+  selector: { app: prisma-mirror-untrusted }
+  ports: [{ port: 8080, targetPort: 8080, name: http }]
+---
+# Egress: DNS + public HTTPS (binaries.prisma.sh) only — mirrors verdaccio-egress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prisma-mirror-egress
+  namespace: build-registry-proxy
+spec:
+  podSelector: { matchLabels: { app.kubernetes.io/name: prisma-mirror } }
+  policyTypes: [Egress]
+  egress:
+    - to: [{ namespaceSelector: {} }]
+      ports: [{ protocol: UDP, port: 53 }, { protocol: TCP, port: 53 }]
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]
+      ports: [{ protocol: TCP, port: 443 }]
+---
+# Per-tier ingress (H3): only untrusted-tier build namespaces may reach it.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prisma-mirror-untrusted-ingress
+  namespace: build-registry-proxy
+spec:
+  podSelector: { matchLabels: { app: prisma-mirror-untrusted } }
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels: { build.capturly/tier: untrusted }
+      ports: [{ protocol: TCP, port: 8080 }]

--- a/build-registry-proxy/prisma-mirror.yaml
+++ b/build-registry-proxy/prisma-mirror.yaml
@@ -52,14 +52,31 @@ spec:
       labels: { app: prisma-mirror-untrusted, app.kubernetes.io/name: prisma-mirror }
     spec:
       enableServiceLinks: false
-      securityContext: { runAsNonRoot: true, runAsUser: 101, fsGroup: 101 }
+      # uid/gid > 10000 (KSV-0020/0021), matches verdaccio. nginx-unprivileged
+      # runs as an arbitrary non-root uid: it writes only to /tmp (pid + caches,
+      # all redirected in nginx.conf) so readOnlyRootFilesystem holds.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile: { type: RuntimeDefault }
       containers:
         - name: nginx
           image: nginxinc/nginx-unprivileged:1.27-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: [ALL] }
+            seccompProfile: { type: RuntimeDefault }
           ports: [{ containerPort: 8080, name: http }]
           volumeMounts:
             - { name: config, mountPath: /etc/nginx/nginx.conf, subPath: nginx.conf, readOnly: true }
             - { name: tmp, mountPath: /tmp }
+            # Empty dir masks the image's default.conf so the entrypoint's
+            # 10-listen-on-ipv6 script early-returns instead of sed-ing a
+            # read-only file. nginx.conf does not include conf.d.
+            - { name: confd, mountPath: /etc/nginx/conf.d }
           resources:
             requests: { cpu: 25m, memory: 64Mi }
             limits: { cpu: "1", memory: 512Mi }
@@ -69,6 +86,7 @@ spec:
       volumes:
         - { name: config, configMap: { name: prisma-mirror-config } }
         - { name: tmp, emptyDir: {} }
+        - { name: confd, emptyDir: {} }
 ---
 apiVersion: v1
 kind: Service

--- a/helm-charts/build-namespace/templates/networkpolicy.yaml
+++ b/helm-charts/build-namespace/templates/networkpolicy.yaml
@@ -34,7 +34,7 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels: { build.capturly/component: registry-proxy }
-      ports: [{ protocol: TCP, port: 4873 }]
+      ports: [{ protocol: TCP, port: 4873 }, { protocol: TCP, port: 8080 }]  # 4873 verdaccio (npm), 8080 prisma-engines mirror
 ---
 # `clone` (no PR code, git only): public HTTPS for the GitHub clone. Private
 # ranges + link-local (169.254 metadata) excluded (anti lateral-movement / SSRF).


### PR DESCRIPTION
#19 reuse-hardening. The build-web-toolchain image baked a **version-pinned** prisma engine (5.22.0), so a second service on a different prisma version would fail offline. Replace the bake with a **per-tier prisma-engines caching mirror** (nginx → binaries.prisma.sh, same isolation model as verdaccio):

- `build-registry-proxy/prisma-mirror.yaml` — nginx caching proxy (untrusted tier) + egress(HTTPS)/ingress(untrusted-only) netpols; added to kustomization.
- `web-ci`: `PRISMA_ENGINES_MIRROR` → the mirror; checks-egress netpol opened to port 8080.
- `build-web-toolchain` 0.5.0 → **0.6.0**: prisma bake removed (node-gyp headers / libsecret / electron-skip kept).

⚠️ Validation: after merge (mirror deploys + toolchain re-pins), I'll re-fire a nextjs build_branch — `prisma generate` should fetch from the mirror. If it regresses, revert the de-bake (keep the bake) and iterate.