### PR TITLE
fix(build): --ignore-scripts for android install (hoisted defeats --filter)

### DIFF
--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -42,11 +42,14 @@ spec:
         # so its checked-in .npmrc (node-linker=hoisted, required for React Native
         # to resolve @react-native/gradle-plugin) must be preserved. cp clobbered it.
         cat /config/npm/.npmrc >> "$HOME/.npmrc"   # registry = Verdaccio, no auth
-        # Scope to the mobile app + its workspace deps only. A full install pulls
-        # the desktop lane (electron/keytar/@parcel/watcher), whose postinstalls
-        # fetch prebuilt binaries from GitHub — blocked in the untrusted egress
-        # lane (by design). None of those are needed for the android APK build.
-        pnpm install --frozen-lockfile --filter "@capturly/mobile..."
+        # node-linker=hoisted installs ONE flat node_modules for the whole
+        # workspace — pnpm --filter can't isolate a subset under hoisted mode, so
+        # the desktop lane (electron/keytar/@parcel/watcher) is installed too and
+        # its postinstalls fetch prebuilt binaries from the public internet, which
+        # the untrusted lane blocks. --ignore-scripts skips all install scripts:
+        # the android gradle build needs none (native code builds via gradle
+        # autolinking, not npm postinstall; workspace dist/ is built next).
+        pnpm install --frozen-lockfile --ignore-scripts
         # Metro resolves workspace deps via their built dist/ — compile first.
         pnpm --filter "@capturly/mobile^..." --if-present build
     - name: gradle-assemble-debug


### PR DESCRIPTION
The .npmrc-hoisting fix (#782) got gradle past settings.gradle, but regressed the install: `node-linker=hoisted` installs one flat node_modules for the whole workspace — `--filter` can't isolate under hoisted mode, so electron/keytar/@parcel/watcher return and their postinstalls hit blocked egress (`ETIMEDOUT`).

The scope-filter approach (#772) is fundamentally incompatible with the hoisting RN needs. Drop the ineffective `--filter` and `--ignore-scripts` instead — the android gradle build needs no npm install scripts (native code builds via gradle autolinking; workspace `dist/` is built by the next `pnpm … build` step). Task-only change.