### PR TITLE
feat(staging): register jlshaw-link smoke tests

### DIFF
--- a/.github/workflows/staging-track.yml
+++ b/.github/workflows/staging-track.yml
@@ -193,6 +193,7 @@ jobs:
             ["coreyalan-com"]="Corey-Alan-Consulting/coreyalan.com"
             ["blue-skysolutions-com"]="Corey-Alan-Consulting/blue-skysolutions.com"
             ["dispatchr-social"]="Corey-Alan-Consulting/dispatchr.social"
+            ["jlshaw-link"]="Corey-Alan-Consulting/jlshaw.link"
           )
           # Per-app staging URL forwarded to the smoke workflow. Must have an
           # entry for every SMOKE_REPOS key (was hardcoded to coreyalan's host,
@@ -201,6 +202,7 @@ jobs:
             ["coreyalan-com"]="https://staging.coreyalan.com"
             ["blue-skysolutions-com"]="https://staging.blue-skysolutions.com"
             ["dispatchr-social"]="https://staging.dispatchr.social"
+            ["jlshaw-link"]="https://staging.jlshawconsulting.com"
           )
 
           REPO="${SMOKE_REPOS[$APP_NAME]:-}"


### PR DESCRIPTION
jlshaw.link's smoke suite + `staging-smoke.yml` merged (Corey-Alan-Consulting/jlshaw.link#116) and a workflow_dispatch dry-run passed against `staging.jlshawconsulting.com` — registering it so `staging-track` gates `staging/ok` on the smoke run. Same pattern as dispatchr's #859. capturly follows once its suite merges (PR #408, typecheck fix pushed).