### PR TITLE
fix(build): android gradle step memory (kata OOMKilled)

### DIFF
--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -56,6 +56,11 @@ spec:
       image: $(params.toolchain-image)
       # React Native: the Gradle project (gradlew + app/) lives in <mobile-dir>/android.
       workingDir: $(workspaces.source.path)/$(params.mobile-dir)/android
+      # kata sizes the pod VM to the memory limit; gradle (-Xmx2048m) + Kotlin/R8/
+      # NDK native compilation OOMs under kata's small default. Match web-ci.
+      computeResources:
+        requests: { cpu: "4", memory: 4Gi }
+        limits: { cpu: "8", memory: 8Gi }
       env:
         - name: HOME
           value: $(workspaces.source.path)


### PR DESCRIPTION
Every dependency now resolves through the mirror — gradle compiled the RN gradle plugin from source and reached `Configure project :app`, then **OOMKilled**. The gradle step had no memory limit and runs under **kata**, which sizes the pod VM to the container limit → it got kata's small default (~2Gi), too small for gradle's 2Gi heap + Kotlin/R8/NDK native compilation.

Add `computeResources` (requests 4 CPU/4Gi, limits 8 CPU/8Gi), matching the web-ci task. This is a resource-tuning fix — the offline-dependency work is done.