### PR TITLE
fix(build): drop /gradle-plugins repo (portal 500 aborts resolution)

### DIFF
--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -79,23 +79,26 @@ spec:
         cat > "$HOME/mirror.init.gradle" <<GRADLE
         // allowInsecureProtocol: the mirror is in-cluster http (no TLS); gradle 9
         // rejects http repos without explicit opt-in.
+        // No /gradle-plugins repo: the only portal plugins the build needs
+        // (foojay, ktfmt) are baked in offline-m2; everything else lives on
+        // google/central. The portal proxy's redirect-follow 500s, and a 500
+        // ABORTS resolution (a 404 would fall through) — so keeping it in the
+        // list breaks dynamic-version lookups (e.g. AGP 8.+ from google).
         def useMirror = { org.gradle.api.artifacts.dsl.RepositoryHandler h ->
           h.clear()
           h.maven { url = "file:///opt/offline-m2" }   // baked portal plugins (foojay, ktfmt)
           h.maven { url = "${MIRROR}/google/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/central/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/jitpack/"; allowInsecureProtocol = true }
-          h.maven { url = "${MIRROR}/gradle-plugins/"; allowInsecureProtocol = true }
         }
         // gradle-plugins LAST: plugin *impls* (e.g. org.gradle.toolchains:foojay-
         // resolver) are on Maven Central, which serves them directly; the portal
         // proxy needs a flaky redirect-follow. Trying central/google first means
         // only the tiny plugin *marker* (portal-only, no redirect) uses the portal.
         def addMirror = { org.gradle.api.artifacts.dsl.RepositoryHandler h ->
-          h.maven { url = "file:///opt/offline-m2" }   // foojay baked in the image
+          h.maven { url = "file:///opt/offline-m2" }   // foojay + ktfmt baked in the image
           h.maven { url = "${MIRROR}/central/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/google/"; allowInsecureProtocol = true }
-          h.maven { url = "${MIRROR}/gradle-plugins/"; allowInsecureProtocol = true }
         }
         // pluginManagement + the settings plugins{} block resolve DURING settings
         // evaluation (before settingsEvaluated), incl. for included builds like


### PR DESCRIPTION
`react-native-haptic-feedback` needs AGP `com.android.tools.build:gradle:8.+` (dynamic version → `maven-metadata.xml`), which lives on **google()**. But gradle hit the `/gradle-plugins` portal proxy first for the metadata and got a **500** (the broken redirect-follow), which **aborts** resolution — a 404 would fall through to google.

The only portal plugins the build needs (foojay, ktfmt) are **baked** in `/opt/offline-m2`, so remove `/gradle-plugins` from the gradle repo list entirely. No more flaky portal; AGP + everything resolve from google/central/offline-m2. Task-only.