### PR TITLE
fix(provisioning): distroless webhook + Renovate-track upstream image pins

### DIFF
--- a/provisioning/control-db.yaml
+++ b/provisioning/control-db.yaml
@@ -14,6 +14,9 @@ spec:
   # Pinned minor on the current "system" image line (legacy-compatible layout,
   # Debian trixie packages). The floating :16 tag had frozen on an ancient
   # bullseye digest whose 15 criticals were all fix:NONE in-distro.
+  # Renovate-tracked so a fixed rebuild lands automatically (today's criticals
+  # are upstream openssl/gnutls/perl/libxml2 with no patched image published yet).
+  # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
   imageName: ghcr.io/cloudnative-pg/postgresql:16.11-system-trixie
   storage:
     size: 2Gi

--- a/provisioning/webhook.yaml
+++ b/provisioning/webhook.yaml
@@ -178,10 +178,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: webhook
-          # Digest-pinned: the floating tag had frozen on a digest whose bundled npm
-          # vendored a critically-vulnerable tar (CVE-2026-59873).
-          image: node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32
-          command: ["node", "/app/server.mjs"]
+          # Distroless: no npm/shell, so the bundled-npm tar CVE (CVE-2026-59873)
+          # and the whole package-manager surface are gone. The webhook only uses
+          # node:http/node:crypto. Digest-pinned + Renovate-tracked so it can't
+          # freeze on a stale build (the old node:22-alpine pin did exactly that).
+          # renovate: datasource=docker depName=gcr.io/distroless/nodejs22-debian12
+          image: gcr.io/distroless/nodejs22-debian12@sha256:8a3e96fe3345b5d83ecec2066e7c498139a02a6d1214e4f6c39f9ce359f3f5bc
+          command: ["/nodejs/bin/node", "/app/server.mjs"]
           ports:
             - containerPort: 8080
           env:

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,23 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests"
+  ],
+  "argocd": {
+    "fileMatch": ["argocd/applications/cloudnativepg-operator\\.yaml$"]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track annotated image/imageName pins in raw manifests so digest/tag pins can't freeze on a vulnerable build",
+      "fileMatch": [
+        "provisioning/webhook\\.yaml$",
+        "provisioning/control-db\\.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+(?:image|imageName): [^\\s@:]+(?::(?<currentValue>[^\\s@]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
+      ],
+      "datasourceTemplate": "{{{datasource}}}",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}"
+    }
   ]
 }


### PR DESCRIPTION
Part of resolving the `provisioning-engine` service Trivy criticals. Investigation (validated with trivy) found the "63 criticals" is a namespace→service aggregate, and **none are in the provisioning-engine app image** — they belong to upstream infra images sharing the `provisioning` namespace:

| Image | Criticals | Fixable today? |
|---|---|---|
| provisioning-engine app | 0 | — (clean) |
| webhook `node:22-alpine` | 1 (`tar`, in bundled npm, **never invoked**) | this PR |
| CNPG operator `1.25.0` | 4 | no — 1.27/1.28 still carry them |
| CNPG Postgres `16.11-trixie` | ~17 | no — latest system-trixie unchanged; several no-fix upstream |
| Kratix `v0.125.0` | 3 | separate PR (v0.126.0 → 1) |

## This PR
- **Webhook → distroless/nodejs22.** `CVE-2026-59873` (node-tar DoS) is in the base image’s bundled npm; the webhook only imports `node:http`/`node:crypto` and never runs npm/tar. Distroless removes npm, tar, and the shell entirely. Digest-pinned.
- **Renovate tracking** (custom manager + argocd manager) for the webhook digest, the CNPG Postgres image, and the CNPG operator chart. The previous `node:22-alpine` pin froze on a *vulnerable* digest exactly because nothing tracked it — this makes upstream fixes land automatically instead of going stale, which is the right handling for the un-ownable CNPG/Postgres CVEs (visible + auto-fixed when patched images ship).

## Validation
- `trivy image` diff: node:22-alpine (tar critical, npm surface) vs distroless (npm/tar/shell gone).
- `renovate-config-validator`: passes; custom-manager regex verified to capture both the webhook digest and the Postgres tag.
- `kubectl apply --dry-run=client`: all manifests parse, CNPG `Cluster` CRD included.

## Follow-ups (tracked separately)
- Kratix `v0.125.0 → v0.126.0` re-vendor (3→1 criticals) — live control-plane manifest, needs its own reviewed PR.
- CNPG operator + Postgres criticals remain visible until upstream ships fixed images; Renovate will PR them automatically.