### PR TITLE
fix(build): allow untrusted `build` task to reach Verdaccio

### DIFF
--- a/helm-charts/build-namespace/templates/networkpolicy.yaml
+++ b/helm-charts/build-namespace/templates/networkpolicy.yaml
@@ -20,7 +20,9 @@ spec:
     - to: [{ namespaceSelector: {} }]
       ports: [{ protocol: UDP, port: 53 }, { protocol: TCP, port: 53 }]
 ---
-# `checks` (arbitrary PR code): Verdaccio ONLY — no public egress, no lateral.
+# `checks` + `build` (arbitrary PR code): Verdaccio ONLY — no public egress, no
+# lateral. Both tasks run untrusted PR code that installs npm deps through the
+# proxy (nextjs in `checks`, android pnpm-workspace-deps in `build`).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -28,7 +30,8 @@ metadata:
   namespace: {{ include "bn.namespace" . }}
 spec:
   podSelector:
-    matchLabels: { tekton.dev/pipelineTask: checks }
+    matchExpressions:
+      - { key: tekton.dev/pipelineTask, operator: In, values: [checks, build] }
   policyTypes: [Egress]
   egress:
     - to:


### PR DESCRIPTION
## Problem
The android CI build (running under `runtimeClassName: kata`) failed at `step-pnpm-workspace-deps` with `ECONNREFUSED` to Verdaccio.

**Root cause:** the untrusted `checks-egress` NetworkPolicy only selected pods labeled `tekton.dev/pipelineTask=checks`. The android npm dep-install runs in the `build` task, so that pod got DNS-only egress and couldn't reach the npm proxy.

## Fix
Broaden the netpol podSelector to `matchExpressions: tekton.dev/pipelineTask In [checks, build]`. Both `checks` (nextjs) and `build` (android) run untrusted PR code that installs npm deps through Verdaccio.

## Security
Posture unchanged — the selected pods still get **Verdaccio + prisma-engines mirror only**, no public egress, no lateral movement. This does not widen the trust boundary; it applies the same npm-proxy-only egress the `checks` task already had to the equally-untrusted `build` task.

## Verification
`helm template` renders the netpol correctly for the untrusted tier (android shares the `capturly-builds-untrusted` namespace). Post-merge: ArgoCD sync + re-fire the android build to confirm it clears the Verdaccio step.