### PR TITLE
fix(build): preserve node-linker=hoisted in android install (.npmrc append)

### DIFF
--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -38,7 +38,10 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
-        cp /config/npm/.npmrc "$HOME/.npmrc"   # registry = Verdaccio, no auth
+        # APPEND the Verdaccio registry — do NOT overwrite. HOME is the repo root,
+        # so its checked-in .npmrc (node-linker=hoisted, required for React Native
+        # to resolve @react-native/gradle-plugin) must be preserved. cp clobbered it.
+        cat /config/npm/.npmrc >> "$HOME/.npmrc"   # registry = Verdaccio, no auth
         # Scope to the mobile app + its workspace deps only. A full install pulls
         # the desktop lane (electron/keytar/@parcel/watcher), whose postinstalls
         # fetch prebuilt binaries from GitHub — blocked in the untrusted egress


### PR DESCRIPTION
gradle now runs (JDK 17 + baked gradle + Maven mirror all working) and fails evaluating `settings.gradle:6`:
```
> Process 'command 'node'' finished with non-zero exit value 1
```
That line runs `node --print require.resolve('@react-native/gradle-plugin/package.json')`. The repo's root `.npmrc` sets `node-linker=hoisted` (required for RN so transitive deps resolve flatly), but the task did `cp /config/npm/.npmrc "$HOME/.npmrc"` — and HOME is the repo root, so it **overwrote** the checked-in `.npmrc`, dropping `node-linker=hoisted`. The plugin then isn't hoisted and `require.resolve` fails.

Fix: **append** the Verdaccio registry instead of overwriting — exactly what the `web-ci` task already does. Task-only change (no image rebuild).