### PR TITLE
fix(staging): promote once per release and route worker images

### DIFF
--- a/.github/workflows/gitops-staging-update.yml
+++ b/.github/workflows/gitops-staging-update.yml
@@ -33,12 +33,31 @@ jobs:
           APP_NAME: ${{ github.event.client_payload.app_name }}
           DIGEST: ${{ github.event.client_payload.digest }}
           IMAGE: ${{ github.event.client_payload.image }}
+          TAG: ${{ github.event.client_payload.tag }}
+          MIGRATE_DIGEST: ${{ github.event.client_payload.migrate_digest }}
         run: |
           if [ -z "$APP_NAME" ] || [ -z "$DIGEST" ] || [ -z "$IMAGE" ]; then
             echo "ERROR: Missing required fields in client_payload"
             echo "  app_name=$APP_NAME"
             echo "  digest=$DIGEST"
             echo "  image=$IMAGE"
+            exit 1
+          fi
+
+          # Regex-validate every dispatch field before use (ci-cd standard;
+          # staging-track.yml is the reference). digest/migrate_digest must be
+          # exact sha256 refs; tag is optional but must stay in the docker tag
+          # charset when present.
+          if ! printf '%s' "$DIGEST" | grep -qE '^sha256:[0-9a-f]{64}$'; then
+            echo "ERROR: Invalid digest: $DIGEST"
+            exit 1
+          fi
+          if [ -n "$MIGRATE_DIGEST" ] && ! printf '%s' "$MIGRATE_DIGEST" | grep -qE '^sha256:[0-9a-f]{64}$'; then
+            echo "ERROR: Invalid migrate_digest: $MIGRATE_DIGEST"
+            exit 1
+          fi
+          if [ -n "$TAG" ] && ! printf '%s' "$TAG" | grep -qE '^[A-Za-z0-9@][A-Za-z0-9@._-]{0,127}$'; then
+            echo "ERROR: Invalid tag: $TAG"
             exit 1
           fi
 
@@ -95,16 +114,29 @@ jobs:
           git reset --hard origin/main
 
       - name: Update image digest
+        id: update
         env:
           APP_NAME: ${{ github.event.client_payload.app_name }}
           DIGEST: ${{ github.event.client_payload.digest }}
           TAG: ${{ github.event.client_payload.tag }}
           MIGRATE_DIGEST: ${{ github.event.client_payload.migrate_digest }}
+          IMAGE_SHORT: ${{ steps.validate.outputs.image_short }}
         run: |
           VALUES_FILE="staging-apps/${APP_NAME}/values.yaml"
 
-          # Values are nested under the staging-app subchart key
-          yq eval ".\"staging-app\".image.digest = \"${DIGEST}\"" -i "${VALUES_FILE}"
+          # Values are nested under the staging-app subchart key. Worker
+          # images live under a different values path and have no migrate
+          # sibling — mirror of the values-path routing in platform-infra's
+          # gitops-update.yml. Without this, a worker dispatch would clobber
+          # the web image digest.
+          DIGEST_PATH='."staging-app".image.digest'
+          IS_WORKER=false
+          if [[ "$IMAGE_SHORT" == *-worker ]]; then
+            DIGEST_PATH='."staging-app".worker.image.digest'
+            IS_WORKER=true
+          fi
+
+          yq eval "${DIGEST_PATH} = \"${DIGEST}\"" -i "${VALUES_FILE}"
 
           # Update migration digest whenever the deploy workflow publishes a
           # new migrate image and the chart declares a migration block. Don't
@@ -115,7 +147,8 @@ jobs:
           # that stale value to prod, and schema changes silently never run
           # (same failure mode that broke capturly-web v1.5/v1.6, mirror of
           # the platform-infra gitops-update.yml fix in PR #589).
-          if [ -n "$MIGRATE_DIGEST" ]; then
+          # Worker dispatches never carry a migrate sibling.
+          if [ "$IS_WORKER" = "false" ] && [ -n "$MIGRATE_DIGEST" ]; then
             HAS_MIGRATION=$(yq eval '.["staging-app"].migration // "null"' "${VALUES_FILE}")
             if [ "$HAS_MIGRATION" != "null" ]; then
               yq eval ".\"staging-app\".migration.digest = \"${MIGRATE_DIGEST}\"" -i "${VALUES_FILE}"
