### PR TITLE
feat(scaffolder): full onboarding lane with approval gates

### DIFF
--- a/build-catalog/pipelines/scaffold-app.yaml
+++ b/build-catalog/pipelines/scaffold-app.yaml
@@ -1,9 +1,25 @@
 ---
-# Scaffolder pipeline: stand up a new app from app-template on demand (Port
-# scaffold_app action -> PaC /incoming). Mints a short-lived GitHub App ORG
-# installation token (repo-create scope), clones platform-infra, and runs
-# scripts/scaffold-app.sh with the requested inputs. Runs in the `scaffolder`
-# namespace (egress-allowed, privileged lane). Everything lands as PRs for review.
+# Scaffolder pipeline — FULL onboarding lane. Stands up a new app from
+# app-template end to end, pausing at in-cluster ApprovalTask gates wherever a
+# human or an out-of-band action is required (design: framework guides/new-app.md).
+#
+# Flow:
+#   prepare  ── rebrand → app-repo PR; onboard-app.sh --yes → platform-infra PR
+#               (TF/Helm/ArgoCD + BWS project/secrets); scaffold-dns.sh → CF zone
+#               + records + <app>-dns.tf PR; prints the registrar nameservers.
+#   ⏸ gate-1 ── APPROVE once you've: merged+applied the onboard + dns PRs AND
+#               done the registrar nameserver cutover for the new domain.
+#   finish   ── reads the new GCP project NUMBER via a read-only SA, patches
+#               apps.tfvars (platform-infra PR), and generates the staging
+#               environment (homelab-infra PR).
+#   ⏸ gate-2 ── APPROVE after reviewing the apps.tfvars + staging PRs and
+#               completing the staging TODOs (BWS staging project, credentials
+#               bootstrap, infraAppName).
+#
+# Everything lands as PRs — the lane never merges. Runs in the `scaffolder`
+# namespace (egress-allowed, privileged: creates repos, DNS zones, BWS secrets).
+# The long pipeline timeout lets gate-1 wait for the out-of-band merge/apply +
+# registrar cutover.
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
@@ -15,23 +31,38 @@ spec:
     - { name: company,     type: string }
     - { name: description, type: string, default: "" }
     - { name: database,    type: string, default: "false" }
-    - { name: github-org,  type: string, default: "Corey-Alan-Consulting" }
+    - { name: github-org,  type: string, default: "Corey-Alan-Consulting" }  # app + platform-infra
+    - { name: homelab-org, type: string, default: "NX211" }                  # homelab-infra (staging)
+    - { name: lb-ip,       type: string, default: "136.113.137.214" }        # google_compute_address.traefik_lb
+    - { name: approvers,          type: array,  default: ["corey"] }
+    - { name: approvals-required, type: string, default: "1" }
     - name: toolchain-image
       type: string
-      # node + npm + git + curl + openssl + python3 (for the App-token JWT); gh
-      # and the claude CLI are installed at run time (this lane has egress).
+      # node + npm + git + curl + openssl + python3. gh + claude installed at run time.
       default: docker.io/library/node:22-bookworm
   workspaces:
-    - name: source        # scratch (clone platform-infra + the generated repo)
-    - name: github-app    # secret: app-id + app-private-key
+    - name: source        # scratch clones
+    - name: github-app    # secret: app-id + app-private-key (installed on BOTH orgs)
     - name: anthropic     # secret: api-key
+    - name: cloudflare    # secret: api-token (Zone:Edit + DNS:Edit)
+    - name: gcp-sa        # secret: key.json (roles/viewer on the Clients folder)
+    - name: bws           # secret: access-token (BWS write, for onboard secret creation)
   tasks:
-    - name: scaffold
+    # ── prepare: rebrand + onboard + dns ────────────────────────────────────
+    - name: prepare
       workspaces:
         - { name: source, workspace: source }
         - { name: github-app, workspace: github-app }
         - { name: anthropic, workspace: anthropic }
+        - { name: cloudflare, workspace: cloudflare }
+        - { name: bws, workspace: bws }
       taskSpec:
+        workspaces:
+          - { name: source }
+          - { name: github-app }
+          - { name: anthropic }
+          - { name: cloudflare }
+          - { name: bws }
         params:
           - { name: name }
           - { name: domain }
@@ -39,13 +70,10 @@ spec:
           - { name: description }
           - { name: database }
           - { name: github-org }
