### PR TITLE
fix(build): reserve CPU for the web-ci checks step

### DIFF
--- a/build-catalog/tasks/web-ci.yaml
+++ b/build-catalog/tasks/web-ci.yaml
@@ -24,6 +24,14 @@ spec:
     - name: checks
       image: $(params.node-image)
       workingDir: $(workspaces.source.path)
+      # Guaranteed CPU so the vitest suite doesn't starve under node contention.
+      # With no request, the step got scheduled with zero reserved CPU and, on a
+      # busy node under gVisor, tests hit their 15s wall-clock timeout. 4 cores
+      # reserved (burst to 8) gives the parallel test/build workers real time;
+      # well within the 32-core build nodes.
+      computeResources:
+        requests: { cpu: "4", memory: 4Gi }
+        limits: { cpu: "8", memory: 8Gi }
       env:
         - name: HOME
           value: $(workspaces.source.path)


### PR DESCRIPTION
The shared `web-ci` `checks` step carried no resource request, so on a busy node under gVisor the vitest suite (1732 tests) starved and hit 15s wall-clock timeouts — 11 of 18 failures on a validation build were timeouts, not logic. Reserve 4 cores (burst to 8) + 4Gi so the parallel test/build workers get real time. Service-agnostic (all web builds); well within the 32-core build nodes. Follow-up to #19 prisma-mirror validation.