### PR TITLE
feat(build): Maven caching mirror for untrusted android (offline gradle Step 2)

### DIFF
--- a/build-catalog/pipelines/android-pr.yaml
+++ b/build-catalog/pipelines/android-pr.yaml
@@ -20,7 +20,7 @@ spec:
       default: ""
     - name: toolchain-image
       type: string
-      default: ghcr.io/nx211/capturly-android-toolchain:0.1.0@sha256:75cd7eb9dee3f7e1c43a7b359950ac49d69a99415067b40db576cbd6fdfc748e
+      default: ghcr.io/nx211/capturly-android-toolchain:0.1.0@sha256:3b8abb02cb57b64ca6ddf9a58aa3208c923ae73a669f6d427aa37304906d2bc6
   workspaces:
     - name: source
     - name: npmrc

--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -58,7 +58,31 @@ spec:
         set -euo pipefail
         # Debug build only — uses the auto-generated debug keystore, no release
         # signing material. Compiles RN + native/NDK; that's the PR-check signal.
+
+        # Route every Gradle repository at the in-cluster Maven mirror — the
+        # untrusted lane blocks public egress, so google()/mavenCentral() would
+        # fail. clear() drops the project's public repos so only the mirror is
+        # used; covers pluginManagement + dependencyResolutionManagement (settings
+        # level, needed under FAIL_ON_PROJECT_REPOS) and buildscript/project repos.
+        MIRROR=http://maven-mirror-untrusted.build-registry-proxy.svc.cluster.local:8080
+        cat > "$HOME/mirror.init.gradle" <<GRADLE
+        def useMirror = { org.gradle.api.artifacts.dsl.RepositoryHandler h ->
+          h.clear()
+          h.maven { url = "${MIRROR}/google/" }
+          h.maven { url = "${MIRROR}/central/" }
+          h.maven { url = "${MIRROR}/gradle-plugins/" }
+        }
+        settingsEvaluated { s ->
+          s.pluginManagement.repositories { useMirror(delegate) }
+          s.dependencyResolutionManagement.repositories { useMirror(delegate) }
+        }
+        allprojects {
+          buildscript.repositories { useMirror(delegate) }
+          repositories { useMirror(delegate) }
+        }
+        GRADLE
+
         # Baked gradle (toolchain image), not ./gradlew — the wrapper would
         # self-download its distribution, which the untrusted lane's egress blocks.
-        gradle assembleDebug --no-daemon
+        gradle assembleDebug --no-daemon --init-script "$HOME/mirror.init.gradle"
         ls -la app/build/outputs/apk/debug/ || true

--- a/build-registry-proxy/kustomization.yaml
+++ b/build-registry-proxy/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - externalsecret-npm-uplink.yaml
   - verdaccio.yaml
   - prisma-mirror.yaml
+  - maven-mirror.yaml

