### PR TITLE
fix(build): re-pin android-pr to foojay-baked image

### DIFF
--- a/build-catalog/pipelines/android-pr.yaml
+++ b/build-catalog/pipelines/android-pr.yaml
@@ -20,7 +20,7 @@ spec:
       default: ""
     - name: toolchain-image
       type: string
-      default: ghcr.io/nx211/capturly-android-toolchain:0.1.0@sha256:b44261b9df0d4905ade8085f42b029140b6282618b4579239c45c34f77478e5a
+      default: ghcr.io/nx211/capturly-android-toolchain:0.1.0@sha256:af1c7fa33b562dcfab47c3695d0927ca48b805c04b94654524abb08bfb9dfad8
   workspaces:
     - name: source
     - name: npmrc


### PR DESCRIPTION
Re-pin unsigned lane to #796 rebuild (`sha256:af1c7fa3`, foojay baked into /opt/offline-m2).