### PR TITLE
fix(build): re-add /gradle-plugins LAST for plugin markers

### DIFF
--- a/build-catalog/tasks/build-unsigned-apk.yaml
+++ b/build-catalog/tasks/build-unsigned-apk.yaml
@@ -79,17 +79,18 @@ spec:
         cat > "$HOME/mirror.init.gradle" <<GRADLE
         // allowInsecureProtocol: the mirror is in-cluster http (no TLS); gradle 9
         // rejects http repos without explicit opt-in.
-        // No /gradle-plugins repo: the only portal plugins the build needs
-        // (foojay, ktfmt) are baked in offline-m2; everything else lives on
-        // google/central. The portal proxy's redirect-follow 500s, and a 500
-        // ABORTS resolution (a 404 would fall through) — so keeping it in the
-        // list breaks dynamic-version lookups (e.g. AGP 8.+ from google).
+        // /gradle-plugins is LAST and used ONLY for plugin markers, which the
+        // portal serves directly (200, no redirect). Portal-only plugin *impls*
+        // that DO 303-redirect (foojay, ktfmt) are baked in offline-m2 (first);
+        // every other impl (e.g. spotless) is on central/google. So no impl ever
+        // reaches the portal's flaky redirect-follow — only 200 marker fetches do.
         def useMirror = { org.gradle.api.artifacts.dsl.RepositoryHandler h ->
           h.clear()
-          h.maven { url = "file:///opt/offline-m2" }   // baked portal plugins (foojay, ktfmt)
+          h.maven { url = "file:///opt/offline-m2" }   // baked portal plugin impls (foojay, ktfmt)
           h.maven { url = "${MIRROR}/google/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/central/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/jitpack/"; allowInsecureProtocol = true }
+          h.maven { url = "${MIRROR}/gradle-plugins/"; allowInsecureProtocol = true }   // markers only (200)
         }
         // gradle-plugins LAST: plugin *impls* (e.g. org.gradle.toolchains:foojay-
         // resolver) are on Maven Central, which serves them directly; the portal
@@ -99,6 +100,7 @@ spec:
           h.maven { url = "file:///opt/offline-m2" }   // foojay + ktfmt baked in the image
           h.maven { url = "${MIRROR}/central/"; allowInsecureProtocol = true }
           h.maven { url = "${MIRROR}/google/"; allowInsecureProtocol = true }
+          h.maven { url = "${MIRROR}/gradle-plugins/"; allowInsecureProtocol = true }   // markers only (200)
         }
         // pluginManagement + the settings plugins{} block resolve DURING settings
         // evaluation (before settingsEvaluated), incl. for included builds like


### PR DESCRIPTION
Removing `/gradle-plugins` (#802) broke portal-only plugin **markers** — `com.diffplug.spotless` 8.4.0 (applied by reanimated/worklets). Key facts discovered:
- Plugin **markers** serve **directly (200, no redirect)**; only **impls** 303-redirect.
- spotless's **impl** is on **Maven Central**; only its marker is portal-only.
- foojay/ktfmt impls (portal-only, redirect) are **baked** in offline-m2.

So re-add `/gradle-plugins` **LAST**: gradle reaches it only for 200 marker fetches; every impl resolves earlier (offline-m2 / central / google). The broken redirect-follow is never exercised. Task-only.