+          - { name: lb-ip }
           - { name: toolchain-image }
-        workspaces:
-          - { name: source }
-          - { name: github-app }
-          - { name: anthropic }
         steps:
-          - name: scaffold
+          - name: prepare
             image: $(params.toolchain-image)
             workingDir: $(workspaces.source.path)
             env:
@@ -55,28 +83,37 @@ spec:
               #!/usr/bin/env bash
               set -euo pipefail
 
-              # --- 1. Mint a ~1h GitHub App ORG installation token (repo-create) ---
+              # --- GitHub App ORG installation token (repo create + PRs) --------
               gh_api="https://api.github.com"
-              APP_ID="$(cat $(workspaces.github-app.path)/app-id)"
-              now="$(date +%s)"
               b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
-              hdr="$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | b64url)"
-              pld="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$((now-60))" "$((now+540))" "$APP_ID" | b64url)"
-              sig="$(printf '%s' "$hdr.$pld" | openssl dgst -sha256 -sign "$(workspaces.github-app.path)/app-private-key" -binary | b64url)"
-              jwt="$hdr.$pld.$sig"
-              inst="$(curl -sf -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" "$gh_api/orgs/${GH_ORG}/installation" | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])')"
-              export GH_TOKEN="$(curl -sf -X POST -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" "$gh_api/app/installations/$inst/access_tokens" | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])')"
+              mint_token() { # mint_token <org>  -> echoes an installation token
+                local org="$1" now hdr pld sig jwt inst
+                now="$(date +%s)"
+                hdr="$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | b64url)"
+                pld="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$((now-60))" "$((now+540))" \
+                       "$(cat $(workspaces.github-app.path)/app-id)" | b64url)"
+                sig="$(printf '%s' "$hdr.$pld" | openssl dgst -sha256 \
+                       -sign "$(workspaces.github-app.path)/app-private-key" -binary | b64url)"
+                jwt="$hdr.$pld.$sig"
+                inst="$(curl -sf -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" \
+                       "$gh_api/orgs/${org}/installation" | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])')"
+                curl -sf -X POST -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" \
+                       "$gh_api/app/installations/$inst/access_tokens" \
+                       | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])'
+              }
+              export GH_TOKEN="$(mint_token "$GH_ORG")"
               git config --global credential.helper ''
               git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+              git config --global user.email "scaffolder@coreyalan.com"
+              git config --global user.name  "app-scaffolder"
 
-              # --- 2. Tooling (egress-allowed lane): gh CLI + claude CLI ---
+              # --- tooling (egress lane): gh CLI + optional claude --------------
               GH_VER=2.63.2
               curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_amd64.tar.gz" | tar -xz -C /tmp
               export PATH="/tmp/gh_${GH_VER}_linux_amd64/bin:${HOME}/.npm-global/bin:${PATH}"
-              # Agent runs only once a real key is present; skip while placeholder.
               AGENT_FLAG=""
               if grep -q "PLACEHOLDER" "$(workspaces.anthropic.path)/api-key"; then
-                echo "ANTHROPIC key is still a placeholder -> --no-agent (deterministic scaffold + worklist PR)"
+                echo "Anthropic key placeholder -> --no-agent"
                 AGENT_FLAG="--no-agent"
               else
                 export ANTHROPIC_API_KEY="$(cat $(workspaces.anthropic.path)/api-key)"
@@ -84,19 +121,155 @@ spec:
                 npm install -g @anthropic-ai/claude-code >/dev/null 2>&1
               fi
 
-              # --- 3. Clone platform-infra (has scaffold-app.sh) + run it ---
+              # --- credentials for onboard (BWS) + dns (Cloudflare) ------------
+              export BWS_ACCESS_TOKEN="$(cat $(workspaces.bws.path)/access-token)"
+              export CLOUDFLARE_API_TOKEN="$(cat $(workspaces.cloudflare.path)/api-token)"
+
+              # --- clone platform-infra (carries all three scripts) ------------
               git clone --depth 1 "https://github.com/${GH_ORG}/platform-infra.git" "${HOME}/platform-infra"
               cd "${HOME}/platform-infra"
+
               DB_FLAG=""; [ "$(params.database)" = "true" ] && DB_FLAG="--database"
               DESC_ARGS=(); [ -n "$(params.description)" ] && DESC_ARGS=(--description "$(params.description)")
