### PR TITLE
feat(seaweedfs): showcase-staging-assets bucket

### DIFF
--- a/helm-charts/seaweedfs/values.yaml
+++ b/helm-charts/seaweedfs/values.yaml
@@ -104,6 +104,9 @@ buckets:
   # Read/Write/List on this bucket added to the seaweedfs-s3-config-json blob
   # in Bitwarden.
   - jlshaw-link-signed-documents-staging
+  # showcase Tier-3 service staging demo assets; the scoped `showcase-staging`
+  # identity in the seaweedfs-s3-config-json blob grants Read/Write/List/Tagging.
+  - showcase-staging-assets
 
 # ---------------------------------------------------------------------------
 # Ingress: external S3 endpoint via Traefik + cert-manager


### PR DESCRIPTION
Adds `showcase-staging-assets` to the bucket-init list. The scoped `showcase-staging` identity already exists in the `s3.json` blob (BWS) and the staging app env landed in #934 — first ingest attempt failed AccessDenied because the bucket didn't exist yet.