### PR TITLE
feat(staging): register dispatchr-social smoke tests

### DIFF
--- a/.github/workflows/staging-track.yml
+++ b/.github/workflows/staging-track.yml
@@ -192,6 +192,7 @@ jobs:
           declare -A SMOKE_REPOS=(
             ["coreyalan-com"]="Corey-Alan-Consulting/coreyalan.com"
             ["blue-skysolutions-com"]="Corey-Alan-Consulting/blue-skysolutions.com"
+            ["dispatchr-social"]="Corey-Alan-Consulting/dispatchr.social"
           )
           # Per-app staging URL forwarded to the smoke workflow. Must have an
           # entry for every SMOKE_REPOS key (was hardcoded to coreyalan's host,
@@ -199,6 +200,7 @@ jobs:
           declare -A SMOKE_URLS=(
             ["coreyalan-com"]="https://staging.coreyalan.com"
             ["blue-skysolutions-com"]="https://staging.blue-skysolutions.com"
+            ["dispatchr-social"]="https://staging.dispatchr.social"
           )
 
           REPO="${SMOKE_REPOS[$APP_NAME]:-}"


### PR DESCRIPTION
dispatchr.social's smoke suite + `staging-smoke.yml` merged in Corey-Alan-Consulting/dispatchr.social#134, so it's safe to register — `staging-track` will now dispatch `staging-smoke-test` and gate `staging/ok` on the result instead of ArgoCD health alone. URL per the SMOKE_URLS pattern: `https://staging.dispatchr.social`.

jlshaw-link and capturly-web get the same registration once their suites merge (branches are staged locally, blocked on an `NPM_TOKEN`-authenticated `pnpm add -D @playwright/test`).