+
+              # rebrand (app-repo PR) + onboard --yes (platform-infra PR: TF/Helm/BWS)
               bash scripts/scaffold-app.sh \
                 --name "$(params.name)" --domain "$(params.domain)" --company "$(params.company)" \
-                --github-org "$GH_ORG" "${DESC_ARGS[@]}" $DB_FLAG --no-onboard $AGENT_FLAG
+                --github-org "$GH_ORG" "${DESC_ARGS[@]}" $DB_FLAG --ci $AGENT_FLAG
+
+              # dns: fresh main so the dns PR carries ONLY <app>-dns.tf
+              git checkout main && git pull --ff-only
+              bash scripts/scaffold-dns.sh \
+                --app "$(params.name)" --domain "$(params.domain)" \
+                --lb-ip "$(params.lb-ip)" --repo-root . --pr
+
+              echo "=== prepare done. Merge+apply the onboard + dns PRs, do the registrar"
+              echo "=== nameserver cutover, then APPROVE gate-1 to continue."
+
+    # ── gate-1: out-of-band merge/apply + registrar cutover ──────────────────
+    - name: gate-merge-apply
+      runAfter: [prepare]
+      taskRef:
+        apiVersion: openshift-pipelines.org/v1alpha1
+        kind: ApprovalTask
       params:
