### PR TITLE
feat(scaffolder): Slice 3 — scaffolder Tekton lane

### DIFF
--- a/argocd/applications/scaffolder.yaml
+++ b/argocd/applications/scaffolder.yaml
@@ -1,0 +1,45 @@
+---
+# Scaffolder lane — namespace + PaC Repository (incoming) + ExternalSecrets +
+# egress netpol for the Port scaffold_app self-service action. Privileged (creates
+# repos via a GitHub App); runs scaffold-app.sh from platform-infra. Syncs after
+# the registry proxy (wave 0, like the build targets).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: scaffolder
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: business
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: main
+    path: scaffolder
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: scaffolder
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  # ESO / PaC admission webhooks default fields the chart doesn't set.
+  ignoreDifferences:
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - '.spec.data[].remoteRef.conversionStrategy'
+        - '.spec.data[].remoteRef.decodingStrategy'
+        - '.spec.data[].remoteRef.metadataPolicy'

--- a/build-catalog/pipelines/scaffold-app.yaml
+++ b/build-catalog/pipelines/scaffold-app.yaml
@@ -1,0 +1,102 @@
+---
+# Scaffolder pipeline: stand up a new app from app-template on demand (Port
+# scaffold_app action -> PaC /incoming). Mints a short-lived GitHub App ORG
+# installation token (repo-create scope), clones platform-infra, and runs
+# scripts/scaffold-app.sh with the requested inputs. Runs in the `scaffolder`
+# namespace (egress-allowed, privileged lane). Everything lands as PRs for review.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: scaffold-app
+spec:
+  params:
+    - { name: name,        type: string }
+    - { name: domain,      type: string }
+    - { name: company,     type: string }
+    - { name: description, type: string, default: "" }
+    - { name: database,    type: string, default: "false" }
+    - { name: github-org,  type: string, default: "Corey-Alan-Consulting" }
+    - name: toolchain-image
+      type: string
+      # node + npm + git + curl + openssl + python3 (for the App-token JWT); gh
+      # and the claude CLI are installed at run time (this lane has egress).
+      default: docker.io/library/node:22-bookworm
+  workspaces:
+    - name: source        # scratch (clone platform-infra + the generated repo)
+    - name: github-app    # secret: app-id + app-private-key
+    - name: anthropic     # secret: api-key
+  tasks:
+    - name: scaffold
+      workspaces:
+        - { name: source, workspace: source }
+        - { name: github-app, workspace: github-app }
+        - { name: anthropic, workspace: anthropic }
+      taskSpec:
+        params:
+          - { name: name }
+          - { name: domain }
+          - { name: company }
+          - { name: description }
+          - { name: database }
+          - { name: github-org }
+          - { name: toolchain-image }
+        workspaces:
+          - { name: source }
+          - { name: github-app }
+          - { name: anthropic }
+        steps:
+          - name: scaffold
+            image: $(params.toolchain-image)
+            workingDir: $(workspaces.source.path)
+            env:
+              - { name: HOME, value: $(workspaces.source.path) }
+              - { name: GH_ORG, value: $(params.github-org) }
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              # --- 1. Mint a ~1h GitHub App ORG installation token (repo-create) ---
+              gh_api="https://api.github.com"
+              APP_ID="$(cat $(workspaces.github-app.path)/app-id)"
+              now="$(date +%s)"
+              b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+              hdr="$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | b64url)"
+              pld="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$((now-60))" "$((now+540))" "$APP_ID" | b64url)"
+              sig="$(printf '%s' "$hdr.$pld" | openssl dgst -sha256 -sign "$(workspaces.github-app.path)/app-private-key" -binary | b64url)"
+              jwt="$hdr.$pld.$sig"
+              inst="$(curl -sf -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" "$gh_api/orgs/${GH_ORG}/installation" | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])')"
+              export GH_TOKEN="$(curl -sf -X POST -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" "$gh_api/app/installations/$inst/access_tokens" | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])')"
+              git config --global credential.helper ''
+              git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+              # --- 2. Tooling (egress-allowed lane): gh CLI + claude CLI ---
+              GH_VER=2.63.2
+              curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_amd64.tar.gz" | tar -xz -C /tmp
+              export PATH="/tmp/gh_${GH_VER}_linux_amd64/bin:${HOME}/.npm-global/bin:${PATH}"
+              # Agent runs only once a real key is present; skip while placeholder.
+              AGENT_FLAG=""
+              if grep -q "PLACEHOLDER" "$(workspaces.anthropic.path)/api-key"; then
+                echo "ANTHROPIC key is still a placeholder -> --no-agent (deterministic scaffold + worklist PR)"
+                AGENT_FLAG="--no-agent"
+              else
+                export ANTHROPIC_API_KEY="$(cat $(workspaces.anthropic.path)/api-key)"
+                npm config set prefix "${HOME}/.npm-global"
+                npm install -g @anthropic-ai/claude-code >/dev/null 2>&1
+              fi
+
+              # --- 3. Clone platform-infra (has scaffold-app.sh) + run it ---
+              git clone --depth 1 "https://github.com/${GH_ORG}/platform-infra.git" "${HOME}/platform-infra"
+              cd "${HOME}/platform-infra"
+              DB_FLAG=""; [ "$(params.database)" = "true" ] && DB_FLAG="--database"
+              DESC_ARGS=(); [ -n "$(params.description)" ] && DESC_ARGS=(--description "$(params.description)")
+              bash scripts/scaffold-app.sh \
+                --name "$(params.name)" --domain "$(params.domain)" --company "$(params.company)" \
+                --github-org "$GH_ORG" "${DESC_ARGS[@]}" $DB_FLAG --no-onboard $AGENT_FLAG
+      params:
+        - { name: name,        value: $(params.name) }
+        - { name: domain,      value: $(params.domain) }
+        - { name: company,     value: $(params.company) }
+        - { name: description, value: $(params.description) }
+        - { name: database,    value: $(params.database) }
+        - { name: github-org,  value: $(params.github-org) }
+        - { name: toolchain-image, value: $(params.toolchain-image) }

