### PR TITLE
feat(staging): flip the showcase DB, migration, and env secrets on

### DIFF
--- a/staging-apps/showcase/values.yaml
+++ b/staging-apps/showcase/values.yaml
@@ -10,19 +10,17 @@ staging-app:
     projectID: "0e531424-811e-4368-8ddf-b4af004207d9" # Staging - Showcase
     organizationID: "4650c1c8-8d22-4073-8a7d-b3cf011d5ff2"
     credentialsSecret: bitwarden-staging-showcase-credentials
-  # The skeleton app is DB-free (health route only, tenant guard proven in
-  # tests). Flip these together when the first DB-touching route ships:
-  # create the staging DB user/name/password in the Staging - Showcase BWS
-  # project and fill the UUIDs.
+  # Flipped with the v1 API (showcase repo #1) — the service now has a schema
+  # and DB-touching routes. Secrets live in the Staging - Showcase BWS project.
   database:
-    enabled: false
+    enabled: true
     superuser:
       create: false # shares the postgres-superuser-staging secret
-    userKey: ""
-    passwordKey: ""
-    nameKey: ""
+    userKey: "d056ef12-ae17-4230-8bc2-b4b0002a70d6" # SHOWCASE_STAGING_DB_USER
+    passwordKey: "fa31c47f-a6db-4f1a-92a8-b4b0002a712e" # SHOWCASE_STAGING_DB_PASSWORD
+    nameKey: "9e063ed3-2083-41a7-a0de-b4b0002a7101" # SHOWCASE_STAGING_DB_NAME
   migration:
-    enabled: false # follows database.enabled
+    enabled: true
     repository: us-central1-docker.pkg.dev/coreyalan-showcase/showcase/showcase-web-migrate
     digest: "sha256:6bba3e84e0f8a8e1adb8d1eb9a0bf12e5abbd193e87816d1d65bf61b2ce872ad" # Updated by CI/CD
   image:
@@ -56,14 +54,18 @@ staging-app:
       value: https://staging.showcase.coreyalan.com
     - name: NEXT_PUBLIC_APP_URL
       value: https://staging.showcase.coreyalan.com
-  # No env secrets yet — the skeleton reads none. When the first secret-reading
-  # code ships, enable this with the STAGING BWS UUIDs (Staging - Showcase
-  # already holds SHOWCASE_COOKIE_SECRET) and add the envFrom secretRef back.
+  envFrom:
+    - secretRef:
+        name: showcase-staging-secrets
   externalSecrets:
-    enabled: false
+    enabled: true
     secretName: showcase-staging-secrets
     refreshInterval: 1h
-    secrets: []
+    secrets:
+      - name: DATABASE_URL
+        key: 27d72ae8-a3a2-43b8-afdf-b4b0002a7160
+      - name: SHOWCASE_COOKIE_SECRET
+        key: e788d8eb-b687-4a06-95e2-b4af00420877
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
The v1 partner API (Corey-Alan-Consulting/showcase#1) ended the DB-free skeleton phase, so the three deferred blocks flip together, exactly as the values file said they would:

- **database.enabled**: db-init creates `showcase_staging` (user + db) on the shared staging postgres; superuser secret shared as usual.
- **migration.enabled**: `prisma migrate deploy` from the app secret's `DATABASE_URL` — applies both migrations (init + v1-api foundations). Migrate digest is already CI-written.
- **externalSecrets + envFrom**: `DATABASE_URL` and `SHOWCASE_COOKIE_SECRET` from the **Staging - Showcase** BWS project (UUIDs in-line; the machine account already has read on it — proven by the CSS validating).

Renders clean; the env section now mirrors the sibling pattern (dispatchr).