### PR TITLE
fix(android-toolchain): JDK 17 base (Java 26 breaks gradle)

### DIFF
--- a/apps/capturly-android-toolchain/Dockerfile
+++ b/apps/capturly-android-toolchain/Dockerfile
@@ -8,7 +8,10 @@
 # ndkVersion 28.2.13676358 · JDK 17. Gradle 9.0.0 is baked (matches the repo
 # wrapper) so the egress-locked untrusted lane needs no distribution download.
 # Node/pnpm match the repo's packageManager.
-FROM eclipse-temurin:26-jdk-jammy
+# JDK 17 — required by Gradle 9 / AGP / React Native. The base had drifted to
+# temurin:26 (Java 26 = class-file major 70), which Gradle can't run on:
+# "Unsupported class file major version 70".
+FROM eclipse-temurin:17-jdk-jammy
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Baked gradle now runs, but assembleDebug fails:
```
BUG! ... Unsupported class file major version 70
```
Major version 70 = Java 26 — the base image had drifted to `eclipse-temurin:26-jdk-jammy`, which Gradle 9 / AGP / React Native can't run on. Pin to `eclipse-temurin:17-jdk-jammy`, matching the Dockerfile's own "JDK 17" comment and the android toolchain requirement.

Merging triggers the toolchain rebuild; the unsigned lane's digest will need a re-pin to the new image (follow-up), then re-fire.