### PR TITLE
fix(scaffolder): allow scaffolder namespace in business AppProject

### DIFF
--- a/business-plane/appproject.yaml
+++ b/business-plane/appproject.yaml
@@ -36,6 +36,9 @@ spec:
     # Phase 2 Verdaccio npm registry proxy (untrusted-tier private-dep install).
     - server: https://kubernetes.default.svc
       namespace: build-registry-proxy
+    # Scaffolder lane (Port scaffold_app action → new app from app-template).
+    - server: https://kubernetes.default.svc
+      namespace: scaffolder
   # Tekton (operator + PaC + MAG) installs cluster-scoped CRDs/RBAC/webhooks; the
   # untrusted tier needs RuntimeClass; our apps apply the cluster-scoped
   # TektonConfig. First sync may surface an additional cluster kind an upstream


### PR DESCRIPTION
The `scaffolder` Application (from #805) sat `InvalidSpecError` — its destination namespace isn't in the `business` project allowlist (it's a bespoke lane, not a `*-builds-*` match). Add `scaffolder` explicitly so ArgoCD can sync it.