### PR TITLE
feat(staging): register capturly-web smoke tests

### DIFF
--- a/.github/workflows/staging-track.yml
+++ b/.github/workflows/staging-track.yml
@@ -194,6 +194,7 @@ jobs:
             ["blue-skysolutions-com"]="Corey-Alan-Consulting/blue-skysolutions.com"
             ["dispatchr-social"]="Corey-Alan-Consulting/dispatchr.social"
             ["jlshaw-link"]="Corey-Alan-Consulting/jlshaw.link"
+            ["capturly-web"]="Corey-Alan-Consulting/capturly.app"
           )
           # Per-app staging URL forwarded to the smoke workflow. Must have an
           # entry for every SMOKE_REPOS key (was hardcoded to coreyalan's host,
@@ -203,6 +204,7 @@ jobs:
             ["blue-skysolutions-com"]="https://staging.blue-skysolutions.com"
             ["dispatchr-social"]="https://staging.dispatchr.social"
             ["jlshaw-link"]="https://staging.jlshawconsulting.com"
+            ["capturly-web"]="https://staging.capturly.app"
           )
 
           REPO="${SMOKE_REPOS[$APP_NAME]:-}"


### PR DESCRIPTION
capturly.app's smoke suite + `staging-smoke.yml` merged (Corey-Alan-Consulting/capturly.app#408) and a workflow_dispatch dry-run passed against `staging.capturly.app`. Same pattern as #859 (dispatchr) and #860 (jlshaw). With this, **every staging-mapped app** (coreyalan, blue-sky, dispatchr, jlshaw, capturly) gates `staging/ok` on a real smoke run.