### PR TITLE
fix(build): baked offline-m2 in useMirror (ktfmt buildscript path)

### DIFF
--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -81,6 +81,7 @@ spec:
         // rejects http repos without explicit opt-in.
         def useMirror = { org.gradle.api.artifacts.dsl.RepositoryHandler h ->
           h.clear()
+          h.maven { url = "file:///opt/offline-m2" }   // baked portal plugins (foojay, ktfmt)
           h.maven { url = "${MIRROR}/google/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/central/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/jitpack/"; allowInsecureProtocol = true }


### PR DESCRIPTION
The ktfmt bake was correct (verified in the image) but unused: foojay resolves via `pluginManagement` (=`addMirror`, which had the file repo), while ktfmt resolves via the **buildscript classpath** (=`useMirror`), which lacked `file:///opt/offline-m2` — so ktfmt still hit the flaky portal redirect. Add the baked repo to `useMirror` too. Task-only (image already has foojay+ktfmt).