### PR TITLE
fix(coredns): split-horizon staging.showcase.coreyalan.com

### DIFF
--- a/coredns/configmap.yaml
+++ b/coredns/configmap.yaml
@@ -59,6 +59,7 @@ data:
     10.43.5.100 slskd.authoritah.tv
     10.43.5.100 s3.authoritah.com
     10.43.5.100 staging.coreyalan.com
+    10.43.5.100 staging.showcase.coreyalan.com
     10.43.5.100 staging.jlshawconsulting.com
     10.43.5.100 staging.dispatchr.social
     10.43.5.100 staging.capturly.app


### PR DESCRIPTION
The showcase staging certificate was stuck 23h in pending HTTP-01 with `failed to perform self check … context deadline exceeded` — cert-manager's in-cluster self-check resolved the public IP and hairpinned. This hosts block exists precisely for that failure (its own comment says so); `staging.showcase.coreyalan.com` just was never added when the host was created. One line, matching the five sibling staging hosts.

This is also what held `staging-showcase` at Progressing and failed `staging/ok` on the v0.1.0 prod promotion — cert completes → app Healthy → promotion re-fires.