### PR TITLE
chore(provisioning): engine v0.2.1 — island gating, credential projection, teardown

### DIFF
--- a/provisioning/engine.yaml
+++ b/provisioning/engine.yaml
@@ -56,7 +56,7 @@ spec:
           # updated provisionTenant are discoverable. The app island also needs a
           # GitHub App (actions:write) + PLATFORM_INFRA_REPO + ONBOARD_WORKFLOW_ID
           # (and ONBOARD_TEARDOWN_WORKFLOW_ID for app teardown) before it dispatches.
-          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:3d20e8cbd33caa579718db705863cfb96795541b3427abb5b65abed137787d6a
+          image: us-central1-docker.pkg.dev/coreyalan-provisioning/provisioning-engine/engine@sha256:d836c668c75bc892239f5723a53632a5e54486936b1e8145330f11fbe3b1066e
           ports:
             - containerPort: 9080
           volumeMounts:


### PR DESCRIPTION
Digest bump to the v0.2.1 Tekton build (`3b983b0` tag object → engine main). Deploys provisioning-engine#13 + #14:

- `spec.islands` explicit allowlist — required by the already-synced tenant-zero CR (#922). Note: the CR landed one reconcile ahead of this deploy; the un-gated engine ran its dns island against `coreyalan.com`, but verified harmless — `ensured` resolved to the existing terraform-managed zone (`2fa8e4ae…`, id matched against TF state) and wrote no records. This deploy closes that window: next reconcile skips dns/email/app/staging for tenant zero.
- Tenant-minted credential projection (id+hash backfill, blueprint defaults + opt-in scopes) — will scope-upgrade `cred-tenant0` in place on next reconcile.
- Teardown via the showcase tenant-delete API (dry-run aware, audit-retaining).

⚠️ The credential/projection leg also needs platform-infra#1334 applied first (the engine's WIF subject was missing from the provider allowlist — STS would reject it).