### PR TITLE
feat(scaffold): forward native platform targets to scaffold-app.sh

### DIFF
--- a/build-catalog/pipelines/scaffold-app.yaml
+++ b/build-catalog/pipelines/scaffold-app.yaml
@@ -40,6 +40,9 @@ spec:
     - { name: secondary-color, type: string, default: "#0ea5e9" }
     - { name: logo-url,        type: string, default: "" }
     - { name: enable-email,    type: string, default: "false" }
+    # Native platform targets (comma-separated: desktop,mobile,extension). Empty
+    # = web-only; unlisted targets are stripped from the scaffold after clone.
+    - { name: targets,         type: string, default: "" }
     # Brand kit picked in the Port scaffold_app dropdown (= a coreyalan.com
     # showcase slug). When set, the pipeline fetches the kit and its values
     # OVERRIDE the branding params above — the app reproduces the approved demo.
@@ -200,7 +203,8 @@ spec:
               # rebrand + branding (app-repo PR) + onboard --yes (platform-infra PR)
               bash scripts/scaffold-app.sh \
                 --name "$(params.name)" --domain "$EFF_DOMAIN" --company "$(params.company)" \
-                --github-org "$GH_ORG" "${DESC_ARGS[@]}" $DB_FLAG "${BRAND_ARGS[@]}" $EMAIL_FLAG --ci $AGENT_FLAG
+                --github-org "$GH_ORG" "${DESC_ARGS[@]}" $DB_FLAG "${BRAND_ARGS[@]}" $EMAIL_FLAG \
+                --targets "$(params.targets)" --ci $AGENT_FLAG
 
               # dns: fresh main so the dns PR carries ONLY <app>-dns.tf
               git checkout main && git pull --ff-only


### PR DESCRIPTION
Declare a `targets` pipeline param (comma-separated `desktop`/`mobile`/`extension`, default empty = web-only) and pass it as `--targets` to `scaffold-app.sh`, so the Port `scaffold_app` platform selection reaches the scaffold strip step.

**Companion to platform-infra PR #1212** (which adds the `--targets` flag + strip, the Port `platform_targets` multi-select, and the Tekton `targets` param). Merge together so the Tekton param resolves against this declared pipeline param.

Verified: pipeline YAML parses; the new param mirrors the existing param declarations and the `--targets "$(params.targets)"` invocation mirrors the existing flag threading.