### PR TITLE
fix(build): resolve gradle plugin impls from Central (portal proxy flaky)

### DIFF
--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -85,10 +85,14 @@ spec:
           h.maven { url = "${MIRROR}/central/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/gradle-plugins/"; allowInsecureProtocol = true }
         }
+        // gradle-plugins LAST: plugin *impls* (e.g. org.gradle.toolchains:foojay-
+        // resolver) are on Maven Central, which serves them directly; the portal
+        // proxy needs a flaky redirect-follow. Trying central/google first means
+        // only the tiny plugin *marker* (portal-only, no redirect) uses the portal.
         def addMirror = { org.gradle.api.artifacts.dsl.RepositoryHandler h ->
-          h.maven { url = "${MIRROR}/gradle-plugins/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/central/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/google/"; allowInsecureProtocol = true }
+          h.maven { url = "${MIRROR}/gradle-plugins/"; allowInsecureProtocol = true }
         }
         // pluginManagement + the settings plugins{} block resolve DURING settings
         // evaluation (before settingsEvaluated), incl. for included builds like


### PR DESCRIPTION
The mirror's plugin-portal redirect-follow is intermittent — one run resolved foojay and compiled the RN plugin (reaching `Configure :app`, then OOM), the next **500**'d on the same `foojay-resolver-0.5.0.pom`.

Plugin *implementations* (e.g. `org.gradle.toolchains:foojay-resolver`) live on **Maven Central**, served directly. Reorder the plugin repos so `/central` and `/google` come **before** `/gradle-plugins` — impls resolve cleanly from Central; only the tiny plugin *marker* (portal-only, no redirect) still hits the portal. Removes the dependence on the flaky redirect for real artifacts.