--- a/scaffolder/kustomization.yaml
+++ b/scaffolder/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: scaffolder
+resources:
+  - scaffolder.yaml

--- a/scaffolder/scaffolder.yaml
+++ b/scaffolder/scaffolder.yaml
@@ -1,0 +1,131 @@
+---
+# Scaffolder lane — a bespoke PRIVILEGED build namespace (not a build-namespace
+# chart target). Unlike the per-project build lanes it needs BOTH an incoming
+# webhook (triggered by Port's scaffold_app action) AND egress (GitHub API to
+# create repos, Anthropic API for the agent). So it's hand-rolled here rather
+# than rendered from helm-charts/build-namespace (which couples incoming↔untrusted
+# and egress↔trusted). Runs scaffold-app.sh from platform-infra.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scaffolder
+  labels:
+    build.capturly/lane: scaffolder
+    # restricted-but-permitted: the pipeline runs non-root; no privileged pods.
+    pod-security.kubernetes.io/enforce: baseline
+---
+# Pipeline ServiceAccount. No cloud identity, no linked git secret: the scaffold
+# task mints a short-lived GitHub App installation token at run time.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scaffolder-runner
+  namespace: scaffolder
+---
+# Pipelines-as-Code Repository for the scaffolder. INCOMING-ONLY: Port's
+# scaffold_app action POSTs to the PaC /incoming endpoint with the shared secret
+# and the scaffold inputs, running .tekton/scaffold-app-incoming.yaml on
+# platform-infra's main. No PR events run here (the PipelineRun is on-event:
+# [incoming] only). The PaC GitHub App must be installed on platform-infra.
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: scaffolder
+  namespace: scaffolder
+spec:
+  url: https://github.com/Corey-Alan-Consulting/platform-infra
+  incoming:
+    - type: webhook-url
+      secret:
+        name: scaffolder-pac-incoming
+        key: secret
+      targets: ["main"]
+---
+# Shared PaC /incoming secret — the SAME value the Port scaffold_app action sends
+# as {{ .secrets.PAC_INCOMING_SECRET }} (BWS CAPTURLY_PAC_INCOMING_SECRET, also
+# used by build_branch). Build Platform project has the working store.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: scaffolder-pac-incoming
+  namespace: scaffolder
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-build-platform
+    kind: ClusterSecretStore
+  target:
+    name: scaffolder-pac-incoming
+    creationPolicy: Owner
+    template: { engineVersion: v2 }
+  data:
+    - secretKey: secret
+      remoteRef: { key: 6e103eb4-23ad-409b-8f73-b49800d3826f }   # CAPTURLY_PAC_INCOMING_SECRET
+---
+# Anthropic API key for the agent pass (mounted as env ANTHROPIC_API_KEY). Fill
+# the placeholder BWS value with a real, scaffolding-scoped key.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: scaffolder-anthropic
+  namespace: scaffolder
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-build-platform
+    kind: ClusterSecretStore
+  target:
+    name: scaffolder-anthropic
+    creationPolicy: Owner
+    template: { engineVersion: v2 }
+  data:
+    - secretKey: api-key
+      remoteRef: { key: 00787b4f-b9c5-4b84-b8be-b499004e35ad }   # SCAFFOLDER_ANTHROPIC_API_KEY
+---
+# Scaffolder GitHub App credentials (Administration:write + Contents:write + PRs).
+# The task mints a ~1h ORG installation token from these — no static git secret.
+# Fill the placeholders after creating + installing the App on the org.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: scaffolder-github-app
+  namespace: scaffolder
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-build-platform
+    kind: ClusterSecretStore
+  target:
+    name: scaffolder-github-app
+    creationPolicy: Owner
+    template: { engineVersion: v2 }
+  data:
+    - secretKey: app-id
+      remoteRef: { key: f9b73dcd-32fa-4973-841d-b499004e35de }   # SCAFFOLDER_GITHUB_APP_ID
+    - secretKey: app-private-key
+      remoteRef: { key: 0b01607c-cdef-4c1d-a5fa-b499004e3611 }   # SCAFFOLDER_GITHUB_APP_PRIVATE_KEY
+---
+# Egress: DNS + k8s API (Tekton orchestration) + public HTTPS (GitHub, Anthropic,
+# npm for the claude/gh CLIs). Private ranges excluded (anti lateral-movement),
+# except the in-cluster API server/service CIDRs above. This lane is privileged
+# by nature (it creates repos) — kept to 443 out + the two cluster CIDRs.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: scaffolder-egress
+  namespace: scaffolder
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress:
+    - to: [{ namespaceSelector: {} }]
+      ports: [{ protocol: UDP, port: 53 }, { protocol: TCP, port: 53 }]
+    - to: [{ ipBlock: { cidr: 10.20.0.250/32 } }]   # kube-apiserver
+      ports: [{ protocol: TCP, port: 6443 }]
+    - to: [{ ipBlock: { cidr: 10.43.0.1/32 } }]     # in-cluster kubernetes Service
+      ports: [{ protocol: TCP, port: 443 }]
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16]
+      ports: [{ protocol: TCP, port: 443 }]


### PR DESCRIPTION
In-cluster half of the Port `scaffold_app` action (Slice 3).

**`scaffolder/`** — bespoke privileged namespace (incoming webhook **and** egress, so not a build-namespace chart target): namespace + `scaffolder-runner` SA + PaC Repository (incoming-only, url=platform-infra) + ExternalSecrets (shared `PAC_INCOMING_SECRET`, Anthropic key, GitHub App creds — Build Platform BWS store) + egress netpol. ArgoCD app (wave 0).

**`build-catalog/pipelines/scaffold-app.yaml`** — mints a ~1h GitHub App **org** installation token (repo-create), installs `gh`+`claude` at runtime, clones platform-infra, runs `scaffold-app.sh`. Auto-`--no-agent` while the Anthropic key is a placeholder (testable pre-key); `--no-onboard` for the MVP.

**Prereqs (you):** create+install the Scaffolder GitHub App on platform-infra; confirm the PaC App is installed there; fill the placeholder BWS secrets (Anthropic `00787b4f`, App id `f9b73dcd`, App key `0b01607c`). Companion PR on platform-infra adds the `.tekton` trigger + `--no-onboard`.