### PR TITLE
fix(build): inject mirror plugin repos in beforeSettings (foojay)

### DIFF
--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -78,6 +78,20 @@ spec:
           h.maven { url = "${MIRROR}/central/" }
           h.maven { url = "${MIRROR}/gradle-plugins/" }
         }
+        def addMirror = { org.gradle.api.artifacts.dsl.RepositoryHandler h ->
+          h.maven { url = "${MIRROR}/gradle-plugins/" }
+          h.maven { url = "${MIRROR}/central/" }
+          h.maven { url = "${MIRROR}/google/" }
+        }
+        // pluginManagement + the settings plugins{} block resolve DURING settings
+        // evaluation (before settingsEvaluated), incl. for included builds like
+        // @react-native/gradle-plugin (which applies foojay-resolver). Inject the
+        // mirror in beforeSettings so it's present in time; settingsEvaluated then
+        // clear()s the public repos the script added.
+        beforeSettings { s ->
+          s.pluginManagement.repositories { addMirror(delegate) }
+          s.dependencyResolutionManagement.repositories { addMirror(delegate) }
+        }
         settingsEvaluated { s ->
           s.pluginManagement.repositories { useMirror(delegate) }
           s.dependencyResolutionManagement.repositories { useMirror(delegate) }


### PR DESCRIPTION
The android build reached gradle plugin resolution and failed on `foojay-resolver-convention` — searching only the **default** repos (MavenRepo/Google/Gradle Central Plugin), not the mirror. Cause: `pluginManagement` and the settings `plugins{}` block resolve **during** settings-script evaluation (before `settingsEvaluated`), including for the included build `@react-native/gradle-plugin` that applies foojay. So the `settingsEvaluated` hook was too late.

Fix: add a `beforeSettings` hook that injects the mirror into `pluginManagement` + `dependencyResolutionManagement` before the settings script runs; `settingsEvaluated` still `clear()`s the public repos afterward. Task-only.