### PR TITLE
fix(build): bake foojay plugin into image (deterministic, no portal redirect)

### DIFF
--- a/apps/capturly-android-toolchain/Dockerfile
+++ b/apps/capturly-android-toolchain/Dockerfile
@@ -58,6 +58,21 @@ RUN yes | sdkmanager --licenses > /dev/null \
        "ndk;${ANDROID_NDK}" \
        "cmake;3.22.1" > /dev/null
 
+# Bake the foojay toolchain-resolver plugin (applied by @react-native/gradle-plugin)
+# into a local file:// maven repo. The plugin portal 302-redirects artifact
+# downloads to a CDN, which the untrusted lane's mirror can't reliably follow;
+# a baked repo removes that flaky network hop entirely. Image build has egress.
+RUN mkdir -p /opt/offline-m2 && cd /opt/offline-m2 \
+    && for f in \
+         "org/gradle/toolchains/foojay-resolver-convention/org.gradle.toolchains.foojay-resolver-convention.gradle.plugin/0.5.0/org.gradle.toolchains.foojay-resolver-convention.gradle.plugin-0.5.0.pom" \
+         "org/gradle/toolchains/foojay-resolver/0.5.0/foojay-resolver-0.5.0.pom" \
+         "org/gradle/toolchains/foojay-resolver/0.5.0/foojay-resolver-0.5.0.jar" \
+         "org/gradle/toolchains/foojay-resolver/0.5.0/foojay-resolver-0.5.0.module" ; do \
+         mkdir -p "$(dirname "$f")" \
+         && curl -fsSL -o "$f" "https://plugins.gradle.org/m2/$f" ; \
+       done \
+    && chmod -R a+rX /opt/offline-m2
+
 # Gradle baked (matches apps/mobile/android/gradle/wrapper — gradle-9.0.0). The
 # untrusted lane has no egress, so the wrapper can't self-download; the task
 # invokes this `gradle` instead of ./gradlew.

--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -91,6 +91,7 @@ spec:
         // proxy needs a flaky redirect-follow. Trying central/google first means
         // only the tiny plugin *marker* (portal-only, no redirect) uses the portal.
         def addMirror = { org.gradle.api.artifacts.dsl.RepositoryHandler h ->
+          h.maven { url = "file:///opt/offline-m2" }   // foojay baked in the image
           h.maven { url = "${MIRROR}/central/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/google/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/gradle-plugins/"; allowInsecureProtocol = true }


### PR DESCRIPTION
The Maven-mirror's Gradle Plugin Portal **redirect-follow is intermittently 500** (`invalid URL prefix in ""` — empty Location): one run resolved foojay and ran **405 tasks / 13 min**, the next failed at 43s on the same artifact. `foojay-resolver` is portal-only (404 on Central), behind a 303 to a CDN the egress-locked build pod can't reach.

Bake foojay's marker + impl (pom/jar/module) into a `file:///opt/offline-m2` maven repo in the toolchain image (image build has egress, follows redirects) and prepend that repo in the gradle plugin repos. Deterministic — removes the flaky redirect dependency for the one portal plugin the RN build needs.

Merging triggers the toolchain rebuild; re-pin + re-fire follow.