--- a/build-registry-proxy/maven-mirror.yaml
+++ b/build-registry-proxy/maven-mirror.yaml
@@ -1,0 +1,152 @@
+---
+# Maven/Gradle caching mirror (UNTRUSTED tier). nginx reverse-proxy to the three
+# upstreams an android assembleDebug resolves — Google Maven (AGP + androidx),
+# Maven Central (deps), Gradle Plugin Portal — so untrusted build pods fetch JVM
+# artifacts offline-from-mirror instead of the public internet (egress-locked by
+# design). Same pattern + per-tier isolation as verdaccio/prisma-mirror (H3):
+# untrusted-only ingress; its own egress to the public repos. Consumed via a
+# gradle init script in build-unsigned-apk that points every repository at the
+# mirror path prefixes below (/google, /central, /gradle-plugins).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maven-mirror-config
+  namespace: build-registry-proxy
+data:
+  nginx.conf: |
+    worker_processes 1;
+    error_log /dev/stderr warn;
+    pid /tmp/nginx.pid;
+    events { worker_connections 1024; }
+    http {
+      access_log off;
+      resolver 10.43.0.10 valid=300s;   # kube-dns; needed for proxy_pass to public hosts
+      proxy_temp_path  /tmp/proxy_temp;
+      client_body_temp_path /tmp/client_temp;
+      proxy_cache_path /tmp/cache levels=1:2 keys_zone=maven:20m max_size=8g inactive=90d use_temp_path=off;
+
+      # Release artifacts (.jar/.aar/.pom/.module) are immutable → cache hard.
+      # maven-metadata.xml is mutable (version listings) → short TTL.
+      map $uri $mvn_ttl { default 30d; ~maven-metadata\.xml$ 10m; }
+
+      server {
+        listen 8080;
+        proxy_ssl_server_name on;
+        proxy_cache maven;
+        proxy_cache_valid 200 206 $mvn_ttl;
+        proxy_cache_valid 404 1m;
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock on;
+        proxy_http_version 1.1;
+
+        # Google Maven — backs gradle google() (AGP, androidx, material).
+        location /google/ {
+          proxy_pass https://dl.google.com/dl/android/maven2/;
+          proxy_set_header Host dl.google.com;
+        }
+        # Maven Central — backs gradle mavenCentral().
+        location /central/ {
+          proxy_pass https://repo.maven.apache.org/maven2/;
+          proxy_set_header Host repo.maven.apache.org;
+        }
+        # Gradle Plugin Portal — backs gradlePluginPortal(). Best-effort: the
+        # portal 302-redirects some artifacts to a CDN; gradle follows redirects
+        # itself, so this covers direct hits. Most android plugins resolve from
+        # google()/central() above.
+        location /gradle-plugins/ {
+          proxy_pass https://plugins.gradle.org/m2/;
+          proxy_set_header Host plugins.gradle.org;
+        }
+        location = /healthz { return 200 'ok'; add_header Content-Type text/plain; }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maven-mirror-untrusted
+  namespace: build-registry-proxy
+  labels: { app: maven-mirror-untrusted, app.kubernetes.io/name: maven-mirror }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: maven-mirror-untrusted }
+  template:
+    metadata:
+      labels: { app: maven-mirror-untrusted, app.kubernetes.io/name: maven-mirror }
+    spec:
+      enableServiceLinks: false
+      # uid/gid > 10000 (KSV-0020/0021), matches verdaccio/prisma-mirror.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: [ALL] }
+            seccompProfile: { type: RuntimeDefault }
+          ports: [{ containerPort: 8080, name: http }]
+          volumeMounts:
+            - { name: config, mountPath: /etc/nginx/nginx.conf, subPath: nginx.conf, readOnly: true }
+            - { name: tmp, mountPath: /tmp }
+            - { name: cache, mountPath: /var/cache/nginx }
+            - { name: confd, mountPath: /etc/nginx/conf.d }
+          resources:
+            requests: { cpu: 25m, memory: 64Mi }
+            limits: { cpu: "1", memory: 512Mi }
+          readinessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+            initialDelaySeconds: 3
+      volumes:
+        - { name: config, configMap: { name: maven-mirror-config } }
+        - { name: tmp, emptyDir: {} }
+        - { name: cache, emptyDir: {} }
+        - { name: confd, emptyDir: {} }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: maven-mirror-untrusted
+  namespace: build-registry-proxy
+spec:
+  selector: { app: maven-mirror-untrusted }
+  ports: [{ port: 8080, targetPort: 8080, name: http }]
+---
+# Egress: DNS + public HTTPS (the three Maven upstreams) only — mirrors prisma-mirror.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: maven-mirror-egress
+  namespace: build-registry-proxy
+spec:
+  podSelector: { matchLabels: { app.kubernetes.io/name: maven-mirror } }
+  policyTypes: [Egress]
+  egress:
+    - to: [{ namespaceSelector: {} }]
+      ports: [{ protocol: UDP, port: 53 }, { protocol: TCP, port: 53 }]
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]
+      ports: [{ protocol: TCP, port: 443 }]
+---
+# Per-tier ingress (H3): only untrusted-tier build namespaces may reach it.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: maven-mirror-untrusted-ingress
+  namespace: build-registry-proxy
+spec:
+  podSelector: { matchLabels: { app: maven-mirror-untrusted } }
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels: { build.capturly/tier: untrusted }
+      ports: [{ protocol: TCP, port: 8080 }]


### PR DESCRIPTION
## What
Step 2 of offline-gradle: `assembleDebug` fetches AGP + deps from Google Maven / Maven Central / Gradle Plugin Portal — public egress the untrusted lane blocks.

- **`build-registry-proxy/maven-mirror.yaml`** — `maven-mirror-untrusted`, an nginx-unprivileged caching reverse-proxy (same hardened pattern as prisma-mirror) fronting the three upstreams under `/google`, `/central`, `/gradle-plugins`; untrusted-only ingress + public-443 egress. Port 8080 (already permitted by the build-namespace egress netpol → no change there).
- **`build-unsigned-apk`** — writes a gradle `init.gradle` that `clear()`s public repos and repoints pluginManagement + dependencyResolutionManagement (settings-level, for `FAIL_ON_PROJECT_REPOS`) + buildscript/project repos at the mirror, then `gradle assembleDebug --init-script …`.

## Validated
- `kubectl kustomize build-registry-proxy` builds clean with the mirror.
- Task YAML parses; the in-`script` heredoc de-indents correctly.

## Sequence to green (after merge)
1. ArgoCD syncs `build-registry-proxy` → maven-mirror comes up.
2. **Re-pin** the unsigned lane's toolchain digest to the #776 rebuild (baked gradle) — separate follow-up.
3. Re-fire android → should resolve gradle deps through the mirror.