-        - { name: name,        value: $(params.name) }
-        - { name: domain,      value: $(params.domain) }
-        - { name: company,     value: $(params.company) }
-        - { name: description, value: $(params.description) }
-        - { name: database,    value: $(params.database) }
-        - { name: github-org,  value: $(params.github-org) }
-        - { name: toolchain-image, value: $(params.toolchain-image) }
+        - { name: approvers, value: $(params.approvers) }
+        - { name: numberOfApprovalsRequired, value: $(params.approvals-required) }
+        - { name: description, value: "Merge+apply onboard & dns PRs for $(params.name); complete the registrar NS cutover for $(params.domain); then approve." }
+
+    # ── finish: project-number backfill + staging ───────────────────────────
+    - name: finish
+      runAfter: [gate-merge-apply]
+      workspaces:
+        - { name: source, workspace: source }
+        - { name: github-app, workspace: github-app }
+        - { name: gcp-sa, workspace: gcp-sa }
+      taskSpec:
+        workspaces:
+          - { name: source }
+          - { name: github-app }
+          - { name: gcp-sa }
+        params:
+          - { name: name }
+          - { name: domain }
+          - { name: company }
+          - { name: database }
+          - { name: github-org }
+          - { name: homelab-org }
+          - { name: toolchain-image }
+        steps:
+          - name: finish
+            image: $(params.toolchain-image)
+            workingDir: $(workspaces.source.path)
+            env:
+              - { name: HOME, value: $(workspaces.source.path) }
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              gh_api="https://api.github.com"
+              b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+              mint_token() { # mint_token <org>
+                local org="$1" now hdr pld sig jwt inst
+                now="$(date +%s)"
+                hdr="$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | b64url)"
+                pld="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$((now-60))" "$((now+540))" \
+                       "$(cat $(workspaces.github-app.path)/app-id)" | b64url)"
+                sig="$(printf '%s' "$hdr.$pld" | openssl dgst -sha256 \
+                       -sign "$(workspaces.github-app.path)/app-private-key" -binary | b64url)"
+                jwt="$hdr.$pld.$sig"
+                inst="$(curl -sf -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" \
+                       "$gh_api/orgs/${org}/installation" | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])')"
+                curl -sf -X POST -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" \
+                       "$gh_api/app/installations/$inst/access_tokens" \
+                       | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])'
+              }
+
+              # --- GCP access token from the read-only SA key (JWT-bearer) ------
+              # Same openssl machinery as the GitHub App token above — kept in
+              # shell (not embedded python) to avoid heredoc-indentation traps.
+              SA="$(workspaces.gcp-sa.path)/key.json"
+              CE="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["client_email"])' "$SA")"
+              python3 -c 'import json,sys;open("/tmp/sa.pem","w").write(json.load(open(sys.argv[1]))["private_key"])' "$SA"
+              gnow="$(date +%s)"
+              ghdr="$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | b64url)"
+              gclm="$(printf '{"iss":"%s","scope":"https://www.googleapis.com/auth/cloud-platform.read-only","aud":"https://oauth2.googleapis.com/token","iat":%s,"exp":%s}' \
+                     "$CE" "$gnow" "$((gnow+3600))" | b64url)"
+              gsig="$(printf '%s' "$ghdr.$gclm" | openssl dgst -sha256 -sign /tmp/sa.pem -binary | b64url)"
+              GCP_TOKEN="$(curl -sf -X POST "https://oauth2.googleapis.com/token" \
+                     --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer" \
+                     --data-urlencode "assertion=$ghdr.$gclm.$gsig" \
+                     | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')"
+              rm -f /tmp/sa.pem
+
+              # --- read the new project's NUMBER (id defaults to the app name) --
+              PROJECT_ID="$(params.name)"
+              NUM="$(curl -sf -H "Authorization: Bearer ${GCP_TOKEN}" \
+                     "https://cloudresourcemanager.googleapis.com/v1/projects/${PROJECT_ID}" \
+                     | python3 -c 'import sys,json;print(json.load(sys.stdin)["projectNumber"])')"
+              [ -n "$NUM" ] || { echo "could not read projectNumber for ${PROJECT_ID} — is the onboard PR applied?"; exit 1; }
+              MOD="$(printf '%s' "$(params.name)" | tr '-' '_')"
+
+              git config --global user.email "scaffolder@coreyalan.com"
+              git config --global user.name  "app-scaffolder"
+
+              # --- platform-infra: patch apps.tfvars project number (PR) --------
+              export GH_TOKEN="$(mint_token "$(params.github-org)")"
+              git config --global credential.helper ''
+              git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+              git clone --depth 1 "https://github.com/$(params.github-org)/platform-infra.git" "${HOME}/pi"
+              cd "${HOME}/pi"
+              git checkout -b "scaffold/project-number-$(params.name)"
+              sed -i "s|^${MOD}_project_number = \"\".*|${MOD}_project_number = \"${NUM}\"|" \
+                terraform/environments/prod/apps.tfvars
+              git add terraform/environments/prod/apps.tfvars
+              git commit -q -m "chore(tfvars): $(params.name) GCP project number (${NUM})"
+              git push -u origin "scaffold/project-number-$(params.name)"
+              gh pr create --repo "$(params.github-org)/platform-infra" \
+                --title "chore(tfvars): $(params.name) GCP project number" \
+                --body "Backfills \`${MOD}_project_number = \"${NUM}\"\` (read from GCP after the onboard apply). Merge after the onboard PR is applied." \
+                || echo "  (apps.tfvars PR skipped/failed)"
+
+              # --- homelab-infra: generate the staging environment (PR) --------
+              export GH_TOKEN="$(mint_token "$(params.homelab-org)")"
+              git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+              git clone --depth 1 "https://github.com/$(params.homelab-org)/homelab-infra.git" "${HOME}/hi"
+              cd "${HOME}/hi"
+              DB_FLAG=""; [ "$(params.database)" = "true" ] && DB_FLAG="--database"
+              bash scripts/gen-staging-app.sh \
+                --name "$(params.name)" --domain "$(params.domain)" --company "$(params.company)" \
+                --gcp-project "$PROJECT_ID" $DB_FLAG --repo-root . --pr
+
+              echo "=== finish done. Review the apps.tfvars + staging PRs, complete the"
+              echo "=== staging TODOs, then APPROVE gate-2."
+
+    # ── gate-2: final review ─────────────────────────────────────────────────
+    - name: gate-final
+      runAfter: [finish]
+      taskRef:
+        apiVersion: openshift-pipelines.org/v1alpha1
+        kind: ApprovalTask
+      params:
+        - { name: approvers, value: $(params.approvers) }
+        - { name: numberOfApprovalsRequired, value: $(params.approvals-required) }
+        - { name: description, value: "Review apps.tfvars + staging PRs for $(params.name); complete staging TODOs (BWS project, credentials, infraAppName); then approve." }

--- a/scaffolder/scaffolder.yaml
+++ b/scaffolder/scaffolder.yaml
@@ -105,6 +105,69 @@ spec:
     - secretKey: app-private-key
       remoteRef: { key: 0b01607c-cdef-4c1d-a5fa-b499004e3611 }   # SCAFFOLDER_GITHUB_APP_PRIVATE_KEY
 ---
