### PR TITLE
fix(build): run android gradle from <mobile-dir>/android (RN layout)

### DIFF
--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -48,7 +48,8 @@ spec:
         pnpm --filter "@capturly/mobile^..." --if-present build
     - name: gradle-assemble-debug
       image: $(params.toolchain-image)
-      workingDir: $(workspaces.source.path)/$(params.mobile-dir)
+      # React Native: the Gradle project (gradlew + app/) lives in <mobile-dir>/android.
+      workingDir: $(workspaces.source.path)/$(params.mobile-dir)/android
       env:
         - name: HOME
           value: $(workspaces.source.path)


### PR DESCRIPTION
The android untrusted build cleared all JS/dep steps (pnpm workspace deps + cloud-backup type-check now pass) and reached gradle, which failed:
```
./gradlew: No such file or directory   (exit 127)
```
`@capturly/mobile` is React Native — `gradlew` and the `app/` Gradle project live in `apps/mobile/android`, not `apps/mobile`. The `gradle-assemble-debug` step's `workingDir` was `<mobile-dir>`; point it at `<mobile-dir>/android`. Consistent with the step's own `ls app/build/outputs/apk/debug/` and the signed-aab task's `<mobile-dir>/android/<AAB>` path.

Post-merge: re-fire the android build — expected to now invoke assembleDebug (next frontier is the actual RN/Gradle/NDK compile).