### PR TITLE
feat(provisioning): jlshaw tenant — showcase white-label proving ground

### DIFF
--- a/provisioning/tenants/jlshaw.yaml
+++ b/provisioning/tenants/jlshaw.yaml
@@ -1,0 +1,24 @@
+---
+# jlshaw — hand-authored, island-managed (decision Q3), the white-label
+# proving ground for showcase demo hosting (decision Q7). Their app and site
+# predate the platform, so spec.islands limits reconcile to the showcase
+# projection; domain rides as identity/projection data only (tenant id
+# derives from it: jlshaw). demoHost jl-shaw.com is the branded demo domain
+# (#1326 zone IaC, #1333 IngressRoute+Certificate — both live). Credential
+# hash is sha256 of the key in BWS JL Shaw Consulting / SHOWCASE_API_KEY;
+# content scopes only (blueprint defaults, no opt-ins) until their app
+# integrates webhooks or DSAR.
+apiVersion: platform.coreyalan.com/v1alpha1
+kind: Tenant
+metadata:
+  name: jlshaw
+  namespace: provisioning
+spec:
+  email: contact@jlshawconsulting.com
+  domain: jlshaw.link
+  demoHost: jl-shaw.com
+  blueprint: managed-hosting@v1
+  islands:
+    - showcase
+  showcaseCredentialId: cred-jlshaw
+  showcaseCredentialHash: cdaffb9e2cda4ed8cc90c7f4751d43d6ade5aed19c54885e74cc7d4618a6d021


### PR DESCRIPTION
Decision Q7: jl-shaw.com proves the demo-host serving surface. Same island-managed pattern as tenant zero:

- `islands: [showcase]` — their site/app predate the platform; only the projection runs. `domain: jlshaw.link` rides as identity data (tenant id derives to `jlshaw`).
- `demoHost: jl-shaw.com` — DNS (#1326) and IngressRoute + cert (#1333) are already live; the host currently fails closed 404, flipping to serving once this projects.
- `cred-jlshaw` hash = sha256 of the key minted into BWS **JL Shaw Consulting / SHOWCASE_API_KEY** (never displayed). Blueprint content scopes only — webhook/DSAR opt-ins can be added on the CR when their app integrates.

After merge I'll verify the projection, upload a demo as jlshaw, mint a share, and load it on jl-shaw.com — the end-to-end white-label proof.