### PR TITLE
fix(staging-update): promote directly when the release PR loses the digest race

### DIFF
--- a/.github/workflows/gitops-staging-update.yml
+++ b/.github/workflows/gitops-staging-update.yml
@@ -240,6 +240,58 @@ jobs:
           labels: staging,auto-merge${{ steps.update.outputs.promote == 'true' && ',promote' || '' }}
           delete-branch: true
 
+      # One AR push emits an event per tag, and both the git-SHA and the
+      # v<semver> dispatch write IDENTICAL digests. If the SHA PR merges
+      # first, this (release) run's branch is not ahead of main, create-pr
+      # makes no PR, and the `promote` label — and with it the entire prod
+      # promotion — used to evaporate (showcase v0.1.0/v0.1.1 both needed
+      # manual dispatch recovery). When that exact race happens, promote
+      # directly: same payload staging-promote.yml would have sent on merge.
+      - name: Promote directly when the release PR lost the digest race
+        if: steps.update.outputs.promote == 'true' && !steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_NAME: ${{ github.event.client_payload.app_name }}
+          IMAGE_SHORT: ${{ steps.validate.outputs.image_short }}
+        run: |
+          set -euo pipefail
+          VALUES_FILE="staging-apps/${APP_NAME}/values.yaml"
+          CHART_FILE="staging-apps/${APP_NAME}/Chart.yaml"
+          if [[ "$IMAGE_SHORT" == *-worker ]]; then
+            DIGEST=$(yq eval '.["staging-app"].worker.image.digest' "${VALUES_FILE}")
+            IMAGE=$(yq eval '.["staging-app"].worker.image.repository' "${VALUES_FILE}")
+            MIGRATE_DIGEST=""
+          else
+            DIGEST=$(yq eval '.["staging-app"].image.digest' "${VALUES_FILE}")
+            IMAGE=$(yq eval '.["staging-app"].image.repository' "${VALUES_FILE}")
+            MIGRATE_DIGEST=$(yq eval '.["staging-app"].migration.digest // ""' "${VALUES_FILE}")
+          fi
+          TAG=$(yq eval '.appVersion' "${CHART_FILE}" 2>/dev/null || echo "")
+          DISPATCH_ID="dispatch-race-$(date -u +%Y%m%dT%H%M%SZ)-$(openssl rand -hex 4)"
+          PAYLOAD=$(jq -n \
+            --arg app_name "$APP_NAME" \
+            --arg image_short "$IMAGE_SHORT" \
+            --arg image "$IMAGE" \
+            --arg digest "$DIGEST" \
+            --arg tag "$TAG" \
+            --arg migrate_digest "$MIGRATE_DIGEST" \
+            --arg argo_app "staging-${APP_NAME}" \
+            --arg dispatch_id "$DISPATCH_ID" \
+            '{event_type: "image-push", client_payload: {app_name: $app_name, image_short: $image_short, image: $image, digest: $digest, tag: $tag, migrate_digest: $migrate_digest, argo_app: $argo_app, dispatch_id: $dispatch_id}}')
+          HTTP_STATUS=$(curl -sS -o /tmp/dispatch.json -w "%{http_code}" -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/Corey-Alan-Consulting/platform-infra/dispatches" \
+            -d "$PAYLOAD")
+          if [ "$HTTP_STATUS" = "204" ]; then
+            echo "Race-recovery promotion dispatched (${DISPATCH_ID})"
+          else
+            echo "ERROR: promotion dispatch failed with status ${HTTP_STATUS}"
+            cat /tmp/dispatch.json || true
+            exit 1
+          fi
+
       - name: Merge PR
         if: steps.create-pr.outputs.pull-request-number
         env:


### PR DESCRIPTION
Closes the promotion-loss race hit by both showcase releases (decision #12's pipeline-hygiene item):

One AR push → one pubsub event per tag → the git-SHA and `v<semver>` dispatches race to merge **identical** digest changes. When the SHA PR wins, the release run's `create-pr` reports *branch not ahead*, no PR exists, and the `promote` label has nothing to land on — the prod promotion silently evaporates (recovered manually twice via hand-built `repository_dispatch`).

The fix triggers **only** in that exact condition (`promote == true` && no PR created): the run dispatches the identical `image-push` payload `staging-promote.yml` would have sent on merge, values read from the same files with the same worker/web selection logic, correlation id prefixed `dispatch-race-`. Every other path is untouched, including the duplicate-promotion guard this label system exists for — the direct dispatch replaces the merge-triggered one, never duplicates it (there is no PR whose merge could double-fire).