### PR TITLE
fix(build): re-pin android-pr to foojay+ktfmt image

### DIFF
--- a/build-catalog/pipelines/android-pr.yaml
+++ b/build-catalog/pipelines/android-pr.yaml
@@ -20,7 +20,7 @@ spec:
       default: ""
     - name: toolchain-image
       type: string
-      default: ghcr.io/nx211/capturly-android-toolchain:0.1.0@sha256:af1c7fa33b562dcfab47c3695d0927ca48b805c04b94654524abb08bfb9dfad8
+      default: ghcr.io/nx211/capturly-android-toolchain:0.1.0@sha256:61e08b0e57b1145ba55fe544129f7cadcec475f72951470108eaabad30d59a06
   workspaces:
     - name: source
     - name: npmrc


### PR DESCRIPTION
Re-pin unsigned lane to #799 rebuild (`sha256:61e08b0e`, foojay + ktfmt baked).