### PR TITLE
feat(scaffolder): provision scaffold-read-token for brand-kit resolve

### DIFF
--- a/scaffolder/scaffolder.yaml
+++ b/scaffolder/scaffolder.yaml
@@ -180,6 +180,12 @@ spec:
   data:
     - secretKey: access-token
       remoteRef: { key: 76802c92-daef-47bb-8af7-b49901016452 }   # SCAFFOLDER_BWS_ACCESS_TOKEN
+    # Bearer for coreyalan.com /api/scaffold/brand-kit/<slug> — the brand-kit
+    # resolve step reads it from the `bws` workspace file `scaffold-read-token`.
+    # MIRROR of the app-side SCAFFOLD_READ_TOKEN (Corey Alan Consulting project);
+    # same value on purpose. Rotate both together.
+    - secretKey: scaffold-read-token
+      remoteRef: { key: a8408b74-c87f-4518-a436-b49a011a5112 }   # SCAFFOLDER_READ_TOKEN (Build Platform)
 ---
 # Egress: DNS + k8s API (Tekton orchestration) + public HTTPS (GitHub, Anthropic,
 # npm for the claude/gh CLIs). Private ranges excluded (anti lateral-movement),


### PR DESCRIPTION
## What

Completes the scaffolder side of the brand-kit bridge token. The scaffold pipeline (`build-catalog/pipelines/scaffold-app.yaml`) already reads a bearer from the `bws` workspace file `scaffold-read-token` to call coreyalan.com's `/api/scaffold/brand-kit/<slug>`, but the key was never provisioned — so a picked brand kit would fail the resolve step (`no 'scaffold-read-token' key in the bws secret`).

Adds `scaffold-read-token` to the `scaffolder-bws` ExternalSecret. The `bws` workspace mounts the whole secret, so the key surfaces as a file automatically — no PipelineRun/binding change.

## Secret

Sourced from a **Build Platform** BWS mirror (`SCAFFOLDER_READ_TOKEN`, id `a8408b74-…`) of the app-side `SCAFFOLD_READ_TOKEN` (Corey Alan Consulting project, id `c5f63e57-…`). **Same value on purpose** — the read route does a timing-safe compare, so both sides must match. Verified value parity at creation. Rotate both copies together.

## Pairs with

- coreyalan.com#154 (the brand-kit bridge + read route)
- platform-infra#1150 (app-side `SCAFFOLD_READ_TOKEN` + Port creds)

Order doesn't matter between this and #1150 — both just provision secrets. The bridge works end-to-end once all three (this, #1150, #154) are live.
