### PR TITLE
feat(capturly): point staging at the studio cover-art bucket

### DIFF
--- a/staging-apps/capturly-web/values.yaml
+++ b/staging-apps/capturly-web/values.yaml
@@ -81,6 +81,12 @@ staging-app:
       value: "true"
     - name: S3_TRANSFER_BUCKET
       value: capturly-transfer
+    # Studio cover art. Shares the prod bucket the same way GCP_TRANSFER_BUCKET
+    # does, and reuses the capturly-transfer-staging SA key already mounted
+    # below — no second long-lived credential. A bucket name is not a secret,
+    # so it rides here rather than through Bitwarden.
+    - name: GCP_STUDIO_ASSETS_BUCKET
+      value: capturly-studio-assets
     # Coreyalan integration — staging Capturly talks to staging Coreyalan
     # so contact + campaign data does not pollute production. API_KEY and
     # WEBHOOK_SECRET come from Bitwarden via the externalSecrets block below.


### PR DESCRIPTION
Points staging Capturly at the new studio cover-art bucket so org admins can upload studio branding there, matching prod.

Adds one non-secret env var. `GCP_STUDIO_ASSETS_BUCKET` rides in the plain `env:` list rather than Bitwarden for the same reason `S3_TRANSFER_BUCKET` does — a bucket name is not a secret.

## No new credential

Staging shares the prod bucket exactly the way `GCP_TRANSFER_BUCKET` already does, and reuses the `capturly-transfer-staging` service account key that is already mounted here. The Terraform in the companion PR binds that same identity to the new bucket, so there is nothing to generate, store, or rotate.

## Depends on

- Corey-Alan-Consulting/platform-infra#1239 — creates the bucket and the IAM binding.

Merge that one and let it apply first. Until the bucket exists this env var points at nothing, and the app falls back to generated cover art with the upload control reporting that storage is unconfigured — degraded, not broken.

## Note for whoever reads the surrounding config

The `STORAGE_PROVIDER=s3` / SeaweedFS block just above is currently dead: the web app never reads `STORAGE_PROVIDER` and talks to real GCS through `GCP_TRANSFER_SA_KEY`. Not changing that here, but it is worth knowing that this new var follows the GCS path, not the S3 one.

## Verification

YAML parses. Not deployed.