### PR TITLE
feat(provisioning): island gating fields + tenant-zero CR

### DIFF
--- a/kratix/promises/managed-hosting/promise.yaml
+++ b/kratix/promises/managed-hosting/promise.yaml
@@ -94,6 +94,27 @@ spec:
                     stagingBaseUrl:
                       type: string
                       pattern: '^https://'
+                    demoHost:
+                      type: string
+                      description: Tenant demo-host domain (ADR-0021 contract point 8). Presence enables the showcase island, which projects the tenant into the showcase Tier-3 service.
+                      pattern: '^[a-z0-9.-]+$'
+                    islands:
+                      type: array
+                      description: Explicit island allowlist, ANDed with each island's own inference (spine always runs). Omit for normal CRs; set on island-managed tenants (e.g. tenant zero) whose other surfaces live outside the reconcile loop.
+                      items:
+                        type: string
+                    showcaseCredentialId:
+                      type: string
+                      description: Credential id the tenant app backfills after minting its own secret (decision 1c); projected to showcase with showcaseCredentialHash.
+                    showcaseCredentialHash:
+                      type: string
+                      description: sha256 hex of the tenant-minted API key. Plaintext never exists in the control plane.
+                      pattern: '^[a-f0-9]{64}$'
+                    showcaseExtraScopes:
+                      type: array
+                      description: Scope opt-ins beyond the blueprint defaults; the engine filters to its allowlist (webhooks:read, webhooks:write, privacy:erase).
+                      items:
+                        type: string
                     blueprint:
                       type: string
                       description: Versioned managed-hosting blueprint stamped onto the tenant.

--- a/provisioning/tenant-crd.yaml
+++ b/provisioning/tenant-crd.yaml
@@ -87,6 +87,23 @@ spec:
                   type: string
                   description: Tenant demo-host domain (ADR-0021 contract point 8). Presence enables the showcase island, which projects the tenant into the showcase Tier-3 service.
                   pattern: '^[a-z0-9.-]+$'
+                islands:
+                  type: array
+                  description: Explicit island allowlist, ANDed with each island's own inference (spine always runs). Omit for normal CRs; set on island-managed tenants (e.g. tenant zero) whose other surfaces live outside the reconcile loop.
+                  items:
+                    type: string
+                showcaseCredentialId:
+                  type: string
+                  description: Credential id the tenant app backfills after minting its own secret (decision 1c); projected to showcase with showcaseCredentialHash.
+                showcaseCredentialHash:
+                  type: string
+                  description: sha256 hex of the tenant-minted API key. Plaintext never exists in the control plane.
+                  pattern: '^[a-f0-9]{64}$'
+                showcaseExtraScopes:
+                  type: array
+                  description: Scope opt-ins beyond the blueprint defaults; the engine filters to its allowlist (webhooks:read, webhooks:write, privacy:erase).
+                  items:
+                    type: string
                 blueprint:
                   type: string
                   description: Versioned managed-hosting blueprint stamped onto the tenant.

--- a/provisioning/tenants/coreyalan.yaml
+++ b/provisioning/tenants/coreyalan.yaml
@@ -1,0 +1,26 @@
+---
+# Tenant zero (coreyalan) — hand-authored, island-managed (decision Q3).
+# Never produced by the onboarding workflow: the dns zone is terraform-managed
+# and the app predates the platform, so spec.islands hard-limits reconcile to
+# the showcase projection. domain/demoHost are carried as projection data only.
+# The credential hash is the sha256 of the tenant-minted key (BWS: Showcase /
+# SHOWCASE_TENANT0_API_KEY); id cred-tenant0 matches the hand-seeded prod row,
+# so the island's first act is an in-place scope upgrade of that credential.
+apiVersion: platform.coreyalan.com/v1alpha1
+kind: Tenant
+metadata:
+  name: coreyalan
+  namespace: provisioning
+spec:
+  email: corey@coreyalan.com
+  domain: coreyalan.com
+  demoHost: coreyalan.dev
+  blueprint: managed-hosting@v1
+  islands:
+    - showcase
+  showcaseCredentialId: cred-tenant0
+  showcaseCredentialHash: 3b75a515a03c0a66b32c498a576dc338a745356eb4bceac360b835e9d77da26c
+  showcaseExtraScopes:
+    - webhooks:read
+    - webhooks:write
+    - privacy:erase


### PR DESCRIPTION
Companion to Corey-Alan-Consulting/provisioning-engine#13 — the homelab half of slice H.

**CRD + Promise schema** (drift fixed: the Promise was missing `demoHost` entirely):
- `spec.islands` — explicit island allowlist, ANDed with each island's own inference; `spine` always runs. Absent = today's behavior, so every existing CR is untouched.
- `spec.showcaseCredentialId` / `showcaseCredentialHash` (sha256 hex, pattern `^[a-f0-9]{64}$`) / `showcaseExtraScopes` — decision 1c: the tenant app mints its own secret and backfills only the hash; plaintext never exists in the control plane.

**Tenant zero** (`provisioning/tenants/coreyalan.yaml`): island-limited to `[showcase]` so `domain: coreyalan.com` rides as projection data without waking the dns island against the terraform-managed zone. Credential id `cred-tenant0` matches the hand-seeded prod row — the island's first act is an in-place scope upgrade (blueprint defaults + `webhooks:read/write` + `privacy:erase`). Hash is sha256 of the existing BWS `SHOWCASE_TENANT0_API_KEY`; the key itself was never displayed.

Note: the `tenants` ArgoCD app will sync this CR once merged; the engine picks up the new spec fields after its next image bump (engine#13 is merged code, deploy pending).