### PR TITLE
fix(android-toolchain): bake gradle 9.0.0 (offline-gradle Step 1)

### DIFF
--- a/apps/capturly-android-toolchain/Dockerfile
+++ b/apps/capturly-android-toolchain/Dockerfile
@@ -5,8 +5,9 @@
 # Phase 0 cleanup). Bakes exactly what release-android needs so the ephemeral
 # build pod IS the environment and nothing is downloaded per run. Versions pinned
 # to apps/mobile/android/build.gradle: compileSdk 36 · buildToolsVersion 36.0.0 ·
-# ndkVersion 28.2.13676358 · JDK 17. Gradle comes from the repo wrapper (cached
-# on a PVC). Node/pnpm match the repo's packageManager.
+# ndkVersion 28.2.13676358 · JDK 17. Gradle 9.0.0 is baked (matches the repo
+# wrapper) so the egress-locked untrusted lane needs no distribution download.
+# Node/pnpm match the repo's packageManager.
 FROM eclipse-temurin:26-jdk-jammy
 
 USER root
@@ -47,6 +48,16 @@ RUN yes | sdkmanager --licenses > /dev/null \
        "platforms;${ANDROID_PLATFORM}" \
        "build-tools;${ANDROID_BUILD_TOOLS}" \
        "ndk;${ANDROID_NDK}" > /dev/null
+
+# Gradle baked (matches apps/mobile/android/gradle/wrapper — gradle-9.0.0). The
+# untrusted lane has no egress, so the wrapper can't self-download; the task
+# invokes this `gradle` instead of ./gradlew.
+ARG GRADLE_VERSION=9.0.0
+RUN curl -fsSL -o /tmp/gradle.zip \
+      https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
+    && unzip -q /tmp/gradle.zip -d /opt \
+    && ln -s /opt/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle \
+    && rm /tmp/gradle.zip
 
 ENV CMAKE_C_COMPILER_LAUNCHER=ccache
 ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -58,5 +58,7 @@ spec:
         set -euo pipefail
         # Debug build only — uses the auto-generated debug keystore, no release
         # signing material. Compiles RN + native/NDK; that's the PR-check signal.
-        ./gradlew assembleDebug --no-daemon
+        # Baked gradle (toolchain image), not ./gradlew — the wrapper would
+        # self-download its distribution, which the untrusted lane's egress blocks.
+        gradle assembleDebug --no-daemon
         ls -la app/build/outputs/apk/debug/ || true


### PR DESCRIPTION
## Problem
The android untrusted build reached gradle and failed — the wrapper self-downloads its distribution, which the egress-locked lane blocks:
```
Downloading https://services.gradle.org/distributions/gradle-9.0.0-bin.zip
Exception in thread "main" java.net.ConnectException: Connection refused
```

## Fix (Step 1 of the offline-gradle/Maven work you approved)
- Bake **gradle 9.0.0** into the toolchain image (matches `apps/mobile/android` wrapper).
- `build-unsigned-apk` runs `gradle assembleDebug` instead of `./gradlew` — no per-run download, consistent with the image's "nothing is downloaded per run" design.

## Follow-ups (not in this PR)
- ⚠️ **Re-pin the toolchain digest** in the unsigned lane after the build-toolchain workflow rebuilds+pushes (the workflow pins android-build.yaml; the unsigned/PR lane's pinned digest needs updating to consume baked gradle).
- **Step 2 — Maven proxy:** `assembleDebug` will next fetch AGP + deps from Google Maven / Maven Central → also egress-blocked. Needs a Maven caching proxy (Verdaccio-analog) + a gradle init script + netpol egress. Separate PR.