### PR TITLE
fix(build): scope android untrusted install to the mobile workspace

### DIFF
--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -39,7 +39,11 @@ spec:
         #!/usr/bin/env bash
         set -euo pipefail
         cp /config/npm/.npmrc "$HOME/.npmrc"   # registry = Verdaccio, no auth
-        pnpm install --frozen-lockfile
+        # Scope to the mobile app + its workspace deps only. A full install pulls
+        # the desktop lane (electron/keytar/@parcel/watcher), whose postinstalls
+        # fetch prebuilt binaries from GitHub — blocked in the untrusted egress
+        # lane (by design). None of those are needed for the android APK build.
+        pnpm install --frozen-lockfile --filter "@capturly/mobile..."
         # Metro resolves workspace deps via their built dist/ — compile first.
         pnpm --filter "@capturly/mobile^..." --if-present build
     - name: gradle-assemble-debug


### PR DESCRIPTION
## Problem
The android untrusted build (build-unsigned-apk) failed at `step-pnpm-workspace-deps` **after** the Verdaccio egress fix landed (#771). All 2297 packages resolved+downloaded from Verdaccio fine, but postinstall scripts for **electron / keytar / @parcel/watcher** tried to fetch prebuilt binaries from GitHub (`ECONNREFUSED 140.82.114.4:443`) — public egress the untrusted lane blocks by design.

Root cause: the task ran a **full** `pnpm install`, pulling the desktop lane (`@capturly/desktop`, `@corey-alan-consulting/license`) that an android APK build doesn't need.

## Fix
Scope the install to `--filter "@capturly/mobile..."` (the mobile app + its workspace dependency closure). Verified that set resolves to 10 `@capturly/*` packages with **no electron/keytar/desktop** — so no postinstall reaches the public internet.

## Security / egress
Unchanged. Verdaccio (npm) + prisma-engines mirror only; no public egress opened. This narrows what gets installed; it does not widen the trust boundary.

## Verification
`pnpm ls --filter "@capturly/mobile..."` locally confirms the desktop/electron packages are excluded. Post-merge: re-fire the android incoming build and confirm it clears postinstall into `gradle assembleDebug`.