### PR TITLE
fix(build-catalog): move web-ci HOME off the source workspace

### DIFF
--- a/build-catalog/tasks/web-ci.yaml
+++ b/build-catalog/tasks/web-ci.yaml
@@ -33,8 +33,17 @@ spec:
         requests: { cpu: "4", memory: 4Gi }
         limits: { cpu: "8", memory: 8Gi }
       env:
+        # A neutral, writable home — NOT the source workspace. With HOME at the
+        # repo root, ESLint's eslintrc mode treats the repo's root .eslintrc.*
+        # as a personal (home-dir) config and SUPPRESSES it for any package
+        # that carries its own .eslintrc layer; that package then lints without
+        # the shared TypeScript parser and every file fails to parse.
         - name: HOME
-          value: $(workspaces.source.path)
+          value: /tmp/build-home
+        # Keep pnpm's content-addressable store on the same filesystem as the
+        # workspace node_modules so installs hardlink instead of copying.
+        - name: npm_config_store_dir
+          value: $(workspaces.source.path)/.pnpm-store
         # Turbo/CI hints; no secrets.
         - name: CI
           value: "true"
@@ -67,11 +76,12 @@ spec:
         #!/usr/bin/env bash
         set -euo pipefail
         # pnpm is baked into the image (non-root); no corepack enable needed.
-        # APPEND the Verdaccio registry — do NOT overwrite. HOME is the repo root,
-        # so `cp` would clobber the repo's committed .npmrc, which sets
-        # node-linker=hoisted. That setting is required: it hoists @types/node into
-        # the root node_modules where every package's tsc finds Node globals
-        # (Buffer/setTimeout). Overwriting it broke every package's build offline.
+        mkdir -p "$HOME"
+        # Registry goes in the USER-level .npmrc. pnpm merges it with the repo's
+        # committed .npmrc (project scope wins per-key), so node-linker=hoisted
+        # stays intact — required: it hoists @types/node into the root
+        # node_modules where every package's tsc finds Node globals
+        # (Buffer/setTimeout) — and the repo file is never mutated.
         cat /config/npm/.npmrc >> "$HOME/.npmrc"   # registry = Verdaccio, no auth
         pnpm install --frozen-lockfile
         # apps/web type-checks against the compiled dist/ of its workspace deps.


### PR DESCRIPTION
## Problem

The `capturly-nextjs-pr` PaC check has failed on every capturly PR since Aug 4. The `checks` step dies on `@capturly/extension#lint` with 53× `Parsing error: The keyword 'import' is reserved`.

Root cause: `web-ci.yaml` sets `HOME=$(workspaces.source.path)`, so the cloned repo's root `.eslintrc.js` sits **in $HOME**. ESLint's eslintrc mode treats a config in the home directory as a *personal config* and **suppresses it entirely** for any file that has a project-level config of its own (`ESLINT_PERSONAL_CONFIG_SUPPRESS`, visible in the step log). `apps/extension` gained a package-local `.eslintrc.js` layer on Aug 4 (AMO `no-unsanitized` rules) that relies on cascading to the root config for the TypeScript parser — with the root config suppressed, espree parses `.ts` files and every one fails. Packages *without* a local config keep working (for them the personal config is used, deprecated but functional), which is why only the extension broke. GitHub Actions runs the identical lint fine because `HOME=/home/runner` there.

## Fix

- `HOME=/tmp/build-home` (neutral, writable; created in the script) — the source workspace is no longer anyone's home directory.
- The Verdaccio registry append now targets the **user-level** `$HOME/.npmrc`; pnpm merges it with the repo's committed `.npmrc`, so `node-linker=hoisted` survives per-key project precedence and the repo file is never mutated.
- `npm_config_store_dir` pinned to the source workspace so the pnpm store stays on the same filesystem as `node_modules` (hardlinks, not copies — HOME is now on container scratch).

Validated with `kubectl create --dry-run=client`.

## Same pattern elsewhere (not changed here)

`build-signed-aab.yaml`, `build-unsigned-apk.yaml`, and `scaffold-app.yaml` also set `HOME=$(workspaces.source.path)`. They carry the same latent eslint hazard, but gradle/scaffold HOME semantics (`~/.gradle`, SDK caches) need their own verification — worth a follow-up.