### PR TITLE
feat(build): proxy JitPack in maven-mirror (RN blur BlurView dep)

### DIFF
--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -83,6 +83,7 @@ spec:
           h.clear()
           h.maven { url = "${MIRROR}/google/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/central/"; allowInsecureProtocol = true }
+          h.maven { url = "${MIRROR}/jitpack/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/gradle-plugins/"; allowInsecureProtocol = true }
         }
         // gradle-plugins LAST: plugin *impls* (e.g. org.gradle.toolchains:foojay-

--- a/build-registry-proxy/maven-mirror.yaml
+++ b/build-registry-proxy/maven-mirror.yaml
@@ -72,6 +72,16 @@ data:
           proxy_cache maven;
           proxy_cache_valid 200 206 7d;
         }
+        # JitPack — com.github.* deps built on-demand from GitHub tags (e.g.
+        # BlurView, pulled by @react-native-community/blur). Follows redirects
+        # (jitpack 302s to its artifact host) via the same handler.
+        location /jitpack/ {
+          proxy_pass https://jitpack.io/;
+          proxy_set_header Host jitpack.io;
+          proxy_intercept_errors on;
+          recursive_error_pages on;
+          error_page 301 302 303 307 308 = @follow_redirect;
+        }
         location = /healthz { return 200 'ok'; add_header Content-Type text/plain; }
       }
     }


### PR DESCRIPTION
The `ipv6=off` fix made the mirror reliable — the android build then compiled native C++ (NDK arm64/armeabi, 10 tasks, ~9 min) and failed only on `com.github.Dimezis:BlurView`, a **JitPack** artifact pulled by `@react-native-community/blur` that the mirror didn't proxy.

Add a `/jitpack` location (proxying jitpack.io, redirect-following) and add `${MIRROR}/jitpack` to the gradle repo list. All other repos the build needs (google/mavenCentral + local file repos) were already covered.