### PR TITLE
fix(web-ci): cap vitest forks to the CPU budget (untrusted lane timeouts)

### DIFF
--- a/build-catalog/tasks/web-ci.yaml
+++ b/build-catalog/tasks/web-ci.yaml
@@ -51,6 +51,18 @@ spec:
         # offline. loose env-mode passes this through to the build tasks.
         - name: PRISMA_ENGINES_MIRROR
           value: http://prisma-mirror-untrusted.build-registry-proxy.svc.cluster.local:8080
+        # Vitest's `forks` pool sizes itself from os.cpus(), which under gVisor
+        # reports the 32-core NODE, not this step's 4–8 CPU cgroup — so it spawned
+        # ~18 forks that starved each other and blew the 15s test timeout (cold
+        # files timed out; siblings then failed on leaked mock state). Cap forks
+        # to the CPU budget and widen the timeouts as a backstop. Read by
+        # apps/web/vitest.config.ts; unset elsewhere so local/GitHub is unchanged.
+        - name: VITEST_MAX_FORKS
+          value: "6"
+        - name: VITEST_TEST_TIMEOUT_MS
+          value: "30000"
+        - name: VITEST_HOOK_TIMEOUT_MS
+          value: "30000"
       script: |
         #!/usr/bin/env bash
         set -euo pipefail


### PR DESCRIPTION
The untrusted `capturly-nextjs-pr` check has been failing ~20 tests with **`Test timed out in 15000ms`** (+ sibling `vi.fn() called 2 times`-style fallout from leaked mock state on the timed-out test).

**Root cause:** vitest's `forks` pool sizes from `os.cpus()`, which under gVisor reports the **32-core node**, not this step's 4–8 CPU cgroup — so it spawned ~18 forks fighting 4–8 cores (cumulative transform 1483s / import 1610s vs 81s wall ≈ 18× oversubscription). Cold files blew the 15s timeout.

**Fix:** `VITEST_MAX_FORKS=6` (matches the CPU budget) + `VITEST_TEST/HOOK_TIMEOUT_MS=30000` backstop. Consumed by `apps/web/vitest.config.ts` (companion capturly PR); unset elsewhere so local/GitHub is unchanged. Not services/secrets — GH Actions provides neither and the same tests pass there. Verified locally: the sampled failing files pass in <1s with real CPU.