### PR TITLE
fix(build): maven-mirror resolver ipv6=off (no IPv6 egress)

### DIFF
--- a/build-registry-proxy/maven-mirror.yaml
+++ b/build-registry-proxy/maven-mirror.yaml
@@ -20,7 +20,11 @@ data:
     events { worker_connections 1024; }
     http {
       access_log off;
-      resolver 10.43.0.10 valid=300s;   # kube-dns; needed for proxy_pass to public hosts
+      # ipv6=off: the cluster has no IPv6 egress; without this nginx tries AAAA
+      # addresses first and fails "Network unreachable", intermittently disabling
+      # upstreams (flaky central/google) and corrupting the portal redirect
+      # (empty Location -> foojay 500).
+      resolver 10.43.0.10 ipv6=off valid=300s;   # kube-dns; for proxy_pass to public hosts
       proxy_temp_path  /tmp/proxy_temp;
       client_body_temp_path /tmp/client_temp;
       proxy_cache_path /tmp/cache levels=1:2 keys_zone=maven:20m max_size=8g inactive=90d use_temp_path=off;


### PR DESCRIPTION
The mirror's nginx log revealed the real flakiness: `connect() to [2606:…]:443 failed (101: Network unreachable)` for central/google (marking upstreams disabled) and `invalid URL prefix in ""` for the foojay portal redirect. kube-dns returns AAAA records but the cluster has **no IPv6 egress**, so nginx tried IPv6 first and failed intermittently — explaining why one run compiled the RN plugin and the next 500'd on foojay.

`resolver ... ipv6=off` forces IPv4. Fixes the flaky central/google fetches **and** the empty redirect Location that 500'd foojay.