### PR TITLE
feat(showcase-staging): SeaweedFS object storage — staging ingest complete

### DIFF
--- a/staging-apps/showcase/values.yaml
+++ b/staging-apps/showcase/values.yaml
@@ -61,6 +61,18 @@ staging-app:
       value: coreyalan-showcase
     - name: INGEST_ENV
       value: staging
+    # SeaweedFS object storage (per-app identity, scoped to this bucket).
+    # App code uses these when STORAGE_PROVIDER=s3; prod uses native GCS.
+    - name: STORAGE_PROVIDER
+      value: s3
+    - name: S3_ENDPOINT
+      value: http://seaweedfs-filer.seaweedfs.svc:8333
+    - name: S3_REGION
+      value: us-east-1
+    - name: S3_FORCE_PATH_STYLE
+      value: "true"
+    - name: S3_SHOWCASE_ASSETS_BUCKET
+      value: showcase-staging-assets
     - name: APP_URL
       value: https://staging.showcase.coreyalan.com
     - name: NEXT_PUBLIC_APP_URL
@@ -77,6 +89,11 @@ staging-app:
         key: 27d72ae8-a3a2-43b8-afdf-b4b0002a7160
       - name: SHOWCASE_COOKIE_SECRET
         key: e788d8eb-b687-4a06-95e2-b4af00420877
+      # SeaweedFS S3 credentials (identity: showcase-staging; scoped to showcase-staging-assets)
+      - name: S3_ACCESS_KEY_ID
+        key: dd3fcf80-f300-4f31-ac25-b4b1017f6870
+      - name: S3_SECRET_ACCESS_KEY
+        key: 028457b6-c74b-46aa-b843-b4b1017f68b0
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
The storage leg of the staging lane (the keyless publisher landed in #923):

- `STORAGE_PROVIDER=s3` + SeaweedFS endpoint/region/path-style + `S3_SHOWCASE_ASSETS_BUCKET=showcase-staging-assets`
- New `showcase-staging` identity in the shared `s3.json` (additive; scoped Read/Write/List/Tagging on its bucket only), creds in the **Staging - Showcase** BWS project, wired via ExternalSecrets.

With this, staging zip ingest works end-to-end: POST → keyless publish → staging push subscription → extract → SeaweedFS. I'll validate with a staging upload after sync.