### PR TITLE
chore(port): align the ocean-argocd image with prod and Renovate-track it

### DIFF
--- a/argocd/applications/port-ocean-argocd.yaml
+++ b/argocd/applications/port-ocean-argocd.yaml
@@ -43,7 +43,8 @@ spec:
         integration:
           type: argocd
           identifier: argocd-homelab
-          version: "0.1.96" # pin (Kyverno disallow-latest-tag)
+          # renovate: datasource=docker depName=ghcr.io/port-labs/port-ocean-argocd
+          version: "0.4.98" # pin (Kyverno disallow-latest-tag)
           eventListener:
             type: POLLING
           config:

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,9 @@
     "helpers:pinGitHubActionDigests"
   ],
   "argocd": {
-    "fileMatch": ["argocd/applications/cloudnativepg-operator\\.yaml$"]
+    "fileMatch": [
+      "argocd/applications/cloudnativepg-operator\\.yaml$"
+    ]
   },
   "customManagers": [
     {
@@ -23,7 +25,7 @@
     },
     {
       "customType": "regex",
-      "description": "Track the vendored Kratix distribution image. Upstream ships one image that serves as both the controller-manager and the pipeline adapter, referenced twice in install.yaml (Deployment image + PIPELINE_ADAPTER_IMG); both carry the same digest and must move together, so one matchString covers both. Not comment-annotated because install.yaml is vendored wholesale and in-file comments do not survive a re-vendor. Digests are resolved from canonical Docker Hub, not from the syntasso-community.docker.reo.dev vanity host the manifest pulls through: that host is a third-party 307 redirector to registry-1.docker.io, and letting it decide which digest we trust would put it in a position to hand Renovate an attacker-chosen image. Resolving upstream keeps it a transport only — the digest pin means a substituted image fails the content check rather than running. This keeps the image (the part that carries CVEs) current; the CRDs/RBAC around it still need a periodic re-vendor per the procedure in argocd/applications/kratix.yaml.",
+      "description": "Track the vendored Kratix distribution image. Upstream ships one image that serves as both the controller-manager and the pipeline adapter, referenced twice in install.yaml (Deployment image + PIPELINE_ADAPTER_IMG); both carry the same digest and must move together, so one matchString covers both. Not comment-annotated because install.yaml is vendored wholesale and in-file comments do not survive a re-vendor. Digests are resolved from canonical Docker Hub, not from the syntasso-community.docker.reo.dev vanity host the manifest pulls through: that host is a third-party 307 redirector to registry-1.docker.io, and letting it decide which digest we trust would put it in a position to hand Renovate an attacker-chosen image. Resolving upstream keeps it a transport only \u2014 the digest pin means a substituted image fails the content check rather than running. This keeps the image (the part that carries CVEs) current; the CRDs/RBAC around it still need a periodic re-vendor per the procedure in argocd/applications/kratix.yaml.",
       "fileMatch": [
         "kratix/install\\.yaml$"
       ],
@@ -35,6 +37,16 @@
       "datasourceTemplate": "docker",
       "currentValueTemplate": "latest",
       "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Port Ocean integration image pin in the ArgoCD Application helm values, annotated with a `renovate:` datasource/depName comment above the version line (mirrors platform-infra so staging and prod ocean images move together).",
+      "fileMatch": [
+        "^argocd/applications/port-ocean-.*\\.yaml$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\n\\s*version:\\s*\"(?<currentValue>[^\"]+)\""
+      ]
     }
   ]
 }


### PR DESCRIPTION
Companion to Corey-Alan-Consulting/platform-infra#1268. The staging ArgoCD Ocean pod ran 0.1.96 while the TF-registered version (and prod's now-bumped pin) is 0.4.98. Bumps the pin and adds the same `# renovate:` annotation + regex customManager platform-infra gained, so both clusters' ocean images track the docker datasource together. Chart revisions (ocean 0.22.0, k8s-exporter 0.3.28 + image 0.7.5) already match prod — this was the only drifted version.