+# Read-only GCP service-account key (roles/viewer on the Clients folder). The
+# finish task reads the new app's project NUMBER from Cloud Resource Manager to
+# backfill apps.tfvars. Mounted as the `gcp-sa` workspace, file key.json.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: scaffolder-gcp-sa
+  namespace: scaffolder
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-build-platform
+    kind: ClusterSecretStore
+  target:
+    name: scaffolder-gcp-sa
+    creationPolicy: Owner
+    template: { engineVersion: v2 }
+  data:
+    - secretKey: key.json
+      remoteRef: { key: bfaeb4af-8c6e-44c9-a78d-b499010163eb }   # SCAFFOLDER_GCP_SA_KEY
+---
+# Cloudflare API token (Zone:Edit + DNS:Edit). scaffold-dns.sh uses it to create
+# the app's zone + apex/staging records. Mounted as the `cloudflare` workspace,
+# file api-token.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: scaffolder-cloudflare
+  namespace: scaffolder
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-build-platform
+    kind: ClusterSecretStore
+  target:
+    name: scaffolder-cloudflare
+    creationPolicy: Owner
+    template: { engineVersion: v2 }
+  data:
+    - secretKey: api-token
+      remoteRef: { key: a043a87a-64c3-4515-81de-b4990101641e }   # SCAFFOLDER_CLOUDFLARE_TOKEN
+---
+# BWS write token — onboard-app.sh --yes uses it to create the app's Bitwarden
+# project + secret placeholders. Distinct from ESO's own machine-account auth.
+# Mounted as the `bws` workspace, file access-token.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: scaffolder-bws
+  namespace: scaffolder
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-build-platform
+    kind: ClusterSecretStore
+  target:
+    name: scaffolder-bws
+    creationPolicy: Owner
+    template: { engineVersion: v2 }
+  data:
+    - secretKey: access-token
+      remoteRef: { key: 76802c92-daef-47bb-8af7-b49901016452 }   # SCAFFOLDER_BWS_ACCESS_TOKEN
+---
 # Egress: DNS + k8s API (Tekton orchestration) + public HTTPS (GitHub, Anthropic,
 # npm for the claude/gh CLIs). Private ranges excluded (anti lateral-movement),
 # except the in-cluster API server/service CIDRs above. This lane is privileged

