### PR TITLE
feat(scaffolder): keyless Claude auth via Workload Identity Federation

### DIFF
--- a/build-catalog/pipelines/scaffold-app.yaml
+++ b/build-catalog/pipelines/scaffold-app.yaml
@@ -56,7 +56,7 @@ spec:
   workspaces:
     - name: source        # scratch clones
     - name: github-app    # secret: app-id + app-private-key (installed on BOTH orgs)
-    - name: anthropic     # secret: api-key
+    - name: anthropic     # secret: WIF identifiers (federation-rule/service-account/org/workspace ids)
     - name: cloudflare    # secret: api-token (Zone:Edit + DNS:Edit)
     - name: bws           # secret: access-token (BWS write, for onboard secret creation)
   tasks:
@@ -75,12 +75,27 @@ spec:
           - { name: anthropic }
           - { name: cloudflare }
           - { name: bws }
+        # Per-run projected identity for keyless Claude (WIF). Audience MUST equal
+        # the Anthropic federation rule's audience; sub is
+        # system:serviceaccount:scaffolder:scaffolder-runner (the run SA).
+        volumes:
+          - name: anthropic-oidc-token
+            projected:
+              sources:
+                - serviceAccountToken:
+                    path: token
+                    expirationSeconds: 3600
+                    audience: https://api.anthropic.com
         # Pipeline params propagate into this inline taskSpec (no explicit
         # declaration/passing needed — declaring them would disable propagation).
         steps:
           - name: prepare
             image: $(params.toolchain-image)
             workingDir: $(workspaces.source.path)
+            volumeMounts:
+              - name: anthropic-oidc-token
+                mountPath: /var/run/anthropic
+                readOnly: true
             env:
               - { name: HOME, value: $(workspaces.source.path) }
               - { name: GH_ORG, value: $(params.github-org) }
@@ -116,12 +131,20 @@ spec:
               GH_VER=2.63.2
               curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_amd64.tar.gz" | tar -xz -C /tmp
               export PATH="/tmp/gh_${GH_VER}_linux_amd64/bin:${HOME}/.npm-global/bin:${PATH}"
+              # Keyless Claude via Workload Identity Federation: the SDK exchanges
+              # the projected SA token (aud api.anthropic.com, mounted below) for a
+              # short-lived Anthropic token — no static API key. Placeholder IDs
+              # (WIF not provisioned yet) fall back to --no-agent.
               AGENT_FLAG=""
-              if grep -q "PLACEHOLDER" "$(workspaces.anthropic.path)/api-key"; then
-                echo "Anthropic key placeholder -> --no-agent"
+              if grep -q "PLACEHOLDER" "$(workspaces.anthropic.path)/federation-rule-id"; then
+                echo "Anthropic WIF not configured -> --no-agent"
                 AGENT_FLAG="--no-agent"
               else
-                export ANTHROPIC_API_KEY="$(cat $(workspaces.anthropic.path)/api-key)"
+                export ANTHROPIC_IDENTITY_TOKEN_FILE=/var/run/anthropic/token
+                export ANTHROPIC_FEDERATION_RULE_ID="$(cat $(workspaces.anthropic.path)/federation-rule-id)"
+                export ANTHROPIC_SERVICE_ACCOUNT_ID="$(cat $(workspaces.anthropic.path)/service-account-id)"
+                export ANTHROPIC_ORGANIZATION_ID="$(cat $(workspaces.anthropic.path)/organization-id)"
+                export ANTHROPIC_WORKSPACE_ID="$(cat $(workspaces.anthropic.path)/workspace-id)"
                 npm config set prefix "${HOME}/.npm-global"
                 npm install -g @anthropic-ai/claude-code >/dev/null 2>&1
               fi

--- a/scaffolder/scaffolder.yaml
+++ b/scaffolder/scaffolder.yaml
@@ -62,8 +62,11 @@ spec:
     - secretKey: secret
       remoteRef: { key: 6e103eb4-23ad-409b-8f73-b49800d3826f }   # CAPTURLY_PAC_INCOMING_SECRET
 ---
-# Anthropic API key for the agent pass (mounted as env ANTHROPIC_API_KEY). Fill
-# the placeholder BWS value with a real, scaffolding-scoped key.
+# Anthropic Workload Identity Federation config for the agent pass. These are
+# NOT credentials — they're the WIF identifiers the Claude SDK needs; auth is the
+# projected SA token (see the anthropic-oidc-token volume in scaffold-app.yaml),
+# which the SDK exchanges for a short-lived Anthropic token. Replaces the old
+# static SCAFFOLDER_ANTHROPIC_API_KEY (now retired in BWS).
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -79,8 +82,14 @@ spec:
     creationPolicy: Owner
     template: { engineVersion: v2 }
   data:
-    - secretKey: api-key
-      remoteRef: { key: 00787b4f-b9c5-4b84-b8be-b499004e35ad }   # SCAFFOLDER_ANTHROPIC_API_KEY
+    - secretKey: federation-rule-id
+      remoteRef: { key: f6d79c8f-0e33-42a4-afa0-b49a004002f1 }   # SCAFFOLDER_ANTHROPIC_FEDERATION_RULE_ID
+    - secretKey: service-account-id
+      remoteRef: { key: 2f505149-9f58-4263-8a8a-b49a004024c2 }   # SCAFFOLDER_ANTHROPIC_SERVICE_ACCOUNT_ID
+    - secretKey: organization-id
+      remoteRef: { key: b07ea975-9fb4-4a38-ae36-b49a00404981 }   # SCAFFOLDER_ANTHROPIC_ORGANIZATION_ID
+    - secretKey: workspace-id
+      remoteRef: { key: 9d1aadfa-2edf-4d3b-9aa7-b49a00405a8f }   # SCAFFOLDER_ANTHROPIC_WORKSPACE_ID
 ---
 # Scaffolder GitHub App credentials (Administration:write + Contents:write + PRs).
 # The task mints a ~1h ORG installation token from these — no static git secret.


### PR DESCRIPTION
Replaces the static `SCAFFOLDER_ANTHROPIC_API_KEY` with keyless WIF for the scaffolder standards agent.

- `scaffolder-anthropic` ExternalSecret now syncs the four Anthropic WIF identifiers (federation-rule / service-account / organization / workspace IDs) from Build Platform instead of an API key.
- The `prepare` task projects a `serviceAccountToken` (aud `https://api.anthropic.com`) at `/var/run/anthropic/token` and exports `ANTHROPIC_IDENTITY_TOKEN_FILE` + the `*_ID` env vars; the Claude SDK exchanges the projected k3s SA token for a short-lived Anthropic token.
- Subject `system:serviceaccount:scaffolder:scaffolder-runner` matches the `scaffolder-runner-staging` federation rule; egress to api.anthropic.com already allowed.

Placeholder `federation-rule-id` still falls back to `--no-agent`. Companion: platform-infra `scripts/scaffold-app.sh` relaxes the agent gate to accept WIF (separate PR). Brand-kit resolve work stays on its own branch.