@@ -146,7 +179,20 @@ jobs:
             NORMALIZED_TAG="${TAG#v}"
           fi
 
+          # Only dispatches carrying a release tag are eligible for prod
+          # promotion. One AR push emits a pubsub event per tag, so a single
+          # release fans out into several staging-image-push dispatches: the
+          # git-SHA tag event (no semver) and the vX.Y.Z event (semver). Both
+          # deploy to staging, but only the release-tag PR gets the `promote`
+          # label that staging-promote.yml requires — otherwise every release
+          # promoted twice (duplicate promote_to_production Port runs, moved
+          # prod-PR heads, duplicate announce builds dying on ALREADY_SENT).
+          # Tagless/manual builds (workflow_dispatch → sha tag only) deploy to
+          # staging and deliberately never auto-promote: prod deploys correlate
+          # on the v<semver> identity (framework git-and-releases standard).
+          PROMOTE=false
           if [[ "$NORMALIZED_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            PROMOTE=true
             CHART_FILE="staging-apps/${APP_NAME}/Chart.yaml"
             if [ -f "$CHART_FILE" ]; then
               yq eval ".appVersion = \"${NORMALIZED_TAG}\"" -i "${CHART_FILE}"
@@ -155,6 +201,7 @@ jobs:
           else
             echo "Skipping appVersion update: tag '${TAG}' did not normalize to bare semver"
           fi
+          echo "promote=${PROMOTE}" >> "$GITHUB_OUTPUT"
 
           echo "Updated ${VALUES_FILE}:"
           yq eval '.["staging-app"].image' "${VALUES_FILE}"
@@ -184,9 +231,13 @@ jobs:
             - **Digest:** `${{ github.event.client_payload.digest }}`
             - **Tag:** `${{ github.event.client_payload.tag || 'N/A' }}`
 
-            Once merged and ArgoCD confirms healthy, this will auto-promote
-            to production via `staging-promote.yml`.
-          labels: staging,auto-merge
+            ${{ steps.update.outputs.promote == 'true'
+              && 'Release-tagged: on merge, `staging-promote.yml` dispatches the prod gitops update (gated by `staging/ok` on the prod PR).'
+              || 'No release tag: deploys to staging only; prod promotion requires a `v<semver>`-tagged dispatch.' }}
+          # `promote` marks the one release-tag PR per release that
+          # staging-promote.yml is allowed to act on — see the comment in the
+          # update step above.
+          labels: staging,auto-merge${{ steps.update.outputs.promote == 'true' && ',promote' || '' }}
           delete-branch: true
 
       - name: Merge PR

--- a/.github/workflows/staging-promote.yml
+++ b/.github/workflows/staging-promote.yml
@@ -13,9 +13,15 @@ on:
 jobs:
   promote:
     name: Dispatch prod gitops update
+    # `promote` is set by gitops-staging-update.yml only on the PR whose
+    # dispatch carried a v<semver> release tag — one per release. Without it,
+    # the git-SHA tag pubsub event for the same push produced a second
+    # staging PR and a duplicate prod promotion (paired promote_to_production
+    # Port runs, moved prod-PR heads, announce builds failing ALREADY_SENT).
     if: >
       github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'staging')
+      contains(github.event.pull_request.labels.*.name, 'staging') &&
+      contains(github.event.pull_request.labels.*.name, 'promote')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,14 +69,25 @@ jobs:
             exit 1
           fi
 
-          # The staging chart currently only exposes the web image under
-          # .staging-app.image.*. When worker staging support is added,
-          # this step will need to select the correct values path based
-          # on IMAGE_SHORT (e.g. worker → .worker.image.*).
-          DIGEST=$(yq eval '.["staging-app"].image.digest' "${VALUES_FILE}")
-          IMAGE=$(yq eval '.["staging-app"].image.repository' "${VALUES_FILE}")
+          # Select the values path by IMAGE_SHORT — worker images live under
+          # .staging-app.worker.image.* and have no migrate sibling (mirror of
+          # the routing in gitops-staging-update.yml and platform-infra's
+          # gitops-update.yml).
+          if [[ "$IMAGE_SHORT" == *-worker ]]; then
+            DIGEST=$(yq eval '.["staging-app"].worker.image.digest' "${VALUES_FILE}")
+            IMAGE=$(yq eval '.["staging-app"].worker.image.repository' "${VALUES_FILE}")
+            MIGRATE_DIGEST=""
+          else
+            DIGEST=$(yq eval '.["staging-app"].image.digest' "${VALUES_FILE}")
+            IMAGE=$(yq eval '.["staging-app"].image.repository' "${VALUES_FILE}")
+            MIGRATE_DIGEST=$(yq eval '.["staging-app"].migration.digest // ""' "${VALUES_FILE}")
+          fi
           TAG=$(yq eval '.appVersion' "${CHART_FILE}" 2>/dev/null || echo "")
-          MIGRATE_DIGEST=$(yq eval '.["staging-app"].migration.digest // ""' "${VALUES_FILE}")
+
+          if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
+            echo "ERROR: No digest found at the ${IMAGE_SHORT} values path in ${VALUES_FILE}"
+            exit 1
+          fi
 
           echo "app_name=${APP_NAME}" >> "$GITHUB_OUTPUT"
           echo "image_short=${IMAGE_SHORT}" >> "$GITHUB_OUTPUT"

--- a/staging-apps/dispatchr-social/values.yaml
+++ b/staging-apps/dispatchr-social/values.yaml
@@ -211,7 +211,7 @@ staging-app:
     replicas: 1
     image:
       repository: us-central1-docker.pkg.dev/dispatchr-social/dispatchr-social/dispatchr-worker
-      digest: "sha256:5df098d1062bdd934430854b500ceb52713158e1ea8eaa9bf49f9e36099aba27" # v0.1.54; update via CI
+      digest: "sha256:23e53b5f9aab34c1715e181718a87b2034c44168e62dbb78066c0c7b24040195" # v0.4.3; updated by CI/CD (seeded to prod parity 2026-08-17)
     command: ["tsx", "packages/core/src/jobs/worker.ts"]
     healthPort: 8080
     healthPath: /healthz


### PR DESCRIPTION
## What

- **One promotion per release.** `gitops-staging-update.yml` now labels a staging PR `promote` only when the dispatch carried a `v<semver>` release tag, and `staging-promote.yml` requires that label. One AR push emits a Pub/Sub event per tag, so the git-SHA event and the `vX.Y.Z` event each landed a staging PR and each merge dispatched a prod promotion — paired `promote_to_production` Port runs, moved prod-PR heads (the stranded-gates class platform-infra#1246 re-gates), and duplicate announce builds dying on `ALREADY_SENT` (dispatchr ×2, capturly ×1 on 2026-08-17). Sha-tag/manual builds still deploy to staging; they just never auto-promote — prod correlates on the `v<semver>` identity.
- **Worker image routing.** `*-worker` dispatches now write `.staging-app.worker.image.digest` (update side) and promote from the same path — mirroring platform-infra's `gitops-update.yml`. Previously a worker dispatch would have clobbered the web digest, which is why workers were never in `STAGING_APP_MAP`.
- **Seed dispatchr worker parity.** The staging worker digest was frozen at a v0.1.54-era image ("update via CI" with no CI path); seeded to the current prod v0.4.3 digest.
- **Dispatch-field validation.** `digest`/`migrate_digest`/`tag` are now regex-validated like the other fields (ci-cd standard).

## Follow-up (ordering matters)

Only **after this merges**: add `dispatchr-social/dispatchr-worker` to `STAGING_APP_MAP` in platform-infra `helm-charts/gitops-trigger` so worker releases go through staging first instead of dispatching straight to prod. Until then worker behavior is unchanged.

## Verification

- actionlint: clean on both workflows (one pre-existing SC2129 style note).
- `helm lint staging-apps/dispatchr-social`: pass.
- Worker yq path exercised against the real values file.
- Ordering-independence: v-tag event first → one PR (values+Chart) with `promote`; sha event second → no diff → no PR. Sha first → values PR without `promote`; v event second → Chart PR with `promote`. Either way exactly one promotion.