--- a/scripts/gen-staging-app.sh
+++ b/scripts/gen-staging-app.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# gen-staging-app.sh — generate the staging half of a new app (homelab-infra):
+# the staging-apps/<prod-app>/ chart wrapper + the argocd staging-<prod-app>
+# Application. "Build once, deploy many" — staging runs the SAME prod image, a
+# different config. Called by the scaffolder lane after onboarding; opens a PR.
+#
+# Naming (matches the existing staging apps):
+#   prod-app  = <domain> with dots -> dashes   (myapp.io -> myapp-io)
+#   dir       = staging-apps/<prod-app>/
+#   Argo app  = staging-<prod-app>   (staging-promote.yml parses this exactly)
+#   host      = staging.<domain>
+#
+# Some values can't be derived and are emitted as PLACEHOLDER for a reviewer to
+# fill at the final gate (they need a human/first-run action):
+#   - bitwarden.projectID          — create a per-app staging BWS project
+#   - bitwarden.credentialsSecret  — one-time ESO bootstrap secret in
+#                                    external-secrets-system (scoped to that project)
+#   - image.digest                 — seeded empty; CI's gitops-staging-update fills it
+#   - ipAllowList.appName          — must equal the StagingSite.infraAppName in the admin UI
+#
+# Usage:
+#   ./scripts/gen-staging-app.sh --name <slug> --domain <domain> --company <display> \
+#     [--gcp-project <id>] [--database] [--repo-root <path>] [--no-pr]
+set -euo pipefail
+
+NAME="" DOMAIN="" COMPANY="" GCP_PROJECT="" DATABASE=false REPO_ROOT="." OPEN_PR=true
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --name)        NAME="$2"; shift 2;;
+    --domain)      DOMAIN="$2"; shift 2;;
+    --company)     COMPANY="$2"; shift 2;;
+    --gcp-project) GCP_PROJECT="$2"; shift 2;;
+    --database)    DATABASE=true; shift;;
+    --repo-root)   REPO_ROOT="$2"; shift 2;;
+    --no-pr)       OPEN_PR=false; shift;;
+    -h|--help)     grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+    *) echo "unknown flag: $1" >&2; exit 1;;
+  esac
+done
+[ -n "$NAME" ]    || { echo "--name is required" >&2; exit 1; }
+[ -n "$DOMAIN" ]  || { echo "--domain is required" >&2; exit 1; }
+[ -n "$COMPANY" ] || { echo "--company is required" >&2; exit 1; }
+GCP_PROJECT="${GCP_PROJECT:-$NAME}"
+
+PROD_APP="$(printf '%s' "$DOMAIN" | tr '.' '-')"          # myapp.io -> myapp-io
+IMAGE_REPO="us-central1-docker.pkg.dev/${GCP_PROJECT}/${GCP_PROJECT}/${NAME}-web"
+STAGING_ORG_ID="4650c1c8-8d22-4073-8a7d-b3cf011d5ff2"      # constant across staging apps
+CHART_VER="0.7.2"                                          # charts/staging-app
+DIR="${REPO_ROOT}/staging-apps/${PROD_APP}"
+APP_FILE="${REPO_ROOT}/argocd/applications/staging-${PROD_APP}.yaml"
+
+echo "=== gen-staging: ${PROD_APP}  (host=staging.${DOMAIN}, db=${DATABASE}) ==="
+mkdir -p "$DIR"
+
+# --- Chart.yaml --------------------------------------------------------------
+cat > "${DIR}/Chart.yaml" <<EOF
+apiVersion: v2
+name: ${PROD_APP}-staging
+description: ${COMPANY} - Staging Environment
+type: application
+version: 1.0.0
+appVersion: "0.1.0"
+keywords:
+  - ${NAME}
+  - nextjs
+  - staging
+maintainers:
+  - name: Homelab Admin
+dependencies:
+  - name: staging-app
+    version: "${CHART_VER}"
+    repository: "file://../../charts/staging-app"
+EOF
+
+# --- values.yaml -------------------------------------------------------------
+if $DATABASE; then
+  DB_BLOCK=$'  database:\n    enabled: true\n    superuser:\n      create: false # uses the shared postgres-superuser-staging secret\n  migration:\n    enabled: true'
+else
+  DB_BLOCK=$'  database:\n    enabled: false\n  migration:\n    enabled: false'
+fi
+
+cat > "${DIR}/values.yaml" <<EOF
+# ${COMPANY} - Staging Values
+# Build once, deploy many: same image as prod, different config.
+
+staging-app:
+  appName: ${NAME}
+  appLabel: ${COMPANY}
+  fullnameOverride: ${PROD_APP}-staging
+  replicaCount: 1
+  # Per-app Bitwarden staging store (least privilege). TODO(scaffold): create a
+  # staging BWS project for this app and put its id here; bootstrap the
+  # credentialsSecret (a BWS access token scoped to that project) as a K8s secret
+  # in external-secrets-system — one-time, same pattern as the other staging apps.
+  bitwarden:
+    projectID: "PLACEHOLDER-create-staging-bws-project"
+    organizationID: "${STAGING_ORG_ID}"
+    credentialsSecret: bitwarden-staging-${NAME}-credentials
+${DB_BLOCK}
+  image:
+    repository: ${IMAGE_REPO}
+    pullPolicy: IfNotPresent
+    digest: "" # Seeded empty; CI's gitops-staging-update.yml fills it from the first prod build
+  imagePullSecrets:
+    - name: gcr-pull-secret-${NAME}
+  gcrPullSecret:
+    bitwardenKey: "" # keyless via WIF (ar-token-refresher); ESO does not manage this pull secret
+    secretName: gcr-pull-secret-${NAME}
+  service:
+    type: ClusterIP
+    port: 3000
+  ingress:
+    enabled: true
+    host: staging.${DOMAIN}
+    clusterIssuer: letsencrypt-prod
+    # On-LAN/in-cluster by default; the allowlist-reconciler unions reviewer IPs
+    # at runtime from Bitwarden (STAGING_BASE_ALLOWLIST_CIDR stays out of git).
+    ipAllowList:
+      enabled: true
+      sourceRange:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+      reconcilerManaged: true
+      # TODO(scaffold): appName MUST equal the StagingSite.infraAppName entered in
+      # the admin UI for review-access to resolve. Defaulted to the prod-app name.
+      appName: ${PROD_APP}
+  env:
+    - name: NODE_ENV
+      value: production
+    - name: APP_ENV
+      value: staging
+EOF
+
+# --- argocd/applications/staging-<prod-app>.yaml -----------------------------
+mkdir -p "$(dirname "$APP_FILE")"
+cat > "$APP_FILE" <<EOF
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # Name follows the \`staging-<prod-app-name>\` convention so staging-promote.yml
+  # (\`ARGO_APP="staging-\${APP_NAME}"\`), the gitops-trigger STAGING_APP_MAP, and the
+  # PR branch naming all line up without per-app special cases.
+  name: staging-${PROD_APP}
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: ${PROD_APP}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/NX211/homelab-infra.git
+    targetRevision: HEAD
+    path: staging-apps/${PROD_APP}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: staging
+  # The allowlist-reconciler owns this Middleware's sourceRange (base ∪ reviewer
+  # IPs); ignore it so selfHeal won't revert runtime writes.
+  ignoreDifferences:
+    - group: traefik.io
+      kind: Middleware
+      name: ${PROD_APP}-staging-ipallowlist
+      namespace: staging
+      jsonPointers:
+        - /spec/ipAllowList/sourceRange
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+EOF
+
+echo "  wrote ${DIR}/{Chart.yaml,values.yaml}"
+echo "  wrote ${APP_FILE}"
+
+# --- optional PR -------------------------------------------------------------
+if $OPEN_PR; then
+  BRANCH="scaffold/staging-${PROD_APP}"
+  git -C "$REPO_ROOT" checkout -b "$BRANCH"
+  git -C "$REPO_ROOT" add "staging-apps/${PROD_APP}" "argocd/applications/staging-${PROD_APP}.yaml"
+  git -C "$REPO_ROOT" commit -q -m "feat(staging): add ${PROD_APP} staging environment
+
+Generated by gen-staging-app.sh (scaffolder lane). Runs the same prod image as
+staging.${DOMAIN}. Reviewer TODOs before first deploy: create the staging BWS
+project + credentialsSecret bootstrap, and confirm ipAllowList.appName matches
+the StagingSite.infraAppName in the admin UI."
+  git -C "$REPO_ROOT" push -u origin "$BRANCH"
+  gh pr create --repo NX211/homelab-infra \
+    --title "feat(staging): add ${PROD_APP} staging environment" \
+    --body "Staging half of the ${COMPANY} scaffold. Same prod image, deployed at \`staging.${DOMAIN}\`.
+
+**Reviewer TODOs before first deploy** (flagged inline):
+- Create a per-app **staging Bitwarden project** → put its id in \`bitwarden.projectID\`.
+- Bootstrap \`bitwarden-staging-${NAME}-credentials\` (BWS token scoped to that project) in \`external-secrets-system\`.
+- Confirm \`ipAllowList.appName\` (\`${PROD_APP}\`) equals the \`StagingSite.infraAppName\` in the admin UI.
+- \`image.digest\` seeds empty; CI's gitops-staging-update fills it from the first prod build." || echo "  (gh pr create skipped/failed — files are committed on ${BRANCH})"
+fi


### PR DESCRIPTION
Upgrades the scaffolder (homelab half) from rebrand-only to **end-to-end onboarding**, pausing at in-cluster `ApprovalTask` gates wherever a human/out-of-band step is required.

**`build-catalog/pipelines/scaffold-app.yaml`** — rewritten to `prepare → gate-1 → finish → gate-2`:
- **prepare**: rebrand (app PR) + `onboard-app.sh --yes` (platform-infra PR: TF/Helm/ArgoCD + BWS project/secrets) + `scaffold-dns.sh` (CF zone/records + `<app>-dns.tf` PR; prints registrar nameservers)
- **gate-1**: merge+apply onboard/dns PRs + registrar NS cutover
- **finish**: read the new GCP project **number** via a read-only SA (JWT-bearer), backfill `apps.tfvars` (PR), generate the staging env (homelab PR)
- **gate-2**: review PRs + finish staging TODOs

**`scaffolder/scaffolder.yaml`** — 3 new ExternalSecrets: `scaffolder-gcp-sa`, `scaffolder-cloudflare`, `scaffolder-bws`.

**`scripts/gen-staging-app.sh`** — staging chart + `staging-<prod-app>` Application generator; human/first-run fields emitted as flagged TODOs.

Companion PR on platform-infra adds `scaffold-dns.sh`, `--yes`/`--ci` script flags, and the new workspaces + 48h timeout. **Inert** until the Scaffolder GitHub App is installed on both orgs (NX211 + Corey-Alan-Consulting) and the 3 credentials are filled.