### PR TITLE
fix(android-toolchain): bake CMake 3.22.1 (RN native builds)

### DIFF
--- a/apps/capturly-android-toolchain/Dockerfile
+++ b/apps/capturly-android-toolchain/Dockerfile
@@ -55,7 +55,8 @@ RUN yes | sdkmanager --licenses > /dev/null \
        "build-tools;36.0.0" \
        "build-tools;35.0.0" \
        "build-tools;34.0.0" \
-       "ndk;${ANDROID_NDK}" > /dev/null
+       "ndk;${ANDROID_NDK}" \
+       "cmake;3.22.1" > /dev/null
 
 # Gradle baked (matches apps/mobile/android/gradle/wrapper — gradle-9.0.0). The
 # untrusted lane has no egress, so the wrapper can't self-download; the task


### PR DESCRIPTION
The IPv4 mirror fix (#793) made resolution reliable — the android build ran **13 min / 405 tasks**, compiled most native C++, then failed: `[CXX1300] CMake '3.22.1' was not found`. RN native modules (react-native-worklets etc.) build with the RN-pinned CMake 3.22.1, which sdkmanager can't download in the egress-locked lane. Bake `cmake;3.22.1`.

Merging triggers the toolchain rebuild; re-pin + re-fire follow.