### PR TITLE
chore(security): trivyignore KSV-0125 for maven-mirror

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -16,9 +16,10 @@ misconfigurations:
   - id: KSV-0113
     paths:
       - "ar-token-refresher/rbac.yaml"
-  # prisma-engines mirror pulls the upstream nginx-unprivileged image from
-  # docker.io (same as the sibling verdaccio proxy). No ghcr re-mirror yet;
-  # accepted, path-scoped. All other KSV findings on this file are hardened.
+  # prisma-engines + maven mirrors pull the upstream nginx-unprivileged image
+  # from docker.io (same as the sibling verdaccio proxy). No ghcr re-mirror yet;
+  # accepted, path-scoped. All other KSV findings on these files are hardened.
   - id: KSV-0125
     paths:
       - "build-registry-proxy/prisma-mirror.yaml"
+      - "build-registry-proxy/maven-mirror.yaml"


### PR DESCRIPTION
Adds `build-registry-proxy/maven-mirror.yaml` to the existing KSV-0125 exception (docker.io nginx-unprivileged), mirroring `prisma-mirror.yaml`. Clears the GitHub code-scanning alert (#1401) raised on the merged Maven-mirror PR (#777) — same accepted, path-scoped finding the sibling proxies already carry.