### PR TITLE
fix(build): portal redirect handler 404s (not 500s) on failure

### DIFF
--- a/build-registry-proxy/maven-mirror.yaml
+++ b/build-registry-proxy/maven-mirror.yaml
@@ -88,6 +88,12 @@ data:
         # the redirect target's host ($proxy_host) — do not override it.
         location @follow_redirect {
           internal;
+          # If the intercepted redirect had no capturable Location, return 404
+          # (not an "invalid URL prefix" 500). A 404 lets gradle fall through to
+          # the next repo (critical for dynamic-version maven-metadata.xml lookups
+          # like AGP 8.+ from google); a 500 aborts the whole resolution. Nothing
+          # actually needs this redirect to succeed — portal-only impls are baked.
+          if ($upstream_http_location = "") { return 404; }
           proxy_ssl_server_name on;
           proxy_pass $upstream_http_location;
           proxy_cache maven;


### PR DESCRIPTION
Dynamic-version resolution (AGP `com.android.tools.build:gradle:8.+`) queries `maven-metadata.xml` from **every** repo. The portal redirects that request, the redirect-follow can't capture the `Location`, and it returned an `invalid URL prefix` **500** — which **aborts** resolution. A **404** falls through to `/google` where AGP lives.

Return 404 when `$upstream_http_location` is empty. Nothing needs the redirect to succeed (portal-only impls baked, markers are 200) — this just makes the portal gracefully non-fatal.