### PR TITLE
feat(build): Tekton coschedule=pipelineruns (multi-PVC android lane)

### DIFF
--- a/tekton/config/tektonconfig.yaml
+++ b/tekton/config/tektonconfig.yaml
@@ -23,6 +23,12 @@ spec:
     # Defense-in-depth on top of gVisor. Validated non-root with a smoke run of the
     # (tools-pre-baked) web + android images before enabling (3b-1).
     set-security-context: true
+    # The android lane's build TaskRun binds two PVC workspaces (source +
+    # gradle-cache). The default "workspaces" affinity mode allows only one PVC
+    # per TaskRun ("more than one PersistentVolumeClaim is bound"). "pipelineruns"
+    # co-locates all of a PipelineRun's pods on one node, so multiple (node-bound
+    # local-path) PVCs attach. Applies cluster-wide; fine for build workloads.
+    coschedule: pipelineruns
   chain:
     # Chains controller runs now; keyless Sigstore signing (Fulcio/Rekor) + SLSA
     # provenance config is wired in Phase 1 with the trusted Android pipeline


### PR DESCRIPTION
The android `build` TaskRun binds two PVC workspaces (`source` + `gradle-cache`), but the cluster's default `coschedule: workspaces` allows only one PVC per TaskRun → `more than one PersistentVolumeClaim is bound`. Set `coschedule: pipelineruns` in the TektonConfig CR (operator-reconciled feature-flag) so a PipelineRun's pods co-locate on one node and both node-bound local-path PVCs attach. Cluster-wide change; appropriate for build workloads. Unblocks the android kata build (#18).