### PR TITLE
feat(provisioning): showcase island wiring — CRD demoHost + keyless identity

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -29,6 +29,14 @@ spec:
         app.kubernetes.io/part-of: provisioning
     spec:
       serviceAccountName: provisioning-engine
+      volumes:
+        - name: gcp-sts
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: //iam.googleapis.com/projects/861533890029/locations/global/workloadIdentityPools/homelab-staging/providers/k3s-oidc
+                  expirationSeconds: 3600
+                  path: token
       imagePullSecrets:
         - name: gcr-pull-secret-provisioning-engine
       securityContext:
@@ -51,6 +59,10 @@ spec:
           image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:3d20e8cbd33caa579718db705863cfb96795541b3427abb5b65abed137787d6a
           ports:
             - containerPort: 9080
+          volumeMounts:
+            - name: gcp-sts
+              mountPath: /var/run/secrets/gcp-sts
+              readOnly: true
           env:
             - name: DATABASE_URL
               valueFrom:
@@ -59,6 +71,18 @@ spec:
                   key: uri
             - name: RESTATE_ADMIN
               value: http://restate.restate.svc.cluster.local:9070
+            # Showcase island (projection writer): keyless GCP identity via the
+            # homelab-staging WIF pool. The projected token's audience must
+            # match the pool provider; the SA's only IAM is tokenCreator for
+            # this pod's KSA (platform-infra showcase-jobs.tf).
+            - name: GCP_WIF_TOKEN_FILE
+              value: /var/run/secrets/gcp-sts/token
+            - name: GCP_WIF_AUDIENCE
+              value: //iam.googleapis.com/projects/861533890029/locations/global/workloadIdentityPools/homelab-staging/providers/k3s-oidc
+            - name: SHOWCASE_WRITER_SA
+              value: showcase-projection-writer@coreyalan-showcase.iam.gserviceaccount.com
+            - name: SHOWCASE_URL
+              value: https://showcase.coreyalan.com
             # Error tracking (Port operational_readiness Gold signal). DSN is a
             # public client key; inert until an engine image with the sentry
             # init ships (provisioning-engine#10).

--- a/provisioning/tenant-crd.yaml
+++ b/provisioning/tenant-crd.yaml
@@ -83,6 +83,10 @@ spec:
                 stagingBaseUrl:
                   type: string
                   pattern: '^https://'
+                demoHost:
+                  type: string
+                  description: Tenant demo-host domain (ADR-0021 contract point 8). Presence enables the showcase island, which projects the tenant into the showcase Tier-3 service.
+                  pattern: '^[a-z0-9.-]+$'
                 blueprint:
                   type: string
                   description: Versioned managed-hosting blueprint stamped onto the tenant.


### PR DESCRIPTION
Companion to provisioning-engine#12 (the showcase island) and platform-infra's `showcase-projection-writer` identity:

- **CRD**: `spec.demoHost` (pattern-validated hostname) — presence is the island's enable signal, per tenant (contract point 8: one demo-host domain per tenant).
- **Engine deployment**: projected ServiceAccount token (audience = the homelab-staging WIF provider, 1h expiry) mounted at `/var/run/secrets/gcp-sts/token`, plus `GCP_WIF_*`, `SHOWCASE_WRITER_SA`, `SHOWCASE_URL` env. The island exchanges that token at STS and mints audience-pinned ID tokens as the writer SA — whose only IAM anywhere is tokenCreator for this pod's KSA.

Inert until an engine image with #12 ships (the env is read lazily at first showcase reconcile).